### PR TITLE
Include freetype headers properly

### DIFF
--- a/Projects/CMakeLists.txt
+++ b/Projects/CMakeLists.txt
@@ -572,8 +572,8 @@ IF(WIN32)
     LINK_DIRECTORIES(
         ${LIBDIR}/FreeImage/lib/${VERSION_DIR}/${WINDOWS_LIB_DIR}
         ${LIBDIR}/SDL2-2.0.20/lib/${WINDOWS_LIB_DIR}
-	${LIBDIR}/freetype-windows-binaries-2.12.0/release_dll/win64
-	${LIBDIR}/SDL2_net-2.0.1/lib/${WINDOWS_LIB_DIR}
+        ${LIBDIR}/freetype-windows-binaries-2.12.0/release_dll/win64
+        ${LIBDIR}/SDL2_net-2.0.1/lib/${WINDOWS_LIB_DIR}
         ${LIBDIR}/openal-soft-1.18.0-bin/libs/${WINDOWS_LIB_DIR}
         ${LIBDIR}/ogg/lib/${WINDOWS_LIB_DIR}
         ${LIBDIR}/vorbis/lib/${WINDOWS_LIB_DIR}
@@ -581,7 +581,7 @@ IF(WIN32)
         ${LIBDIR}/zlib1.2.7/lib/${WINDOWS_LIB_DIR}
         ${LIBDIR}/theora/lib/${WINDOWS_LIB_DIR}
         ${LIBDIR}/openvr-master/lib/win/${WINDOWS_LIB_DIR}
-	${LIBDIR}/breakpad/src/client/windows/lib/${WINDOWS_LIB_DIR}
+	    ${LIBDIR}/breakpad/src/client/windows/lib/${WINDOWS_LIB_DIR}
         ${LIBDIR}/xinput/Lib/x86
         ${LIBDIR}/NvToolsExt/lib/Win32
     )
@@ -696,6 +696,7 @@ IF(LINUX)
         ${GTK2_INCLUDE_DIRS}
         ${SDL2_INCLUDE_DIR}
         ${SDL2NET_INCLUDE_DIR}
+        ${FREETYPE_INCLUDE_DIRS}
         ${LIBDIR}/Linux/include
         ${LIBDIR}/Linux/include/AL
         ${LIBDIR}/${FFTW_DIR}


### PR DESCRIPTION
Fix an error on Ubuntu 22.04 that `ft2build.h` cannot be found. This error is related to the changes in #8 