### PR TITLE
More portable top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROCS = $(shell nproc)
+PROCS ?= $(shell nproc)
 
 default: setup build
 setup:
@@ -29,7 +29,7 @@ deactivate-ogda:
 	cd Build; cmake -DBUILD_OGDA=Off ../Projects
 
 build: 
-	make --no-print-directory -j$(PROCS) -C Build
+	$(MAKE) --no-print-directory -j$(PROCS) -C Build
 run:
 	cd Build; ./Overgrowth.bin.x86_64
 
@@ -39,4 +39,4 @@ debug:
 test: 
 	cd Build; ./Overgrowth.bin.x86_64 --run-unit-tests
 clean:
-	make --no-print-directory -j$(PROCS) -C Build clean
+	$(MAKE) --no-print-directory -j$(PROCS) -C Build clean


### PR DESCRIPTION
* Don't assume GNU make is called "make"
* Don't assume nproc(1) is available

---

This is a small and self-contained change that I needed to do in order to get Overgrowth working on NetBSD, but this change will be beneficial for other BSDs and yet other OSes too.

* `--no-print-directory` and `$(shell)` is are GNU-isms but not all systems call GNU make "make", therefore parameterize the name of the 'make' executable
* Make PROCS overrideable on the command line so that systems which do not have nproc(1) can specify a number on their own, e.g. `gmake build PROCS=4`