### PR TITLE
Allow to disable DDS image search

### DIFF
--- a/Source/Asset/Asset/averagecolorasset.cpp
+++ b/Source/Asset/Asset/averagecolorasset.cpp
@@ -56,7 +56,7 @@ int AverageColor::Load( const string& rel_path, uint32_t load_flags ) {
     
     char abs_path[kPathSize];
     ModID modsource;
-    if(FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths, true, NULL, true, &modsource) == -1){
+    if(FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths, true, NULL, true, true, &modsource) == -1){
         //FatalError("Error", "Could not get average color of %s", rel_path.c_str());
         return kLoadErrorMissingFile;
     }

--- a/Source/Asset/Asset/image_sampler.cpp
+++ b/Source/Asset/Asset/image_sampler.cpp
@@ -120,7 +120,7 @@ int ImageSampler::Load( const std::string& path, uint32_t load_flags ) {
     if( loaded_cache == false ) {
         char abs_path[kPathSize];
         ModID modsource;
-        if(FindImagePath(path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kModWriteDirs, true, NULL, false, &modsource) == -1){
+        if(FindImagePath(path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kModWriteDirs, true, NULL, false, false, &modsource) == -1){
             return kLoadErrorMissingFile;
         }
         LOGI << "Loading " << abs_path << std::endl;

--- a/Source/Graphics/textures.cpp
+++ b/Source/Graphics/textures.cpp
@@ -562,7 +562,7 @@ void Textures::ReloadInternal() {
                 SubTexture &sub = texture.sub_textures[s];
                 LOG_ASSERT(!sub.texture_name.empty());
                 ModID modsource;
-                if (FindImagePath(sub.texture_name.c_str(), abs_path, kPathSize, kAnyPath, false,NULL,true, &modsource) == 0){
+                if (FindImagePath(sub.texture_name.c_str(), abs_path, kPathSize, kAnyPath, false,NULL,true, true, &modsource) == 0){
                     if(strcmp(abs_path, sub.load_name.c_str()) == 0 && GetDateModifiedInt64(abs_path) == sub.orig_modified){
                         LogSystem::LogData(LogSystem::debug, "tex", __FILE__, __LINE__) << " slice " << s << ": \"" << sub.texture_name << "\" no" << std::endl;
                     } else {
@@ -1966,7 +1966,7 @@ int Textures::loadTexture(const std::string& rel_path, unsigned int which, unsig
     char abs_path[kPathSize];
     PathFlags res_source;
     ModID modsource;
-    int err = FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kAbsPath | kModWriteDirs, true, &res_source, true, &modsource );
+    int err = FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kAbsPath | kModWriteDirs, true, &res_source, true, true, &modsource );
     if(err == -1){
         //DisplayError("Error", "Could not find texture: %s", rel_path.c_str());
         return kLoadErrorMissingFile;
@@ -2091,7 +2091,7 @@ void Textures::loadArraySlice(const TextureRef& texref, unsigned int slice, cons
 
     char abs_path[kPathSize];
     ModID modsource;
-    int err = FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kModWriteDirs, true, NULL, true, &modsource);
+    int err = FindImagePath(rel_path.c_str(), abs_path, kPathSize, kDataPaths | kModPaths | kWriteDir | kModWriteDirs, true, NULL, true, true, &modsource);
     if(err == -1){
         FatalError("Error", "Could not find texture: %s", rel_path.c_str());
     }
@@ -2684,7 +2684,7 @@ bool Textures::ReloadAsCompressed(const TextureRef& texref) {
 
     char abs_path[kPathSize];
     ModID modsource;
-    if(FindImagePath(newName.c_str(), abs_path, kPathSize, kWriteDir | kModWriteDirs, true, NULL, true, &modsource) == -1) {
+    if(FindImagePath(newName.c_str(), abs_path, kPathSize, kWriteDir | kModWriteDirs, true, NULL, true, true, &modsource) == -1) {
         LOGE << "Texture not found after writing it" << std::endl;
         return false;
     }

--- a/Source/Internal/filesystem.cpp
+++ b/Source/Internal/filesystem.cpp
@@ -178,7 +178,7 @@ const int overgrowth_dds_cache_version = 1;
 //The case for looking for both the normal image and the converted became so common I felt the need for this simplification.
 
 //Currently ignoring the modsource, should set it to the correct source if it's not null TODO
-int FindImagePath( const char* path, char* buf, int buf_size, PathFlagsBitfield flags, bool is_necessary, PathFlags* resulting_path, bool allow_crn, ModID* modsource )
+int FindImagePath( const char* path, char* buf, int buf_size, PathFlagsBitfield flags, bool is_necessary, PathFlags* resulting_path, bool allow_crn, bool allow_dds, ModID* modsource )
 {
     const char* fallback = "Data/Textures/error.tga";
     // We might want a converted image, let's assume it's priority for reasons like performance
@@ -192,7 +192,10 @@ int FindImagePath( const char* path, char* buf, int buf_size, PathFlagsBitfield 
     ModID dds_modsources[kMaxPaths];
     PathFlags orig_flags[kMaxPaths];
     ModID orig_modsources[kMaxPaths];
-    int num_dds_paths_found = FindFilePaths( dds_converted.c_str(), dds_paths, buf_size, kMaxPaths, flags, false, dds_flags, dds_modsources );
+    int num_dds_paths_found = 0;
+    if( allow_dds) {
+        num_dds_paths_found = FindFilePaths( dds_converted.c_str(), dds_paths, buf_size, kMaxPaths, flags, false, dds_flags, dds_modsources );
+    }
     if (num_dds_paths_found == 0 && allow_crn) {
         num_dds_paths_found = FindFilePaths( crn_converted.c_str(), dds_paths, buf_size, kMaxPaths, flags, false, dds_flags, dds_modsources );
     }

--- a/Source/Internal/filesystem.h
+++ b/Source/Internal/filesystem.h
@@ -49,7 +49,7 @@ Path FindImagePath( const char* path, PathFlagsBitfield flags = kAnyPath, bool i
 Path FindFilePath( const std::string& path, PathFlagsBitfield flags = kAnyPath, bool is_necessary = true );
 Path FindFilePath( const char* path, PathFlagsBitfield flags = kAnyPath, bool is_necessary = true );
 
-int FindImagePath( const char* path, char* buf, int buf_size, PathFlagsBitfield flags, bool is_necessary = true, PathFlags* resulting_path = NULL, bool allow_crn = true, ModID* modsource = NULL);
+int FindImagePath( const char* path, char* buf, int buf_size, PathFlagsBitfield flags, bool is_necessary = true, PathFlags* resulting_path = NULL, bool allow_crn = true, bool allow_dds = true, ModID* modsource = NULL);
 int FindFilePath(const char* path, char* buf, int buf_size, PathFlagsBitfield flags, bool is_necessary = true, PathFlags* resulting_path = NULL, ModID* modsource = NULL);
 int FindFilePaths(const char* path, char* bufs, int buf_size, int num_bufs, PathFlagsBitfield flags, bool is_necessary, PathFlags* resulting_paths, ModID* modsourceids );
 void AddPath(const char* path, PathFlags type);


### PR DESCRIPTION
The **ImageSampler** (which loads textures in software/ on the CPU) currently uses DDS textures instead of the also existing TGA image. The problem with that is that DDS decoding requires CPU time and is a lossy format. We have `GL_EXT_texture_compression_s3tc` as  a required extension, so we don't need any fallback

We can avoid loading DDS on the CPU by explicitly asking for the original image path.

As a nice side benefit this avoids us having to support DDS decoding on the CPU at all, which allows #58 to proceed. 