### PR TITLE
Add CentOS Stream 8 to test reasonably old GCC version for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         docker:
           - 'registry.fedoraproject.org/fedora:latest'
+          - 'quay.io/centoshyperscale/centos:stream8'
       fail-fast: false
 
     container: ${{ matrix.docker }}


### PR DESCRIPTION
We want to establish a decent floor for compiler compatibility, and
CentOS Stream 8 is a good place for supportability reasons, as it
is essentially the Red Hat Enterprise Linux 8 platform.

We use the CentOS Hyperscale SIG official container since it
pre-configures all the necessary base repositories for us.