### PR TITLE
Disable analysis for pull requests

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,6 +1,9 @@
 name: Analyze
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   sonarqube:


### PR DESCRIPTION
The analysis workflow tries to access a secret of the organization but for security reasons that is not possible for external pull requests. Otherwise people could simply create pull requests that print the secret. Since most, if not all, of the pull requests here will be from forks this means that the action will fail. To avoid that I think it makes sense to limit the conditions when the analysis will be started a bit for now.