### PR TITLE
Use clang-tidy to find performance issues

### DIFF
--- a/Source/Asset/Asset/material.cpp
+++ b/Source/Asset/Asset/material.cpp
@@ -160,8 +160,7 @@ void Material::ReportLoad()
 void Material::HandleEvent( const std::string &the_event, const vec3 &pos )
 {
     // Make local copies so they can be passed to Angelscript without const
-    std::string event_string = the_event;
-    //vec3 event_pos = pos;
+       //vec3 event_pos = pos;
     
     //Arglist args;
     //args.AddObject(&event_string);

--- a/Source/Compat/processpool.cpp
+++ b/Source/Compat/processpool.cpp
@@ -610,7 +610,8 @@ int ChildProcessMessage(const string& msg, const ProcessPool::JobMap &job_map){
         }
         int argc = (int)params_separated.size();
         vector<const char*> argv;
-        for(int i=0; i<argc; ++i){
+        argv.reserve(argc);
+for(int i=0; i<argc; ++i){
             argv.push_back(params_separated[i].c_str());
         }
 #ifdef _WIN32

--- a/Source/Compat/processpool.cpp
+++ b/Source/Compat/processpool.cpp
@@ -611,7 +611,7 @@ int ChildProcessMessage(const string& msg, const ProcessPool::JobMap &job_map){
         int argc = (int)params_separated.size();
         vector<const char*> argv;
         argv.reserve(argc);
-for(int i=0; i<argc; ++i){
+        for (int i = 0; i < argc; ++i) {
             argv.push_back(params_separated[i].c_str());
         }
 #ifdef _WIN32

--- a/Source/Editors/map_editor.cpp
+++ b/Source/Editors/map_editor.cpp
@@ -1619,7 +1619,7 @@ void MapEditor::ApplyScriptParams(const ScriptParamMap& spm, int id){
     } else {
         Object* obj = scenegraph_->GetObjectFromID(id);
         if(obj){
-            ScriptParamMap new_spm = spm;
+            const ScriptParamMap& new_spm = spm;
             ScriptParamMap::iterator iter;
 
             if( !testScriptParamsEqual(new_spm, obj->GetScriptParamMap() ) ) {
@@ -3075,8 +3075,8 @@ static ToolMode DetermineToolMode(EditorTypes::Tool type) {
 static bool GetTranslationBasis(vec3 clicked_point, vec3 clicked_normal,
                                 Basis* basis, const Object* object_, const Box& box_, ToolMode tool_mode)
 {
-    mat4 obj_transform = object_->GetTransform();
-    quaternion obj_rot = object_->GetRotation();
+    const mat4& obj_transform = object_->GetTransform();
+    const quaternion& obj_rot = object_->GetRotation();
     int box_face_index = box_.GetHitFaceIndex(invert(obj_rot) * clicked_normal,
         invert(obj_transform) * clicked_point);
     if (box_face_index != -1){
@@ -3103,8 +3103,8 @@ static bool GetTranslationBasis(vec3 clicked_point, vec3 clicked_normal,
 static bool GetScaleBasis(vec3 clicked_point, vec3 clicked_normal,
                           Basis* basis, vec3* p, const Object* object_, const Box& box_, ToolMode tool_mode)
 {
-    mat4 obj_transform = object_->GetTransform();
-    quaternion obj_rot = object_->GetRotation();
+    const mat4& obj_transform = object_->GetTransform();
+    const quaternion& obj_rot = object_->GetRotation();
 
     int i = box_.GetHitFaceIndex(invert(obj_rot) * clicked_normal, invert(obj_transform) * clicked_point);
     if (i == -1) {
@@ -3125,8 +3125,8 @@ static bool GetRotationBasis(vec3 clicked_point, vec3 clicked_normal,
                              Basis* basis, vec3* p, vec3* around,
                              const Object* object_, const Box& box_)
 {
-    mat4 obj_transform = object_->GetTransform();
-    quaternion obj_rot = object_->GetRotation();
+    const mat4& obj_transform = object_->GetTransform();
+    const quaternion& obj_rot = object_->GetRotation();
     int i = box_.GetHitFaceIndex(invert(obj_rot) * clicked_normal, invert(obj_transform) * clicked_point);
     if (i == -1) {
         return false;
@@ -3190,7 +3190,7 @@ static vec3 GetTranslation(const LineSegment& mouseray, bool snapping_enabled, c
 
     vec3 delta_translation = new_point - old_point;
     if (snapping_enabled) {
-        quaternion obj_rotate = object_->GetRotation();
+        const quaternion& obj_rotate = object_->GetRotation();
         delta_translation = invert( object_->GetRotation() ) * delta_translation;
         for(int i=0; i<3; ++i){
             delta_translation[i] = floorf(delta_translation[i]/TRANSLATION_SNAP_INCR+0.5f) * TRANSLATION_SNAP_INCR;

--- a/Source/GUI/dimgui/dimgui.cpp
+++ b/Source/GUI/dimgui/dimgui.cpp
@@ -4029,7 +4029,7 @@ Mark Stockton\nMikko Tarmia");
 
         if(ImGui::TreeNode("Peer debug info")) {
             auto peers = online->GetPeers();
-            for(auto peer : peers) {
+            for(const auto& peer : peers) {
                 ImGui::Text("Connection ID: %d", peer.conn_id);
                 ImGui::Text("Peer ID: %d", peer.peer_id);
                 ImGui::Separator();

--- a/Source/Graphics/geometry.cpp
+++ b/Source/Graphics/geometry.cpp
@@ -169,6 +169,8 @@
 #include <Math/vec3math.h>
 #include <Memory/allocation.h>
 
+#include <cmath>
+
 static void circleTable(double **sint,double **cost,const int n);
 
 /* -- INTERFACE FUNCTIONS -------------------------------------------------- */
@@ -242,11 +244,11 @@ void GetWireCylinderVertArray(GLint slices, std::vector<vec3> &data)
         float rotation1 = i*rotationStep;
         float rotation2 = (i+1)*rotationStep;
 
-        vec3 offset1(radius*(cos(rotation1)-sin(rotation1)), 0.0f, radius*(sin(rotation1)+cos(rotation1)));
+        vec3 offset1(radius*(std::cos(rotation1)-std::sin(rotation1)), 0.0f, radius*(std::sin(rotation1)+std::cos(rotation1)));
         vec3 pointTop1 = offset1+centerTop;
         vec3 pointBottom1 = offset1+centerBottom;
 
-        vec3 offset2(radius*(cos(rotation2)-sin(rotation2)), 0.0f, radius*(sin(rotation2)+cos(rotation2)));
+        vec3 offset2(radius*(std::cos(rotation2)-std::sin(rotation2)), 0.0f, radius*(std::sin(rotation2)+std::cos(rotation2)));
         vec3 pointTop2 = offset2+centerTop;
         vec3 pointBottom2 = offset2+centerBottom;
 

--- a/Source/Internal/collisiondetection.cpp
+++ b/Source/Internal/collisiondetection.cpp
@@ -132,9 +132,9 @@ bool inTriangle(const vec3 &pointv, const vec3 &normal, const vec3 &p1v, const v
     else maximum = new_norm.y();
     if(maximum<new_norm.z())maximum=new_norm.z();
 
-    if (maximum == fabs(normal.x())) {i = 1; j = 2;}
-    if (maximum == fabs(normal.y())) {i = 0; j = 2;}
-    if (maximum == fabs(normal.z())) {i = 0; j = 1;}
+    if (maximum == std::fabs(normal.x())) {i = 1; j = 2;}
+    if (maximum == std::fabs(normal.y())) {i = 0; j = 2;}
+    if (maximum == std::fabs(normal.z())) {i = 0; j = 1;}
 
     u0 = pointv[i] - p1v[i];
     v0 = pointv[j] - p1v[j];
@@ -185,9 +185,9 @@ vec3 barycentric(const vec3 &pointv, const vec3 &normal, const vec3 &p1v, const 
     else maximum = new_norm.y();
     if(maximum<new_norm.z())maximum=new_norm.z();
 
-    if (maximum == fabs(normal.x())) {i = 1; j = 2;}
-    if (maximum == fabs(normal.y())) {i = 0; j = 2;}
-    if (maximum == fabs(normal.z())) {i = 0; j = 1;}
+    if (maximum == std::fabs(normal.x())) {i = 1; j = 2;}
+    if (maximum == std::fabs(normal.y())) {i = 0; j = 2;}
+    if (maximum == std::fabs(normal.z())) {i = 0; j = 1;}
 
     u0 = pointv[i] - p1v[i];
     v0 = pointv[j] - p1v[j];
@@ -235,7 +235,7 @@ int LineFacet(const vec3 &p1,const vec3 &p2,const vec3 &pa,const vec3 &pb,const 
 
     //Calculate the position on the line that intersects the plane 
     float denom = n.x() * (p2.x() - p1.x()) + n.y() * (p2.y() - p1.y()) + n.z() * (p2.z() - p1.z());
-    if (fabs(denom) < 0.0000001f)        // Line and plane don't intersect 
+    if (std::fabs(denom) < 0.0000001f)        // Line and plane don't intersect 
         return 0;
     float d = - n.x() * pa.x() - n.y() * pa.y() - n.z() * pa.z();
     float mu = - (d + n.x() * p1.x() + n.y() * p1.y() + n.z() * p1.z()) / denom;
@@ -268,7 +268,7 @@ int LineFacetNoBackface(const vec3 &p1,const vec3 &p2,const vec3 &pa,const vec3 
 
     //Calculate the position on the line that intersects the plane 
     float denom = n.x() * (p2.x() - p1.x()) + n.y() * (p2.y() - p1.y()) + n.z() * (p2.z() - p1.z());
-    if (fabs(denom) < 0.0000001f)   // Line and plane don't intersect 
+    if (std::fabs(denom) < 0.0000001f)   // Line and plane don't intersect 
         return 0;
     float d = - n.x() * pa.x() - n.y() * pa.y() - n.z() * pa.z();
     float mu = - (d + n.x() * p1.x() + n.y() * p1.y() + n.z() * p1.z()) / denom;

--- a/Source/Internal/config.cpp
+++ b/Source/Internal/config.cpp
@@ -70,7 +70,7 @@ Config::Config(): has_changed_since_save(false) {
 
 bool Config::Load(const std::string& filename, bool just_filling_blanks, bool shadow_variables) {
 
-    std::string configFile = filename;//pathUtility::localPathToGlobal(filename);
+    const std::string& configFile = filename;//pathUtility::localPathToGlobal(filename);
     std::ifstream file;
     my_ifstream_open(file, configFile.c_str(), std::ios_base::in);
 

--- a/Source/Internal/filesystem.cpp
+++ b/Source/Internal/filesystem.cpp
@@ -983,7 +983,7 @@ string ApplicationPathSeparators( const string& v )
 	size_t slash_pos = 0;
 	string res = v;
 
-	while( (slash_pos = res.find_first_of("\\")) != string::npos )
+	while( (slash_pos = res.find_first_of('\\')) != string::npos )
 	{
 		res[slash_pos] = '/';
 	}
@@ -1010,7 +1010,7 @@ string NormalizePathSeparators( const string& v)
 		res[slash_pos] = '\\';
 	}
 #else
-	while( (slash_pos = res.find_first_of("\\")) != string::npos )
+	while( (slash_pos = res.find_first_of('\\')) != string::npos )
 	{
 		res[slash_pos] = '/';
 	}
@@ -1067,7 +1067,7 @@ Path FindShortestPath2(const string& p1)
 
         if(!try_again)
         {
-            next_slash = current_path.find_first_of("/");
+            next_slash = current_path.find_first_of('/');
             if( next_slash != string::npos )
             {
                 current_path = current_path.substr(next_slash+1);

--- a/Source/Internal/modloading.cpp
+++ b/Source/Internal/modloading.cpp
@@ -1143,7 +1143,7 @@ void ModInstance::Reload( ) {
             const static size_t LOC_LENGTH = strlen("Localized/");
             if(memcmp("Localized/", str.c_str(), LOC_LENGTH) == 0) {
                 if(str.size() > 9 && strcmp(str.c_str() + str.size() - 9, "_meta.xml") == 0) {
-                    size_t second_slash = str.find("/", LOC_LENGTH);
+                    size_t second_slash = str.find('/', LOC_LENGTH);
 
                     std::string shortcode = str.substr(LOC_LENGTH, second_slash - LOC_LENGTH);
                     std::string level = str.substr(second_slash + 1, str.size() - (second_slash + 1));

--- a/Source/Main/engine.cpp
+++ b/Source/Main/engine.cpp
@@ -1146,7 +1146,8 @@ static void RasterizeTrisToVoxelField(const std::vector<vec3>& tri_verts, VoxelF
         for(int voxel_x = 0; voxel_x < voxel_size[0]; ++voxel_x){
             // Start with initial triangle
             std::vector<vec3> poly_verts;
-            for(int i=0; i<3; ++i){
+            poly_verts.reserve(3);
+for(int i=0; i<3; ++i){
                 poly_verts.push_back(tri_verts[tri_index+i]);
             }
             // Clip to slice bounds

--- a/Source/Main/engine.cpp
+++ b/Source/Main/engine.cpp
@@ -6420,7 +6420,7 @@ void Engine::ScriptableUICallback(const std::string &level)
     if( hasEnding( level, ".as" ) )
     {
         std::string short_path = script_dir_path + level;
-        std::string long_path = level;
+        const std::string& long_path = level;
 
         //First check if a full path was entered.
         if( FileExists( long_path, kAnyPath ) )
@@ -6446,7 +6446,7 @@ void Engine::ScriptableUICallback(const std::string &level)
     else if( hasEnding( level, ".xml" ) )
     {
         std::string short_path = "Data/Levels/" + level;
-        std::string long_path = level;
+        const std::string& long_path = level;
 
         EngineStateType target_state_type = kEngineLevelState;
         if(current_engine_state_.type == kEngineEditorLevelState){

--- a/Source/Math/enginemath.cpp
+++ b/Source/Math/enginemath.cpp
@@ -32,7 +32,7 @@
 #include <algorithm>
 
 void PlaneSpace(const vec3 &n, vec3 &p, vec3 &q) {
-    if (fabs(n[2]) > 0.7071067f) {
+    if (std::fabs(n[2]) > 0.7071067f) {
         // choose p in y-z plane
         float a = n[1]*n[1] + n[2]*n[2]; 
         float k = 1.0f/sqrtf(a);
@@ -79,7 +79,7 @@ float YAxisRotationFromVector(const vec3 &theVector)
 {
     vec3 vector(theVector.x(),0,theVector.z());
     vector = normalize(vector);
-    float new_rotation = acos(vector.z())/3.1415f*180.0f;
+    float new_rotation = std::acos(vector.z())/3.1415f*180.0f;
     if(vector.x()<0)new_rotation*=-1;
     new_rotation+=180;
     return new_rotation;

--- a/Source/Math/mat4.cpp
+++ b/Source/Math/mat4.cpp
@@ -942,7 +942,7 @@ void mat4::NormalizeBases()
     float vec_length;
     int index = 0;
     for(int i=0; i<3; i++){
-        vec_length = sqrt(square(entries[index+0])+
+        vec_length = std::sqrt(square(entries[index+0])+
                                  square(entries[index+1])+
                                  square(entries[index+2]));
         entries[index+0] /= vec_length;
@@ -1024,16 +1024,16 @@ vec4 AxisAngleFromMat4( const mat4& m )
     float epsilon2 = 0.1f; // margin to distinguish between 0 and 180 degrees
     // optional check that input is pure rotation, 'isRotationMatrix' is defined at:
     // http://www.euclideanspace.com/maths/algebra/matrix/orthogonal/rotation/
-    if ((fabs(m(0,1)-m(1,0))< epsilon)
-        && (fabs(m(0,2)-m(2,0))< epsilon)
-        && (fabs(m(1,2)-m(2,1))< epsilon)) {
+    if ((std::fabs(m(0,1)-m(1,0))< epsilon)
+        && (std::fabs(m(0,2)-m(2,0))< epsilon)
+        && (std::fabs(m(1,2)-m(2,1))< epsilon)) {
             // singularity found
             // first check for identity matrix which must have +1 for all terms
             //  in leading diagonaland zero in other terms
-            if ((fabs(m(0,1)+m(1,0)) < epsilon2)
-                && (fabs(m(0,2)+m(2,0)) < epsilon2)
-                && (fabs(m(1,2)+m(2,1)) < epsilon2)
-                && (fabs(m(0,0)+m(1,1)+m(2,2)-3) < epsilon2)) {
+            if ((std::fabs(m(0,1)+m(1,0)) < epsilon2)
+                && (std::fabs(m(0,2)+m(2,0)) < epsilon2)
+                && (std::fabs(m(1,2)+m(2,1)) < epsilon2)
+                && (std::fabs(m(0,0)+m(1,1)+m(2,2)-3) < epsilon2)) {
                     // this singularity is identity matrix so angle = 0
                     return vec4(1.0f,0.0f,0.0f,0.0f); // zero angle, arbitrary axis
             }
@@ -1082,7 +1082,7 @@ vec4 AxisAngleFromMat4( const mat4& m )
     float s = sqrtf((m(2,1) - m(1,2))*(m(2,1) - m(1,2))
         +(m(0,2) - m(2,0))*(m(0,2) - m(2,0))
         +(m(1,0) - m(0,1))*(m(1,0) - m(0,1))); // used to normalise
-    if (fabs(s) < 0.001) s=1; 
+    if (std::fabs(s) < 0.001) s=1; 
     // prevent divide by zero, should not happen if matrix is orthogonal and should be
     // caught by singularity test above, but I've left it in just in case
     float test = ( m(0,0) + m(1,1) + m(2,2) - 1.0f)/2.0f;

--- a/Source/Math/quaternions.cpp
+++ b/Source/Math/quaternions.cpp
@@ -105,7 +105,7 @@ void QuaternionToAxisAngle(quaternion quat, vec3 * axis, float * angle) {
 
     QuaternionNormalize(&quat);
     sinAngle = sqrtf(1.0f - (quat.entries[3] * quat.entries[3]));
-    if (fabs(sinAngle) < 0.0005f) sinAngle = 1.0f;
+    if (std::fabs(sinAngle) < 0.0005f) sinAngle = 1.0f;
     axis->entries[0] = (quat.entries[0] / sinAngle);
     axis->entries[1] = (quat.entries[1] / sinAngle);
     axis->entries[2] = (quat.entries[2] / sinAngle);
@@ -224,8 +224,8 @@ vec4 Quat_2_AA(quaternion Quat)
             Ang_Ax.entries[0]=1.0f; Ang_Ax.entries[1] = 0.0f; Ang_Ax.entries[2] = 0.0f; Ang_Ax.angle() = 0.0f;
             return Ang_Ax;
         }
-        tw = (float)acos(Quat.entries[3]) * 2;
-        scale = (float)sin(tw / 2.0f);
+        tw = std::acos(Quat.entries[3]) * 2;
+        scale = std::sin(tw / 2.0f);
         Ang_Ax.entries[0] = Quat.entries[0] / scale;
         Ang_Ax.entries[1] = Quat.entries[1] / scale;
         Ang_Ax.entries[2] = Quat.entries[2] / scale;
@@ -247,12 +247,12 @@ quaternion::quaternion(bool In_Degrees, vec3 Euler)
         }
         //Calculate trig identities
         //Formerly roll, pitch, yaw
-        cr = float(cos(Euler.entries[0]/2));
-        cp = float(cos(Euler.entries[1]/2));
-        cy = float(cos(Euler.entries[2]/2));
-        sr = float(sin(Euler.entries[0]/2));
-        sp = float(sin(Euler.entries[1]/2));
-        sy = float(sin(Euler.entries[2]/2));
+        cr = std::cos(Euler.entries[0]/2);
+        cp = std::cos(Euler.entries[1]/2);
+        cy = std::cos(Euler.entries[2]/2);
+        sr = std::sin(Euler.entries[0]/2);
+        sp = std::sin(Euler.entries[1]/2);
+        sy = std::sin(Euler.entries[2]/2);
 
         
         cpcy = cp * cy;
@@ -551,29 +551,29 @@ bool operator==(const quaternion &a, const quaternion &b) {
 vec3 QuaternionToEuler(const quaternion& quat) {
     vec3 euler_angles;
     quaternion q(quat[3], quat[0], quat[1], quat[2]);
-    euler_angles[0] = atan2(2*(q[0]*q[1] + q[2]*q[3]), 1 - 2*(q[1]*q[1] + q[2]*q[2]));
+    euler_angles[0] = std::atan2(2*(q[0]*q[1] + q[2]*q[3]), 1 - 2*(q[1]*q[1] + q[2]*q[2]));
     float sinval = 2*(q[0]*q[2] - q[3]*q[1]);
-    if(fabs(sinval) >= 1.0f)
+    if(std::fabs(sinval) >= 1.0f)
         if(sinval >= 0.0f)
             euler_angles[1] = 3.14159266f / 2.0f;
         else
             euler_angles[1] = 3.14159266f / -2.0f;
     else
-        euler_angles[1] = asin(2*(q[0]*q[2] - q[3]*q[1]));
-    euler_angles[2] = atan2(2*(q[0]*q[3] + q[1]*q[2]), 1 - 2*(q[2]*q[2] + q[3]*q[3]));
+        euler_angles[1] = std::asin(2*(q[0]*q[2] - q[3]*q[1]));
+    euler_angles[2] = std::atan2(2*(q[0]*q[3] + q[1]*q[2]), 1 - 2*(q[2]*q[2] + q[3]*q[3]));
     return euler_angles;
 }
 
 quaternion EulerToQuaternion(const vec3& euler) {
     quaternion q;
     vec3 eu = euler * 0.5f; // makes conversion simpler
-    q[3] = cos(eu[0])*cos(eu[1])*cos(eu[2]) +
-        sin(eu[0])*sin(eu[1])*sin(eu[2]);
-    q[0] = sin(eu[0])*cos(eu[1])*cos(eu[2]) -
-        cos(eu[0])*sin(eu[1])*sin(eu[2]);
-    q[1] = cos(eu[0])*sin(eu[1])*cos(eu[2]) +
-        sin(eu[0])*cos(eu[1])*sin(eu[2]);
-    q[2] = cos(eu[0])*cos(eu[1])*sin(eu[2]) -
-        sin(eu[0])*sin(eu[1])*cos(eu[2]);
+    q[3] = std::cos(eu[0])*std::cos(eu[1])*std::cos(eu[2]) +
+        std::sin(eu[0])*std::sin(eu[1])*std::sin(eu[2]);
+    q[0] = std::sin(eu[0])*std::cos(eu[1])*std::cos(eu[2]) -
+        std::cos(eu[0])*std::sin(eu[1])*std::sin(eu[2]);
+    q[1] = std::cos(eu[0])*std::sin(eu[1])*std::cos(eu[2]) +
+        std::sin(eu[0])*std::cos(eu[1])*std::sin(eu[2]);
+    q[2] = std::cos(eu[0])*std::cos(eu[1])*std::sin(eu[2]) -
+        std::sin(eu[0])*std::sin(eu[1])*std::cos(eu[2]);
     return q;
 }

--- a/Source/Objects/riggedobject.cpp
+++ b/Source/Objects/riggedobject.cpp
@@ -767,9 +767,9 @@ void RiggedObject::Draw(const mat4& proj_view_matrix, Object::DrawType type) {
             shaders->SetUniformVec3("blood_tint", vec3(-1,-1,-1)); // Presumably this is here to force refreshing this uniform?
             shaders->SetUniformVec3("blood_tint", Graphics::Instance()->config_.blood_color());
             std::vector<vec3> ambient_cube_color_vec;
-            ambient_cube_color_vec.reserve(ambient_cube_color.size());
+            ambient_cube_color_vec.reserve(6);
             for (auto& i : ambient_cube_color) {
-                ambient_cube_color_vec.push_back(ambient_cube_color[i]);
+                ambient_cube_color_vec.push_back(i);
             }
             shaders->SetUniformVec3Array("ambient_cube_color", ambient_cube_color_vec);        
             shaders->SetUniformVec3Array("tint_palette", palette_colors_srgb);

--- a/Source/Objects/riggedobject.cpp
+++ b/Source/Objects/riggedobject.cpp
@@ -3343,7 +3343,7 @@ void UpdateStuckItem(AttachedItem& stuck_item, const Skeleton &skeleton, bool an
     int bone = stuck_item.bone_id;
     mat4 bone_mat = skeleton.physics_bones[bone].bullet_object->GetTransform();
     mat4 the_weap_mat = bone_mat * stuck_item.rel_mat;
-    mat4 temp_weap_mat = the_weap_mat;
+    const mat4& temp_weap_mat = the_weap_mat;
     ItemObjectScriptReader &item = stuck_item.item;
     item.SetPhysicsTransform(temp_weap_mat);
     if(item.just_created){

--- a/Source/Objects/riggedobject.cpp
+++ b/Source/Objects/riggedobject.cpp
@@ -767,8 +767,9 @@ void RiggedObject::Draw(const mat4& proj_view_matrix, Object::DrawType type) {
             shaders->SetUniformVec3("blood_tint", vec3(-1,-1,-1)); // Presumably this is here to force refreshing this uniform?
             shaders->SetUniformVec3("blood_tint", Graphics::Instance()->config_.blood_color());
             std::vector<vec3> ambient_cube_color_vec;
-            for(auto & i : ambient_cube_color){
-                ambient_cube_color_vec.push_back(i);
+            ambient_cube_color_vec.reserve(ambient_cube_color.size());
+            for (auto& i : ambient_cube_color) {
+                ambient_cube_color_vec.push_back(ambient_cube_color[i]);
             }
             shaders->SetUniformVec3Array("ambient_cube_color", ambient_cube_color_vec);        
             shaders->SetUniformVec3Array("tint_palette", palette_colors_srgb);

--- a/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.cpp
+++ b/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.cpp
@@ -290,18 +290,18 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "CameraObject", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "parameters", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "AmbientSoundObject", "ambient_sound_object", false, params  );
         aos.push_back(ao);
     }
@@ -347,7 +347,7 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "Decal", "decal_object", false, params  );
         aos.push_back(ao);
     }
@@ -411,7 +411,7 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "ItemObject", "item", false, params  );
         aos.push_back(ao);
     }
@@ -424,17 +424,17 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "NavmeshRegionObject", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "NavmeshHintObject", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "NavmeshConnectionObject", "", true, params  );
         aos.push_back(ao);
     }
@@ -446,7 +446,7 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
         ActorObject ao( "LightVolumeObject", "", true, params  );
         aos.push_back(ao);
     }
@@ -468,37 +468,37 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "Group", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "Prefab", "prefab", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "EnvObjectAttachments", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "Palette", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "ItemConnections", "", true, params  );
         aos.push_back(ao);
     }
     {
-        std::vector<Parameter> params = global_params;
+        const std::vector<Parameter>& params = global_params;
 
         ActorObject ao( "Connections", "", true, params  );
         aos.push_back(ao);

--- a/Source/Ogda/jobhandler.cpp
+++ b/Source/Ogda/jobhandler.cpp
@@ -94,7 +94,7 @@ bool JobHandler::Run(const std::string& path )
                     bool is_ok = false;
 
 		    LOGD << "Loading Transfer: " << itemit->path << std::endl;
-		    for(std::string input_folder : input_folders) 
+		    for(const std::string& input_folder : input_folders) 
 		    {
 			if(is_ok == false) {
                             if( CheckFileAccess(AssemblePath(input_folder,itemit->path).c_str()) ) {
@@ -303,7 +303,7 @@ bool JobHandler::Run(const std::string& path )
     
         std::vector<std::string> manifest;
 
-        for(std::string input_folder : input_folders) 
+        for(const std::string& input_folder : input_folders) 
 	{
             GenerateManifest( input_folder.c_str(), manifest );
 	}

--- a/Source/Online/online.cpp
+++ b/Source/Online/online.cpp
@@ -293,7 +293,7 @@ void Online::SendPlayerInputState() {
     //Assume player one control. For split screen multiplayer we have to start dealing with multiplayer controllers here.
     PlayerInput* player_input = Input::Instance()->GetController(0);
 
-    for(string binding : Input::Instance()->GetAllAvailableBindings()) {
+    for(const string& binding : Input::Instance()->GetAllAvailableBindings()) {
 
         // TODO Can we make it so these bindings don't even show up in available bindings?
         if(binding == "look_left" || binding == "look_right" || binding == "look_up" || binding == "look_down") {
@@ -544,7 +544,7 @@ void Online::StartMultiplayer(MultiplayerMode multiplayerMode) {
         }
 
         //Assign mappings for input bindings.
-        for(string binding : Input::Instance()->GetAllAvailableBindings()) {
+        for(const string& binding : Input::Instance()->GetAllAvailableBindings()) {
             AssignBindID(binding);
         }
 

--- a/Source/Scripting/angelscript/add_on/scripthelper/scripthelper.cpp
+++ b/Source/Scripting/angelscript/add_on/scripthelper/scripthelper.cpp
@@ -228,7 +228,7 @@ int WriteConfigToStream(asIScriptEngine *engine, ostream &strm)
 			for(;;)
 			{
 				// Find " characters
-				pos = str.find("\"",pos);
+				pos = str.find('\"',pos);
 				if( pos == string::npos )
 					break;
 
@@ -699,7 +699,7 @@ int ConfigEngineFromStream(asIScriptEngine *engine, istream &strm, const char *c
 			in::ReplaceSlashQuote(decl);
 
 			// Remove the $ that the engine prefixes the behaviours with
-			size_t n = decl.find("$");
+			size_t n = decl.find('$');
 			if( n != string::npos )
 				decl[n] = ' ';
 

--- a/Source/Scripting/angelscript/add_on/scriptstdstring/scriptstdstring.cpp
+++ b/Source/Scripting/angelscript/add_on/scriptstdstring/scriptstdstring.cpp
@@ -406,12 +406,12 @@ static void StringResize(asUINT l, string &str)
 // string formatInt(int64 val, const string &in options, uint width)
 static string formatInt(asINT64 value, const string &options, asUINT width)
 {
-	bool leftJustify = options.find("l") != string::npos;
-	bool padWithZero = options.find("0") != string::npos;
-	bool alwaysSign  = options.find("+") != string::npos;
-	bool spaceOnSign = options.find(" ") != string::npos;
-	bool hexSmall    = options.find("h") != string::npos;
-	bool hexLarge    = options.find("H") != string::npos;
+	bool leftJustify = options.find('l') != string::npos;
+	bool padWithZero = options.find('0') != string::npos;
+	bool alwaysSign  = options.find('+') != string::npos;
+	bool spaceOnSign = options.find(' ') != string::npos;
+	bool hexSmall    = options.find('h') != string::npos;
+	bool hexLarge    = options.find('H') != string::npos;
 
 	string fmt = "%";
 	if( leftJustify ) fmt += "-";
@@ -450,12 +450,12 @@ static string formatInt(asINT64 value, const string &options, asUINT width)
 // string formatUInt(uint64 val, const string &in options, uint width)
 static string formatUInt(asQWORD value, const string &options, asUINT width)
 {
-	bool leftJustify = options.find("l") != string::npos;
-	bool padWithZero = options.find("0") != string::npos;
-	bool alwaysSign  = options.find("+") != string::npos;
-	bool spaceOnSign = options.find(" ") != string::npos;
-	bool hexSmall    = options.find("h") != string::npos;
-	bool hexLarge    = options.find("H") != string::npos;
+	bool leftJustify = options.find('l') != string::npos;
+	bool padWithZero = options.find('0') != string::npos;
+	bool alwaysSign  = options.find('+') != string::npos;
+	bool spaceOnSign = options.find(' ') != string::npos;
+	bool hexSmall    = options.find('h') != string::npos;
+	bool hexLarge    = options.find('H') != string::npos;
 
 	string fmt = "%";
 	if( leftJustify ) fmt += "-";
@@ -494,12 +494,12 @@ static string formatUInt(asQWORD value, const string &options, asUINT width)
 // string formatFloat(double val, const string &in options, uint width, uint precision)
 static string formatFloat(double value, const string &options, asUINT width, asUINT precision)
 {
-	bool leftJustify = options.find("l") != string::npos;
-	bool padWithZero = options.find("0") != string::npos;
-	bool alwaysSign  = options.find("+") != string::npos;
-	bool spaceOnSign = options.find(" ") != string::npos;
-	bool expSmall    = options.find("e") != string::npos;
-	bool expLarge    = options.find("E") != string::npos;
+	bool leftJustify = options.find('l') != string::npos;
+	bool padWithZero = options.find('0') != string::npos;
+	bool alwaysSign  = options.find('+') != string::npos;
+	bool spaceOnSign = options.find(' ') != string::npos;
+	bool expSmall    = options.find('e') != string::npos;
+	bool expLarge    = options.find('E') != string::npos;
 
 	string fmt = "%";
 	if( leftJustify ) fmt += "-";

--- a/Source/Scripting/angelscript/asfuncs.cpp
+++ b/Source/Scripting/angelscript/asfuncs.cpp
@@ -2240,7 +2240,8 @@ int ASDebugDrawLines( const CScriptArray &array, vec4 color, int lifespan_int ) 
 
     std::vector<vec3> data;
 
-    for( int n = 0; n < (int)array.GetSize(); n++ )
+    data.reserve((int)array.GetSize());
+for( int n = 0; n < (int)array.GetSize(); n++ )
     {
         data.push_back(*((vec3*)array.At(n)));
     }
@@ -3934,7 +3935,8 @@ bool AS_ImGui_Combo(const std::string& label, int& current_item, const CScriptAr
     const int items_count = items.GetSize();
     std::vector<const char*> items_data;
 
-    for(int n = 0; n < items_count; ++n) {
+    items_data.reserve(items_count);
+for(int n = 0; n < items_count; ++n) {
         items_data.push_back(reinterpret_cast<const std::string*>(items.At(n))->c_str());
     }
 
@@ -4250,7 +4252,8 @@ bool AS_ImGui_ListBox(const std::string& label, int& current_item, const CScript
     const int items_count = items.GetSize();
     std::vector<const char*> items_data;
 
-    for(int n = 0; n < items_count; ++n) {
+    items_data.reserve(items_count);
+for(int n = 0; n < items_count; ++n) {
         items_data.push_back(reinterpret_cast<const std::string*>(items.At(n))->c_str());
     }
 

--- a/Source/Scripting/angelscript/asfuncs.cpp
+++ b/Source/Scripting/angelscript/asfuncs.cpp
@@ -2241,7 +2241,7 @@ int ASDebugDrawLines( const CScriptArray &array, vec4 color, int lifespan_int ) 
     std::vector<vec3> data;
 
     data.reserve((int)array.GetSize());
-for( int n = 0; n < (int)array.GetSize(); n++ )
+    for (int n = 0; n < (int)array.GetSize(); n++)
     {
         data.push_back(*((vec3*)array.At(n)));
     }
@@ -3936,7 +3936,7 @@ bool AS_ImGui_Combo(const std::string& label, int& current_item, const CScriptAr
     std::vector<const char*> items_data;
 
     items_data.reserve(items_count);
-for(int n = 0; n < items_count; ++n) {
+    for (int n = 0; n < items_count; ++n) {
         items_data.push_back(reinterpret_cast<const std::string*>(items.At(n))->c_str());
     }
 
@@ -4253,7 +4253,7 @@ bool AS_ImGui_ListBox(const std::string& label, int& current_item, const CScript
     std::vector<const char*> items_data;
 
     items_data.reserve(items_count);
-for(int n = 0; n < items_count; ++n) {
+    for (int n = 0; n < items_count; ++n) {
         items_data.push_back(reinterpret_cast<const std::string*>(items.At(n))->c_str());
     }
 

--- a/Source/Sound/AudioFilters/transition_mixer.cpp
+++ b/Source/Sound/AudioFilters/transition_mixer.cpp
@@ -80,8 +80,8 @@ bool TransitionMixer::Step( HighResBufferSegment* out, const HighResBufferSegmen
         {
             //Crossfade in a sinusoid to preserve the energy.
             float dp = d*(float)PI/2;
-            dl = sin(dp);
-            dr = cos(dp);
+            dl = std::sin(dp);
+            dr = std::cos(dp);
         }
         else if( transition_type == Linear )
         {

--- a/Source/UserInput/input.cpp
+++ b/Source/UserInput/input.cpp
@@ -727,8 +727,8 @@ std::vector<std::string> Input::GetAvailableBindings(const std::string& binding_
 std::set<std::string> Input::GetAllAvailableBindings() {
     std::set<std::string> binds;
 
-    for(auto binding_cat : bindings_) {
-        for(auto binding : binding_cat.second) {
+    for(const auto& binding_cat : bindings_) {
+        for(const auto& binding : binding_cat.second) {
             binds.insert(binding.first);
         }
     }

--- a/Source/XML/level_loader.cpp
+++ b/Source/XML/level_loader.cpp
@@ -324,7 +324,7 @@ void AnalyzeForLineBreaks(char* str, int len){
 	std::string second_line;
 	while(first_line.length() > 0){
 		while(metrics.bounds[2] > threshold){
-			int last_space = first_line.find_last_of(" ");
+			int last_space = first_line.find_last_of(' ');
 			second_line.insert(0, first_line.substr(last_space));
 			first_line.resize(last_space);
 			metrics = g_as_text_context.ASGetTextAtlasMetrics( font_path, font_size, 0, first_line.c_str());

--- a/Source/XML/xml_helper.cpp
+++ b/Source/XML/xml_helper.cpp
@@ -36,18 +36,18 @@ TiXmlElement *XmlHelper::findNode(TiXmlDocument &doc, std::string &item, TiXmlEl
     {
         if (element == NULL)
         {
-            element = doc.FirstChildElement(item.substr(0, item.find("/")));
+            element = doc.FirstChildElement(item.substr(0, item.find('/')));
         }
         else
         {
-            element = element->FirstChildElement(item.substr(0, item.find("/")));
+            element = element->FirstChildElement(item.substr(0, item.find('/')));
         }
 
         if (element == NULL)
             return NULL;
 
-        if (std::string::npos != item.find("/"))
-            item = item.substr(item.find("/") + 1);
+        if (std::string::npos != item.find('/'))
+            item = item.substr(item.find('/') + 1);
         else
             item = "";            
     }


### PR DESCRIPTION
Use the [clang-tidy](https://clang.llvm.org/extra/clang-tidy) static code analyzer to find any performance issues within our source code. I've applied the following checks:
- [performance-faster-string-find](https://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html): find any string find algorithms that can be improved
- [performance-for-range-copy](https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html): avoid unnecessary copies inside range based for loops
- [performance-inefficient-vector-operation](https://clang.llvm.org/extra/clang-tidy/checks/performance-inefficient-vector-operation.html): when growing a vector inside a loop, reserve the size before
- [performance-type-promotion-in-math-fn](https://clang.llvm.org/extra/clang-tidy/checks/performance-type-promotion-in-math-fn.html): avoid calling double variants of math functions if the input & output is a float
- [performance-unnecessary-copy-initialization](https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-copy-initialization.html): avoid creating any local variable which could be references