### PR TITLE
Replace deprecated auto_ptr (S4997)

### DIFF
--- a/Source/Game/level.h
+++ b/Source/Game/level.h
@@ -187,7 +187,7 @@ private:
     // vvv These are just here to avoid per-frame mallocs vvv
     CollisionPtrMap old_col_ptr_map;
 
-	std::auto_ptr<ASCollisions> as_collisions;
+    std::unique_ptr<ASCollisions> as_collisions;
 
     Path FindScript(const std::string& path);
 };

--- a/Source/Graphics/skeleton.h
+++ b/Source/Graphics/skeleton.h
@@ -99,7 +99,7 @@ class Skeleton {
 
 
 public:    
-    std::auto_ptr<BulletWorld> col_bullet_world;
+    std::unique_ptr<BulletWorld> col_bullet_world;
     std::vector<int> parents;
     std::vector<PhysicsBone> physics_bones;
     std::vector<PhysicsJoint> physics_joints;

--- a/Source/JSON/jsoncpp.cpp
+++ b/Source/JSON/jsoncpp.cpp
@@ -236,7 +236,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-typedef std::auto_ptr<CharReader>   CharReaderPtr;
+typedef std::unique_ptr<CharReader>   CharReaderPtr;
 
 // Implementation of class Features
 // ////////////////////////////////
@@ -3825,7 +3825,7 @@ Value& Path::make(Value& root) const {
 
 namespace Json {
 
-typedef std::auto_ptr<StreamWriter>   StreamWriterPtr;
+typedef std::unique_ptr<StreamWriter>   StreamWriterPtr;
 
 static bool containsControlCharacter(const char* str) {
   while (*str) {

--- a/Source/Objects/envobject.h
+++ b/Source/Objects/envobject.h
@@ -93,7 +93,7 @@ struct MaterialParticle;
 class EnvObject: public Object {
     public:
         float timestamp_for_sendoff = 0.0f;
-        std::auto_ptr<PlantComponent> plant_component_;
+        std::unique_ptr<PlantComponent> plant_component_;
         ObjectFileRef ofr;
 
         BulletObject* bullet_object_;

--- a/Source/Objects/hotspot.h
+++ b/Source/Objects/hotspot.h
@@ -59,7 +59,7 @@ public:
     virtual void NotifyDeleted(Object* o);
     virtual EntityType GetType() const { return _hotspot_object; }
 
-	std::auto_ptr<ASCollisions> as_collisions;
+    std::unique_ptr<ASCollisions> as_collisions;
 
 	void Reset();
 	virtual void SetEnabled(bool val);

--- a/Source/Objects/movementobject.h
+++ b/Source/Objects/movementobject.h
@@ -130,7 +130,7 @@ public:
     std::string character_path;
     ReactionScriptGetter reaction_script_getter;
     CharacterScriptGetter character_script_getter;
-    std::auto_ptr<ASContext> as_context;
+    std::unique_ptr<ASContext> as_context;
     OGPalette palette;
     int connected_pathpoint_id;
     std::vector<ItemConnection> item_connection_vec;
@@ -150,7 +150,7 @@ public:
     std::string nametag_string;
 	vec3 nametag_last_position;
 
-    std::auto_ptr<ASCollisions> as_collisions;
+    std::unique_ptr<ASCollisions> as_collisions;
 
     ActorFileRef actor_file_ref;
     std::set<SoundGroupRef> touched_surface_refs;
@@ -248,7 +248,7 @@ public:
 	std::string GetTeamString();
     void StartPoseAnimation(std::string path);
 private:
-    std::auto_ptr<RiggedObject> rigged_object_;
+    std::unique_ptr<RiggedObject> rigged_object_;
     std::string current_control_script_path;
     std::string actor_script_path;
     BulletObject* char_sphere;

--- a/Source/Physics/bulletobject.h
+++ b/Source/Physics/bulletobject.h
@@ -56,7 +56,7 @@ public:
     std::vector<mat4> transform_history;
     btRigidBody *body;
     SharedShapePtr shape;
-    std::auto_ptr<ShapeDisposalData> shape_disposal_data;
+    std::unique_ptr<ShapeDisposalData> shape_disposal_data;
     bool visible;
     vec3 com_offset;
     short collision_group;

--- a/Source/Sound/sound.h
+++ b/Source/Sound/sound.h
@@ -145,7 +145,7 @@ class Sound {
 
         Soundtrack m_soundtrack;
 
-        typedef std::auto_ptr<ambientSound> ambient_ptr;
+        typedef std::unique_ptr<ambientSound> ambient_ptr;
         ambient_ptr m_air_whoosh_sound;
         int whoosh_active_countdown; //Kill whoosh if not updated in given frameperiod.
 


### PR DESCRIPTION
In this PR I have replaced the [deprecated auto_ptr](https://sonarcloud.io/project/issues?resolved=false&rules=cpp%3AS4997&types=BUG&id=WolfireGames_overgrowth) that were detected by SonarCloud ([S4997](https://rules.sonarsource.com/cpp/RSPEC-4997)).