### PR TITLE
Compiletime reduction

### DIFF
--- a/Source/AI/tilemesh.cpp
+++ b/Source/AI/tilemesh.cpp
@@ -31,10 +31,6 @@
 #include <Compat/fileio.h>
 #include <GUI/widgetframework.h>
 
-#include <SDL.h>
-
-#include <opengl.h>
-
 #include <Recast.h>
 #include <DetourNavMesh.h>
 #include <DetourNavMeshBuilder.h>

--- a/Source/AI/tilemeshtestertool.cpp
+++ b/Source/AI/tilemeshtestertool.cpp
@@ -30,8 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "SDL.h"
-#include "opengl.h"
 #include "Recast.h"
 #include "DetourNavMesh.h"
 #include "DetourNavMeshBuilder.h"

--- a/Source/Asset/assetbase.cpp
+++ b/Source/Asset/assetbase.cpp
@@ -30,9 +30,6 @@
 #include <cxxabi.h>
 #endif
 
-#include <cstdlib>
-#include <cassert>
-
 Asset::Asset(AssetManager* owner, uint32_t asset_id): 
 asset_id(asset_id),
 owner(owner) {

--- a/Source/Compat/Mac/os_dialogs_mac.mm
+++ b/Source/Compat/Mac/os_dialogs_mac.mm
@@ -26,8 +26,6 @@
 #include <UserInput/input.h>
 #include <Logging/logdata.h>
 
-#include <SDL.h>
-
 #import <AppKit/NSAlert.h>
 #import <AppKit/NSTextField.h>
 #import <AppKit/NSPanel.h>

--- a/Source/Editors/save_state.h
+++ b/Source/Editors/save_state.h
@@ -26,7 +26,6 @@
 #include <Game/EntityDescription.h>
 
 #include <list>
-#include <vector>
 
 namespace ChunkType {
     enum ChunkType {

--- a/Source/GUI/IMUI/imui.cpp
+++ b/Source/GUI/IMUI/imui.cpp
@@ -36,7 +36,6 @@
 #include <Main/engine.h>
 
 #include <utf8/utf8.h>
-#include <SDL.h>
 
 #include <cmath>
 #include <algorithm>

--- a/Source/Game/avatar_control_manager.h
+++ b/Source/Game/avatar_control_manager.h
@@ -26,7 +26,6 @@
 #include <Objects/object.h>
 
 #include <vector>
-#include <utility>
 
 class Possession {
 public:

--- a/Source/Game/detailobjectlayer.cpp
+++ b/Source/Game/detailobjectlayer.cpp
@@ -24,19 +24,11 @@
 #include "detailobjectlayer.h"
 
 #include <Asset/Asset/character.h>
-#include <Asset/Asset/material.h>
-
-#include <XML/xml_helper.h>
 #include <Internal/filesystem.h>
-#include <Graphics/shaders.h>
-#include <Scripting/scriptfile.h>
-#include <Logging/logdata.h>
 
 #include <tinyxml.h>
 
-#include <map>
 #include <string>
-#include <cmath>
 
 DetailObjectLayer ReadDetailObjectLayerXML( const TiXmlElement* detail_object_element) {
     DetailObjectLayer detail_object_layer;

--- a/Source/Game/detailobjectlayer.h
+++ b/Source/Game/detailobjectlayer.h
@@ -23,14 +23,11 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <Asset/assetbase.h>
-#include <Asset/assetinfobase.h>
-
-#include <Math/vec3.h>
-#include <Graphics/palette.h>
+#include <Internal/path_set.h>
 
 #include <string>
-#include <vector>
+
+class TiXmlElement;
 
 enum CollisionType {_none, _static, _plant};
 

--- a/Source/Game/outofdateinfo.cpp
+++ b/Source/Game/outofdateinfo.cpp
@@ -25,6 +25,8 @@
 
 #include <Logging/logdata.h>
 
+#include <ostream>
+
 void OutOfDateInfo::Print()
 {
     LOGI << "Out of date: " << std::endl;

--- a/Source/Game/outofdateinfo.h
+++ b/Source/Game/outofdateinfo.h
@@ -23,15 +23,6 @@
 //-----------------------------------------------------------------------------
 #pragma once 
 
-#include <Game/EntityDescription.h>
-#include <Game/detailobjectlayer.h>
-
-#include <Math/mat4.h>
-#include <Math/quaternions.h>
-
-#include <Asset/assets.h>
-#include <Scripting/scriptparams.h>
-
 struct OutOfDateInfo {
     bool shadow;
     bool ao;

--- a/Source/Graphics/animationclient.h
+++ b/Source/Graphics/animationclient.h
@@ -27,7 +27,6 @@
 #include <Graphics/animationflags.h>
 
 #include <Asset/Asset/animation.h>
-#include <Scripting/angelscript/ascontext.h>
 
 class Skeleton;
 class ASContext;
@@ -89,7 +88,7 @@ class AnimationClient {
     std::string retarget_new;
 
     struct {
-        ASFunctionHandle layer_removed;
+        int32_t layer_removed;
     } as_funcs;
 
     void ApplyAnimationFlags( AnimationReader &reader, AnimationAssetRef &new_ref, char flags);

--- a/Source/Graphics/animationclient.h
+++ b/Source/Graphics/animationclient.h
@@ -31,6 +31,7 @@
 class Skeleton;
 class ASContext;
 const float _default_fade_speed = 5.0f;
+typedef int32_t ASFunctionHandle;
 
 struct AnimationFadeOut {
     AnimationReader reader;
@@ -88,7 +89,7 @@ class AnimationClient {
     std::string retarget_new;
 
     struct {
-        int32_t layer_removed;
+        ASFunctionHandle layer_removed;
     } as_funcs;
 
     void ApplyAnimationFlags( AnimationReader &reader, AnimationAssetRef &new_ref, char flags);

--- a/Source/Graphics/animationeffectsystem.cpp
+++ b/Source/Graphics/animationeffectsystem.cpp
@@ -23,19 +23,7 @@
 //-----------------------------------------------------------------------------
 #include "animationeffectsystem.h"
 
-#include <Internal/common.h>
-#include <Internal/filesystem.h>
-#include <Internal/timer.h>
-
 #include <TheoraPlayer/TheoraVideoManager.h>
-#include <TheoraPlayer/TheoraDataSource.h>
-#include <TheoraPlayer/TheoraVideoFrame.h>
-
-#include <XML/xml_helper.h>
-#include <Graphics/textures.h>
-#include <Logging/logdata.h>
-
-#include <tinyxml.h>
 
 #include <cstdio>
 

--- a/Source/Graphics/animationeffectsystem.h
+++ b/Source/Graphics/animationeffectsystem.h
@@ -23,15 +23,6 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <Asset/assetbase.h>
-#include <Asset/assetinfobase.h>
-
-#include <Math/quaternions.h>
-#include <Graphics/textureref.h>
-
-#include <vector>
-#include <string>
-
 class TheoraVideoManager;
 
 class AnimationEffectSystem

--- a/Source/Graphics/bloodsurface.h
+++ b/Source/Graphics/bloodsurface.h
@@ -27,6 +27,7 @@
 #include <Asset/Asset/texture.h>
 #include <Graphics/modelsurfacewalker.h>
 
+#include <opengl.h>
 #include <list>
 #include <map>
 

--- a/Source/Graphics/detailmapinfo.cpp
+++ b/Source/Graphics/detailmapinfo.cpp
@@ -23,17 +23,12 @@
 //-----------------------------------------------------------------------------
 #include "detailmapinfo.h"
 
-#include <Internal/comma_separated_list.h>
-#include <Internal/filesystem.h>
-#include <Internal/returnpathutil.h>
-#include <Internal/levelxml.h>
-
+#include <Asset/assetmanager.h>
+#include <Asset/assetref.h>
 #include <Asset/Asset/material.h>
 #include <Logging/logdata.h>
 #include <Game/detailobjectlayer.h>
 #include <Main/engine.h>
-
-#include <tinyxml.h>
 
 void DetailMapInfo::Print()
 {

--- a/Source/Graphics/detailmapinfo.h
+++ b/Source/Graphics/detailmapinfo.h
@@ -23,14 +23,7 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <Math/mat4.h>
-#include <Math/quaternions.h>
-
-#include <Game/EntityDescription.h>
-#include <Game/detailobjectlayer.h>
-
-#include <Asset/assets.h>
-#include <Scripting/scriptparams.h>
+#include <Internal/path_set.h>
 
 #include <string>
 

--- a/Source/Graphics/dynamiclightcollection.hpp
+++ b/Source/Graphics/dynamiclightcollection.hpp
@@ -23,15 +23,9 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <Graphics/textureref.h>
-#include <Graphics/model.h>
-
 #include <Math/vec3.h>
 
-#include <opengl.h>
-
 #include <vector>
-#include <queue>
 
 struct DynamicLight {
     int id;

--- a/Source/Graphics/modelsurfacewalker.cpp
+++ b/Source/Graphics/modelsurfacewalker.cpp
@@ -66,7 +66,7 @@ namespace {
         return true;
     }
 
-    void GetVertexDuplicates( const std::vector<GLfloat> &vertices, std::vector<int> &first_dup ) {
+    void GetVertexDuplicates( const std::vector<float> &vertices, std::vector<int> &first_dup ) {
         // For each vertex, store the id of the first vertex with the same position
         first_dup.resize(vertices.size()/3);
         std::map<vec3, int> point_map;

--- a/Source/Graphics/modelsurfacewalker.h
+++ b/Source/Graphics/modelsurfacewalker.h
@@ -26,8 +26,6 @@
 #include <Math/vec3.h>
 #include <Math/vec2.h>
 
-#include <opengl.h>
-
 #include <vector>
 
 struct MSWTriInfo {

--- a/Source/Graphics/navmeshrenderer.cpp
+++ b/Source/Graphics/navmeshrenderer.cpp
@@ -37,6 +37,7 @@
 
 #include <Memory/allocation.h>
 #include <AI/mesh_loader_obj.h>
+#include <AI/navmesh.h>
 #include <Logging/logdata.h>
 
 NavMeshRenderer::NavMeshRenderer() :

--- a/Source/Graphics/navmeshrenderer.h
+++ b/Source/Graphics/navmeshrenderer.h
@@ -23,8 +23,9 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <AI/navmesh.h>
 #include <Graphics/vbocontainer.h>
+
+class NavMesh;
 
 //Note that this renderer only renders the state which the nav-mesh was in when it was last set. 
 //The data will be reloaded if updated_nav_mesh_ flag is set to true.

--- a/Source/Internal/checksum.cpp
+++ b/Source/Internal/checksum.cpp
@@ -35,8 +35,6 @@
 using std::string;
 using std::endl;
 
-class ProfilerContext;
-
 //TODO: Maybe modifying this to be Adler32 would be a little better CRC32 even more so, lowering the risk for collisions for small changes. 
 //(If you make a 'b' a 'c' and another 'b' an 'a' in a file, this function will give you the same checksum value, i would consider this a possible common change)
 unsigned short Checksum(const string& abs_path) {

--- a/Source/Internal/datemodified.cpp
+++ b/Source/Internal/datemodified.cpp
@@ -32,8 +32,6 @@
 #include <windows.h>
 #endif
 
-#include <time.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <stdio.h>
 #include <errno.h>

--- a/Source/Internal/error.mm
+++ b/Source/Internal/error.mm
@@ -28,7 +28,6 @@
 
 #include <map>
 #include <string>
-#include <SDL.h>
 
 #import <AppKit/NSAlert.h>
 #import <AppKit/NSTextField.h>

--- a/Source/Internal/path.cpp
+++ b/Source/Internal/path.cpp
@@ -28,7 +28,6 @@
 
 #include <iostream>
 #include <string>
-#include <cstdlib>
 #include <cstring>
 
 using std::string;

--- a/Source/Internal/stopwatch.cpp
+++ b/Source/Internal/stopwatch.cpp
@@ -26,6 +26,8 @@
 #include <Logging/logdata.h>
 #include <Threading/sdl_wrapper.h>
 
+#include <SDL.h>
+
 void BusyWaitMilliseconds( uint32_t how_many )
 {    
     Stopwatch watch;

--- a/Source/Internal/stopwatch.h
+++ b/Source/Internal/stopwatch.h
@@ -22,8 +22,6 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-#include <SDL.h>
-
 #include <string>
 
 void BusyWaitMilliseconds(uint32_t how_many);

--- a/Source/Logging/logdata.cpp
+++ b/Source/Logging/logdata.cpp
@@ -23,7 +23,6 @@
 
 #include <Logging/logdata.h>
 #include <Logging/loghandler.h>
-#include <Logging/consolehandler.h>
 
 #include <Utility/strings.h>
 

--- a/Source/Logging/loghandler.cpp
+++ b/Source/Logging/loghandler.cpp
@@ -23,9 +23,6 @@
 
 #include <Logging/loghandler.h>
 
-#include <ostream>
-#include <iostream>
-
 LogHandler::LogHandler()
 {
 }

--- a/Source/Logging/ramhandler.cpp
+++ b/Source/Logging/ramhandler.cpp
@@ -23,8 +23,6 @@
 #include <Logging/ramhandler.h>
 
 #include <iostream>
-#include <algorithm>
-
 #include <cassert>
 
 #include <Utility/strings.h>

--- a/Source/Main/engine.h
+++ b/Source/Main/engine.h
@@ -23,22 +23,17 @@
 #pragma once
 
 #include <Main/scenegraph.h>
-#include <Main/scenegraph.h>
 
 #include <UserInput/input.h>
 
 #include <Graphics/Cursor.h>
 #include <Graphics/graphics.h>
 #include <Graphics/text.h>
-#include <Graphics/model.h>
 #include <Graphics/font_renderer.h>
-#include <Graphics/particles.h>
-#include <Graphics/vbocontainer.h>
 #include <Graphics/animationeffectsystem.h>
 #include <Graphics/lipsyncsystem.h>
 
 #include <Sound/sound.h>
-#include <Sound/threaded_sound_wrapper.h>
 #include <Sound/threaded_sound_wrapper.h>
 
 
@@ -50,7 +45,6 @@
 #include <Asset/assetmanager.h>
 #include <Network/asnetwork.h>
 #include <Internal/modloading.h>
-#include <Online/online.h>
 
 #include <stack>
 #include <iostream>

--- a/Source/Memory/allocation.cpp
+++ b/Source/Memory/allocation.cpp
@@ -25,8 +25,6 @@
 #include <Internal/error.h>
 
 #include <cstdlib>
-#include <map>
-#include <cassert>
 
 #if MONITOR_MEMORY 
 //POSIX variant, win version necessary.

--- a/Source/Objects/envobject.cpp
+++ b/Source/Objects/envobject.cpp
@@ -77,7 +77,6 @@
 #include <Scripting/angelscript/ascontext.h>
 #include <Online/online.h>
 
-#include <SDL.h>
 #include <tinyxml.h>
 
 #include <cmath>

--- a/Source/Objects/object.cpp
+++ b/Source/Objects/object.cpp
@@ -34,6 +34,7 @@
 #include <Editors/map_editor.h>
 #include <Utility/ieee.h>
 #include <GUI/gui.h>
+#include <Online/online.h>
 
 #include <tinyxml.h>
 #include <SDL_assert.h>

--- a/Source/Objects/terrainobject.cpp
+++ b/Source/Objects/terrainobject.cpp
@@ -50,8 +50,6 @@
 #include <Wrappers/glm.h>
 #include <Utility/compiler_macros.h>
 
-#include <SDL.h>
-
 extern bool g_simple_shadows;
 extern bool g_level_shadows;
 extern char* global_shader_suffix;

--- a/Source/Online/Message/audio_play_sound_group_voice_message.cpp
+++ b/Source/Online/Message/audio_play_sound_group_voice_message.cpp
@@ -24,6 +24,7 @@
 
 #include <Main/engine.h>
 #include <Utility/binn_util.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     AudioPlaySoundGroupVoiceMessage::AudioPlaySoundGroupVoiceMessage(const std::string& path, ObjectID id, float delay) :

--- a/Source/Online/Message/audio_play_sound_impact_item_message.cpp
+++ b/Source/Online/Message/audio_play_sound_impact_item_message.cpp
@@ -26,6 +26,7 @@
 
 #include <Main/engine.h>
 #include <Utility/binn_util.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     AudioPlaySoundImpactItemMessage::AudioPlaySoundImpactItemMessage(ObjectID id, vec3 pos, vec3 normal, float impulse) :

--- a/Source/Online/Message/chat_entry_message.cpp
+++ b/Source/Online/Message/chat_entry_message.cpp
@@ -24,6 +24,7 @@
 
 #include <Main/engine.h>
 #include <Utility/binn_util.h>
+#include <Online/online.h>
 #include <Online/online_utility.h>
 
 namespace OnlineMessages {

--- a/Source/Online/Message/cut_line.cpp
+++ b/Source/Online/Message/cut_line.cpp
@@ -23,6 +23,7 @@
 #include "cut_line.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     CutLine::CutLine() :

--- a/Source/Online/Message/editor_transform_change.cpp
+++ b/Source/Online/Message/editor_transform_change.cpp
@@ -23,6 +23,7 @@
 #include "editor_transform_change.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     EditorTransformChange::EditorTransformChange(ObjectID id, const vec3& trans, const vec3& scale, const quaternion& rot) :

--- a/Source/Online/Message/env_object_update.cpp
+++ b/Source/Online/Message/env_object_update.cpp
@@ -23,6 +23,7 @@
 #include "env_object_update.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 extern Timer game_timer;
 

--- a/Source/Online/Message/material_sound_event.cpp
+++ b/Source/Online/Message/material_sound_event.cpp
@@ -23,6 +23,7 @@
 #include "material_sound_event.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     MaterialSoundEvent::MaterialSoundEvent(ObjectID object_id, const string& ev, const vec3& pos, float gain) :

--- a/Source/Online/Message/morph_target_update.cpp
+++ b/Source/Online/Message/morph_target_update.cpp
@@ -23,6 +23,7 @@
 #include "morph_target_update.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     MorphTargetUpdate::MorphTargetUpdate() :

--- a/Source/Online/Message/movement_object_update.cpp
+++ b/Source/Online/Message/movement_object_update.cpp
@@ -24,6 +24,7 @@
 
 #include <Utility/binn_util.h>
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     MovementObjectUpdate::MovementObjectUpdate() :

--- a/Source/Online/Message/online_message_base.h
+++ b/Source/Online/Message/online_message_base.h
@@ -24,13 +24,7 @@
 
 
 #include <Online/online_datastructures.h>
-
-#include <Math/vec3.h>
-
 #include <binn.h>
-
-#include <string>
-
 
 //These are message types, they control the behaviour and allowance of a message
 //this only controls messages from the host to the clients, messages sent from the client are always

--- a/Source/Online/Message/set_avatar_palette.cpp
+++ b/Source/Online/Message/set_avatar_palette.cpp
@@ -23,6 +23,7 @@
 #include "set_avatar_palette.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 namespace OnlineMessages {
     SetAvatarPalette::SetAvatarPalette(ObjectID id, const vec3& color, uint8_t channel) :

--- a/Source/Online/Message/timed_slow_motion.cpp
+++ b/Source/Online/Message/timed_slow_motion.cpp
@@ -23,6 +23,7 @@
 #include "timed_slow_motion.h"
 
 #include <Main/engine.h>
+#include <Online/online.h>
 
 extern Timer game_timer;
 

--- a/Source/Online/online_utility.cpp
+++ b/Source/Online/online_utility.cpp
@@ -20,8 +20,6 @@
 //   limitations under the License.
 //
 //-----------------------------------------------------------------------------
-#pragma once
-
 #include <Online/online_utility.h>
 #include <Main/engine.h>
 #include <Internal/config.h>
@@ -29,6 +27,8 @@
 #if ENABLE_STEAMWORKS
 #include <isteamfriends.h>
 #endif
+
+using std::stringstream;
 
 // Name is invalid if (less than 3 letters) or (contains any non alpha numerical characters)
 bool OnlineUtility::IsValidPlayerName(const std::string& name) {

--- a/Source/Physics/bulletworld.cpp
+++ b/Source/Physics/bulletworld.cpp
@@ -48,8 +48,6 @@
 #include <Logging/logdata.h>
 #include <Utility/assert.h>
 
-#include <SDL.h>
-
 #include <btBulletDynamicsCommon.h>
 #include <LinearMath/btGeometryUtil.h>
 #include <BulletSoftBody/btSoftBodyHelpers.h>

--- a/Source/Scripting/scriptparams.cpp
+++ b/Source/Scripting/scriptparams.cpp
@@ -27,6 +27,7 @@
 #include <Logging/logdata.h>
 #include <Utility/assert.h>
 #include <Main/engine.h>
+#include <Online/online.h>
 
 #include <tinyxml.h>
 

--- a/Source/Threading/sdl_wrapper.h
+++ b/Source/Threading/sdl_wrapper.h
@@ -24,6 +24,4 @@
 //-----------------------------------------------------------------------------
 #include <Internal/integer.h>
 
-
-
 unsigned int SDL_TS_GetTicks();

--- a/Source/Timing/timingevent.h
+++ b/Source/Timing/timingevent.h
@@ -128,8 +128,6 @@
 #include <Graphics/text.h>
 #include <Graphics/vboringcontainer.h>
 
-#include <SDL.h>
-
 #if defined(PLATFORM_WINDOWS) && _MSC_VER >= 1600 
 #include <intrin.h>
 #endif


### PR DESCRIPTION
Run some clang compile time analysis and try to reduce some of the hotspots found (only the low hanging fruits). There are some other things i'll look out for and try to reduce. The are the principles i applied:
- Use forward declaration where applicable
- Don't include large headers into other headers if not required
- Remove unused headers

These are the numbers i get for a full compile using `ninja` on an `AMD Ryzen 7 1800X`
|  |Before | After   |
|---|---|--|
| read | 2m41,982s | 2m24,437s |
| user | 36m57,585s |  34m13,440s |
| sys   | 1m25,232s| 1m18,250s |

If someone is interested in a good read about the tools i've used:
https://aras-p.info/blog/2019/01/16/time-trace-timeline-flame-chart-profiler-for-Clang/
https://aras-p.info/blog/2019/09/28/Clang-Build-Analyzer/