### PR TITLE
Use range based loops where applicable

### DIFF
--- a/Source/AI/navmesh.cpp
+++ b/Source/AI/navmesh.cpp
@@ -319,8 +319,7 @@ namespace {
 
     bool Convex2DCollide(const vector<vec2> points[2], const vector<vec2> &axes) {
         bool intersects = true;
-        for(size_t i=0, len=axes.size(); i<len; ++i){
-            const vec2& axis = axes[i];
+        for(const auto & axis : axes){
             float proj_bounds[2][2];
             for(size_t i=0; i<2; ++i){
                 const vector<vec2> &point_vec = points[i];
@@ -460,8 +459,8 @@ void VoxellizeMesh(const vector<unsigned int> &faces, const vector<float> &verti
                     points[0].push_back(vec2((vox_x+i%2)*VOXEL_SIZE+bounds[0], (vox_z+i/2)*VOXEL_SIZE+bounds[2]));
                 }
                 points[1].clear();
-                for(int i=0; i<3; ++i){
-                    points[1].push_back(vec2(vert[i][0], vert[i][2]));
+                for(auto & i : vert){
+                    points[1].push_back(vec2(i[0], i[2]));
                 }
                 axes.clear();
                 axes.push_back(vec2(1,0));
@@ -474,8 +473,8 @@ void VoxellizeMesh(const vector<unsigned int> &faces, const vector<float> &verti
                 if(Convex2DCollide(points, axes)){
                     old_points.clear();
                     new_points.clear();
-                    for(int i=0; i<3; ++i){
-                        old_points.push_back(vec3(vert[i][0], vert[i][1], vert[i][2]));
+                    for(auto & i : vert){
+                        old_points.push_back(vec3(i[0], i[1], i[2]));
                     }
                     vector<vec3> plane_normal;
                     vector<float> plane_d;
@@ -520,8 +519,7 @@ void VoxellizeMesh(const vector<unsigned int> &faces, const vector<float> &verti
         for(int vox_x = 0; vox_x < voxel_dim[0]; ++vox_x){
             int column_index = vox_z * voxel_dim[0] + vox_x;
             ColumnEntryList list = columns[column_index];
-            for(ColumnEntryList::iterator iter = list.begin(); iter != list.end(); ++iter){
-                const ColumnEntry &entry = *iter;
+            for(auto & entry : list){
                 vec3 pos;
                 pos[0] = vox_x * VOXEL_SIZE + bounds[0];
                 pos[1] = entry.y * VOXEL_SIZE + bounds[1];

--- a/Source/AI/sample.cpp
+++ b/Source/AI/sample.cpp
@@ -51,8 +51,8 @@ Sample::Sample() :
 	m_navQuery = dtAllocNavMeshQuery();
 	m_crowd = dtAllocCrowd();
 
-	for (int i = 0; i < MAX_TOOLS; i++)
-		m_toolStates[i] = 0;
+	for (auto & toolState : m_toolStates)
+		toolState = 0;
 }
 
 Sample::~Sample()
@@ -61,8 +61,8 @@ Sample::~Sample()
 	dtFreeNavMesh(m_navMesh);
 	dtFreeCrowd(m_crowd);
 	delete m_tool;
-	for (int i = 0; i < MAX_TOOLS; i++)
-		delete m_toolStates[i];
+	for (auto & toolState : m_toolStates)
+		delete toolState;
 }
 
 void Sample::setTool(SampleTool* tool)
@@ -201,46 +201,46 @@ void Sample::handleUpdate(const float dt)
 
 void Sample::updateToolStates(const float dt)
 {
-	for (int i = 0; i < MAX_TOOLS; i++)
+	for (auto & toolState : m_toolStates)
 	{
-		if (m_toolStates[i])
-			m_toolStates[i]->handleUpdate(dt);
+		if (toolState)
+			toolState->handleUpdate(dt);
 	}
 }
 
 void Sample::initToolStates(Sample* sample)
 {
-	for (int i = 0; i < MAX_TOOLS; i++)
+	for (auto & toolState : m_toolStates)
 	{
-		if (m_toolStates[i])
-			m_toolStates[i]->init(sample);
+		if (toolState)
+			toolState->init(sample);
 	}
 }
 
 void Sample::resetToolStates()
 {
-	for (int i = 0; i < MAX_TOOLS; i++)
+	for (auto & toolState : m_toolStates)
 	{
-		if (m_toolStates[i])
-			m_toolStates[i]->reset();
+		if (toolState)
+			toolState->reset();
 	}
 }
 
 void Sample::renderToolStates()
 {
-	for (int i = 0; i < MAX_TOOLS; i++)
+	for (auto & toolState : m_toolStates)
 	{
-		if (m_toolStates[i])
-			m_toolStates[i]->handleRender();
+		if (toolState)
+			toolState->handleRender();
 	}
 }
 
 void Sample::renderOverlayToolStates(double* proj, double* model, int* view)
 {
-	for (int i = 0; i < MAX_TOOLS; i++)
+	for (auto & toolState : m_toolStates)
 	{
-		if (m_toolStates[i])
-			m_toolStates[i]->handleRenderOverlay(proj, model, view);
+		if (toolState)
+			toolState->handleRenderOverlay(proj, model, view);
 	}
 }
 

--- a/Source/AI/sample_interfaces.cpp
+++ b/Source/AI/sample_interfaces.cpp
@@ -94,11 +94,11 @@ void BuildContext::dumpLog(const char* format, ...)
 			if (*msg == '\t')
 			{
 				int count = 1;
-				for (int j = 0; j < 4; ++j)
+				for (int j : TAB_STOPS)
 				{
-					if (n < TAB_STOPS[j])
+					if (n < j)
 					{
-						count = TAB_STOPS[j] - n;
+						count = j - n;
 						break;
 					}
 				}

--- a/Source/Asset/Asset/animation.cpp
+++ b/Source/Asset/Asset/animation.cpp
@@ -149,9 +149,7 @@ void Animation::CalcInvertBoneMats() {
 }
 
 void Animation::UpdateIKBones() {
-    for(unsigned i=0; i<keyframes.size(); i++){
-        Keyframe& k = keyframes[i];
-
+    for(auto & k : keyframes){
         // Initialize uses_ik vector
         size_t num_bones = k.bone_mats.size();
         k.uses_ik.resize(num_bones);
@@ -182,95 +180,95 @@ void Animation::WriteToFile( FILE * file ) {
     int num_keyframes = (int)keyframes.size();;
     fwrite(&num_keyframes, sizeof(int), 1, file);
 
-    for(unsigned i=0; i<keyframes.size(); i++){
-        fwrite(&keyframes[i].time, sizeof(int), 1, file);
+    for(auto & keyframe : keyframes){
+        fwrite(&keyframe.time, sizeof(int), 1, file);
         
-        size_t num_weights = keyframes[i].weights.size();
+        size_t num_weights = keyframe.weights.size();
         fwrite(&num_weights, sizeof(int), 1, file);
         if(num_weights){
-            fwrite(&keyframes[i].weights[0], sizeof(float), num_weights, file);
+            fwrite(&keyframe.weights[0], sizeof(float), num_weights, file);
         }
 
-        int num_bone_mats = (int)keyframes[i].bone_mats.size();
+        int num_bone_mats = (int)keyframe.bone_mats.size();
         fwrite(&num_bone_mats, sizeof(int), 1, file);
         mat4 temp;
-        for(unsigned j=0; j<keyframes[i].bone_mats.size(); j++){
-            temp = keyframes[i].bone_mats[j].GetMat4();
+        for(unsigned j=0; j<keyframe.bone_mats.size(); j++){
+            temp = keyframe.bone_mats[j].GetMat4();
             fwrite(&temp.entries, sizeof(float), 16, file);
         }
 
-        int num_weapon_mats = (int)keyframes[i].weapon_mats.size();
+        int num_weapon_mats = (int)keyframe.weapon_mats.size();
         fwrite(&num_weapon_mats, sizeof(int), 1, file);
-        for(unsigned j=0; j<keyframes[i].weapon_mats.size(); j++){
-            temp = keyframes[i].weapon_mats[j].GetMat4();
+        for(unsigned j=0; j<keyframe.weapon_mats.size(); j++){
+            temp = keyframe.weapon_mats[j].GetMat4();
             fwrite(&temp.entries, sizeof(float), 16, file);
-            fwrite(&keyframes[i].weapon_relative_id[j], sizeof(int), 1, file);
-            fwrite(&keyframes[i].weapon_relative_weight[j], sizeof(float), 1, file);
+            fwrite(&keyframe.weapon_relative_id[j], sizeof(int), 1, file);
+            fwrite(&keyframe.weapon_relative_weight[j], sizeof(float), 1, file);
         }
 
-        fwrite(&keyframes[i].use_mobility, sizeof(bool), 1, file);
-        if(keyframes[i].use_mobility){
+        fwrite(&keyframe.use_mobility, sizeof(bool), 1, file);
+        if(keyframe.use_mobility){
             mat4 temp_mat;
-            temp_mat.SetColumn(0, keyframes[i].mobility_mat.GetColumn(0));
-            temp_mat.SetColumn(1, keyframes[i].mobility_mat.GetColumn(2)*-1.0f);
-            temp_mat.SetColumn(2, keyframes[i].mobility_mat.GetColumn(1));
-            temp_mat.SetColumn(3, keyframes[i].mobility_mat.GetColumn(3));
+            temp_mat.SetColumn(0, keyframe.mobility_mat.GetColumn(0));
+            temp_mat.SetColumn(1, keyframe.mobility_mat.GetColumn(2)*-1.0f);
+            temp_mat.SetColumn(2, keyframe.mobility_mat.GetColumn(1));
+            temp_mat.SetColumn(3, keyframe.mobility_mat.GetColumn(3));
             fwrite(&temp_mat.entries, sizeof(float), 16, file);
         }
 
-        int num_events = (int)keyframes[i].events.size();
+        int num_events = (int)keyframe.events.size();
         fwrite(&num_events, sizeof(int), 1, file);
 
-        for(size_t j=0; j<keyframes[i].events.size(); j++){
-            fwrite(&keyframes[i].events[j].which_bone, sizeof(int), 1, file);
-            const string &event_string = keyframes[i].events[j].event_string;
+        for(size_t j=0; j<keyframe.events.size(); j++){
+            fwrite(&keyframe.events[j].which_bone, sizeof(int), 1, file);
+            const string &event_string = keyframe.events[j].event_string;
             size_t string_size = event_string.size();
             fwrite(&string_size, sizeof(int), 1, file);
             fwrite(event_string.c_str(), sizeof(char), string_size, file);
         }
 
-        int num_ik_bones = (int)keyframes[i].ik_bones.size();
+        int num_ik_bones = (int)keyframe.ik_bones.size();
         fwrite(&num_ik_bones, sizeof(int), 1, file);
 
-        for(size_t j=0; j<keyframes[i].ik_bones.size(); j++){
+        for(size_t j=0; j<keyframe.ik_bones.size(); j++){
             // Used to be ik_bones.start and end
             vec3 filler;
             fwrite(&filler, sizeof(vec3), 1, file);
             fwrite(&filler, sizeof(vec3), 1, file);
-            size_t path_length = keyframes[i].ik_bones[j].bone_path.size();
+            size_t path_length = keyframe.ik_bones[j].bone_path.size();
             fwrite(&path_length, sizeof(int), 1, file);
-            fwrite(&keyframes[i].ik_bones[j].bone_path[0], sizeof(int), path_length, file);
-            const string &label_string = keyframes[i].ik_bones[j].label;
+            fwrite(&keyframe.ik_bones[j].bone_path[0], sizeof(int), path_length, file);
+            const string &label_string = keyframe.ik_bones[j].label;
             size_t string_size = label_string.size();
             fwrite(&string_size, sizeof(int), 1, file);
             fwrite(label_string.c_str(),sizeof(char), string_size, file);
         }
 
-        int num_shape_keys = (int)keyframes[i].shape_keys.size();
+        int num_shape_keys = (int)keyframe.shape_keys.size();
         fwrite(&num_shape_keys, sizeof(int), 1, file);
 
-        for(size_t j=0; j<keyframes[i].shape_keys.size(); j++){
-            fwrite(&keyframes[i].shape_keys[j].weight, sizeof(float), 1, file);
-            const string &label_string = keyframes[i].shape_keys[j].label;
+        for(size_t j=0; j<keyframe.shape_keys.size(); j++){
+            fwrite(&keyframe.shape_keys[j].weight, sizeof(float), 1, file);
+            const string &label_string = keyframe.shape_keys[j].label;
             size_t string_size = label_string.size();
             fwrite(&string_size, sizeof(int), 1, file);
             fwrite(label_string.c_str(),sizeof(char), string_size, file);
         }
         
-        int num_status_keys = (int)keyframes[i].status_keys.size();
+        int num_status_keys = (int)keyframe.status_keys.size();
         fwrite(&num_status_keys, sizeof(int), 1, file);
 
-        for(size_t j=0; j<keyframes[i].status_keys.size(); j++){
-            fwrite(&keyframes[i].status_keys[j].weight, sizeof(float), 1, file);
-            const string &label_string = keyframes[i].status_keys[j].label;
+        for(size_t j=0; j<keyframe.status_keys.size(); j++){
+            fwrite(&keyframe.status_keys[j].weight, sizeof(float), 1, file);
+            const string &label_string = keyframe.status_keys[j].label;
             size_t string_size = label_string.size();
             fwrite(&string_size, sizeof(int), 1, file);
             fwrite(label_string.c_str(),sizeof(char), string_size, file);
         }
 
         if(centered){
-            fwrite(&keyframes[i].rotation, sizeof(float), 1, file);
-            fwrite(&keyframes[i].center_offset, sizeof(float), 3, file);
+            fwrite(&keyframe.rotation, sizeof(float), 1, file);
+            fwrite(&keyframe.center_offset, sizeof(float), 3, file);
         }
     }
 }
@@ -301,19 +299,19 @@ void Animation::Center() {
         } else {
             // If not using mobility bone, determine center of mass
             float total_mass = 0.0f;
-            for(unsigned j=0; j<k.bone_mats.size(); j++){
-                center += k.bone_mats[j].origin;
+            for(auto & bone_mat : k.bone_mats){
+                center += bone_mat.origin;
                 total_mass += 1.0f;
             }
             LOG_ASSERT(total_mass != 0.0f);
             center /= total_mass;
         }
         // Subtract the center from the position of each bone
-        for(unsigned j=0; j<k.bone_mats.size(); j++){
-            k.bone_mats[j].origin -= center;
+        for(auto & bone_mat : k.bone_mats){
+            bone_mat.origin -= center;
         }
-        for(unsigned j=0; j<k.weapon_mats.size(); j++){
-            k.weapon_mats[j].origin -= center;
+        for(auto & weapon_mat : k.weapon_mats){
+            weapon_mat.origin -= center;
         }
         k.center_offset = center;
     }
@@ -327,11 +325,11 @@ void Animation::Center() {
     for(int i=0; i<num_keyframes; i++){
         Keyframe &k = keyframes[i];
         temp_offset = base_offset;
-        for(unsigned j=0; j<k.bone_mats.size(); j++){
-            k.bone_mats[j].origin += temp_offset;
+        for(auto & bone_mat : k.bone_mats){
+            bone_mat.origin += temp_offset;
         }
-        for(unsigned j=0; j<k.weapon_mats.size(); j++){
-            k.weapon_mats[j].origin += temp_offset;
+        for(auto & weapon_mat : k.weapon_mats){
+            weapon_mat.origin += temp_offset;
         }
         k.center_offset -= temp_offset;
     }
@@ -340,11 +338,11 @@ void Animation::Center() {
         Keyframe &k = keyframes[i];
         mat4 rotation_mat;
         rotation_mat.SetRotationY(-k.rotation);
-        for(unsigned j=0; j<k.bone_mats.size(); j++){
-            k.bone_mats[j] = rotation_mat * k.bone_mats[j];
+        for(auto & bone_mat : k.bone_mats){
+            bone_mat = rotation_mat * bone_mat;
         }
-        for(unsigned j=0; j<k.weapon_mats.size(); j++){
-            k.weapon_mats[j] = rotation_mat * k.weapon_mats[j];
+        for(auto & weapon_mat : k.weapon_mats){
+            weapon_mat = rotation_mat * weapon_mat;
         }
     }
     // Apply the inverse rotation to center offset changes
@@ -437,8 +435,7 @@ void Retarget(const AnimInput& anim_input, AnimOutput & anim_output, const strin
 			anim_output.matrices[i].origin *= ratio;
 		}
 	}
-	for(size_t i=0, len=anim_output.ik_bones.size(); i<len; ++i){
-		BlendedBonePath& bbp = anim_output.ik_bones[i];
+	for(auto & bbp : anim_output.ik_bones){
 		bbp.transform.origin += old_root_offset;
 		bbp.transform.origin *= ratio;
 	}
@@ -476,8 +473,8 @@ void Retarget(const AnimInput& anim_input, AnimOutput & anim_output, const strin
 
 	{
 		PROFILER_ZONE(g_profiler_ctx, "Calculate new bone positions using sorted bone list");
-		for(size_t i=0, len=depth_sorter.size(); i<len; ++i){
-			int bone_id = depth_sorter[i].bone_id;
+		for(auto & i : depth_sorter){
+			int bone_id = i.bone_id;
 			int parent = new_data.hier_parents[bone_id];
 
 			// Set rotation for new bones
@@ -527,21 +524,21 @@ void Retarget(const AnimInput& anim_input, AnimOutput & anim_output, const strin
 			matrices[i] = matrices[i] * invert(skeleton_file_data.bone_mats[i]);
 		}
 
-		for(size_t j=0; j<matrices.size(); j++){
-			matrices[j].rotation[0] *= -1.0f;
-			matrices[j].rotation[3] *= -1.0f;
-			matrices[j].origin[0] *= -1.0f;
+		for(auto & matrix : matrices){
+			matrix.rotation[0] *= -1.0f;
+			matrix.rotation[3] *= -1.0f;
+			matrix.origin[0] *= -1.0f;
 		}
 
 		vector<BoneTransform> &weapon_matrices = anim_output.weapon_matrices;
-		for(unsigned j=0; j<weapon_matrices.size(); j++){
-			MirrorBT(weapon_matrices[j], true);
+		for(auto & weapon_matrix : weapon_matrices){
+			MirrorBT(weapon_matrix, true);
 		}
 
 		// Swap weapon relative ids (so knife in right hand is now in left hand)
-		for(unsigned j=0; j<anim_output.weapon_relative_ids.size(); j++){
-			if(anim_output.weapon_relative_ids[j] != -1){
-				anim_output.weapon_relative_ids[j] = symmetry[anim_output.weapon_relative_ids[j]];
+		for(int & weapon_relative_id : anim_output.weapon_relative_ids){
+			if(weapon_relative_id != -1){
+				weapon_relative_id = symmetry[weapon_relative_id];
 			}
 		}
 		for(unsigned j=0; j<symmetry.size(); j++){
@@ -574,31 +571,29 @@ void Retarget(const AnimInput& anim_input, AnimOutput & anim_output, const strin
 		anim_output.delta_rotation *= -1.0f;
 		anim_output.rotation *= -1.0f;
 
-		for(unsigned j=0; j<anim_output.status_keys.size(); ++j){
-			StatusKeyBlend& skey = anim_output.status_keys[j];
-			SwitchStringRightLeft(skey.label);
+		for(auto & skey : anim_output.status_keys){
+				SwitchStringRightLeft(skey.label);
 		}
-		for(unsigned j=0; j<anim_output.shape_keys.size(); ++j){
-			ShapeKeyBlend& skey = anim_output.shape_keys[j];
-			SwitchStringRL(skey.label);
+		for(auto & skey : anim_output.shape_keys){
+				SwitchStringRL(skey.label);
 		}
 
-		for(unsigned j=0; j<anim_output.ik_bones.size(); ++j){
-			string &label = anim_output.ik_bones[j].ik_bone.label;
+		for(auto & ik_bone : anim_output.ik_bones){
+			string &label = ik_bone.ik_bone.label;
 			SwitchStringRightLeft(label);
-			BonePath& bone_path = anim_output.ik_bones[j].ik_bone.bone_path;
-			anim_output.ik_bones[j].transform = anim_output.ik_bones[j].transform * skeleton_file_data.bone_mats[bone_path[0]];
-			anim_output.ik_bones[j].transform.origin[0] *= -1.0f;
-			anim_output.ik_bones[j].transform.rotation[0] *= -1.0f;
-			anim_output.ik_bones[j].transform.rotation[3] *= -1.0f;
-			for(unsigned k=0; k<bone_path.size(); ++k){
-				if(bone_path[k] < (int)symmetry.size() && symmetry[bone_path[k]] != -1){
-					bone_path[k] = symmetry[bone_path[k]];
+			BonePath& bone_path = ik_bone.ik_bone.bone_path;
+			ik_bone.transform = ik_bone.transform * skeleton_file_data.bone_mats[bone_path[0]];
+			ik_bone.transform.origin[0] *= -1.0f;
+			ik_bone.transform.rotation[0] *= -1.0f;
+			ik_bone.transform.rotation[3] *= -1.0f;
+			for(int & k : bone_path){
+				if(k < (int)symmetry.size() && symmetry[k] != -1){
+					k = symmetry[k];
 				}
 			}
-			anim_output.ik_bones[j].transform = anim_output.ik_bones[j].transform * invert(skeleton_file_data.bone_mats[bone_path[0]]);
+			ik_bone.transform = ik_bone.transform * invert(skeleton_file_data.bone_mats[bone_path[0]]);
 			if(label == "left_leg" || label == "right_leg"){
-				anim_output.ik_bones[j].transform.rotation = anim_output.ik_bones[j].transform.rotation * quaternion(vec4(0.0f,0.0f,1.0f,3.14f));
+				ik_bone.transform.rotation = ik_bone.transform.rotation * quaternion(vec4(0.0f,0.0f,1.0f,3.14f));
 			}
 		}
 	}
@@ -612,9 +607,8 @@ void Retarget(const AnimInput& anim_input, AnimOutput & anim_output, const strin
 			vec3 test = QuaternionFromMat4(old_data.bone_mats[ik_bone.bone_id]) * invert(QuaternionFromMat4(new_data.bone_mats[ik_bone.bone_id])) * vec3(0.0f,1.0f,0.0f);
 			if(test[1] < 0.0f){
 				anim_output.matrices[ik_bone.bone_id].rotation = anim_output.matrices[ik_bone.bone_id].rotation * quaternion(vec4(0.0f,0.0f,1.0f,3.14f));
-				for(size_t i=0, len=anim_output.ik_bones.size(); i<len; ++i){
-					BlendedBonePath& bbp = anim_output.ik_bones[i];
-					if(bbp.ik_bone.label == "left_leg"){
+				for(auto & bbp : anim_output.ik_bones){
+						if(bbp.ik_bone.label == "left_leg"){
 						bbp.transform.rotation = bbp.transform.rotation * quaternion(vec4(0.0f,0.0f,1.0f,3.14f));
 					}
 				}
@@ -707,9 +701,9 @@ int Animation::ReadFromFile( FILE * file ) {
         keyframe->bone_mats.resize(num_bone_mats);
 
         mat4 temp;
-        for(unsigned j=0; j<keyframe->bone_mats.size(); j++){
+        for(auto & bone_mat : keyframe->bone_mats){
             fread(&temp.entries, sizeof(float), 16, file);
-            keyframe->bone_mats[j] = temp;
+            bone_mat = temp;
         }
 
         if(version>=7){
@@ -753,13 +747,13 @@ int Animation::ReadFromFile( FILE * file ) {
             fread(&num_events, sizeof(int), 1, file);
             keyframe->events.resize(num_events);
 
-            for(unsigned j=0; j<keyframe->events.size(); j++){
-                fread(&keyframe->events[j].which_bone, sizeof(int), 1, file);
+            for(auto & event : keyframe->events){
+                fread(&event.which_bone, sizeof(int), 1, file);
                 int string_size;
                 fread(&string_size, sizeof(int), 1, file);
                 vector<char> string_buffer(string_size+1,'\0');
                 fread(&string_buffer[0], sizeof(char), string_size, file);
-                keyframe->events[j].event_string = &string_buffer[0];
+                event.event_string = &string_buffer[0];
             }
         }
 
@@ -768,20 +762,20 @@ int Animation::ReadFromFile( FILE * file ) {
             fread(&num_ik_bones, sizeof(int), 1, file);
             keyframe->ik_bones.resize(num_ik_bones);
 
-            for(unsigned j=0; j<keyframe->ik_bones.size(); j++){
+            for(auto & ik_bone : keyframe->ik_bones){
                 // used to be ik_bones start and end
                 vec3 filler;
                 fread(&filler, sizeof(vec3), 1, file);
                 fread(&filler, sizeof(vec3), 1, file);
                 int path_length;
                 fread(&path_length, sizeof(int), 1, file);
-                keyframe->ik_bones[j].bone_path.resize(path_length);
-                fread(&keyframe->ik_bones[j].bone_path[0], sizeof(int), path_length, file);
+                ik_bone.bone_path.resize(path_length);
+                fread(&ik_bone.bone_path[0], sizeof(int), path_length, file);
                 int string_size;
                 fread(&string_size, sizeof(int), 1, file);
                 vector<char> string_buffer(string_size+1,'\0');
                 fread(&string_buffer[0], sizeof(char), string_size, file);
-                keyframe->ik_bones[j].label = &string_buffer[0];
+                ik_bone.label = &string_buffer[0];
             }
         }
 
@@ -790,13 +784,13 @@ int Animation::ReadFromFile( FILE * file ) {
             fread(&num_shape_keys, sizeof(int), 1, file);
             keyframe->shape_keys.resize(num_shape_keys);
 
-            for(unsigned j=0; j<keyframe->shape_keys.size(); j++){
-                fread(&keyframe->shape_keys[j].weight, sizeof(float), 1, file);
+            for(auto & shape_key : keyframe->shape_keys){
+                fread(&shape_key.weight, sizeof(float), 1, file);
                 int string_size;
                 fread(&string_size, sizeof(int), 1, file);
                 vector<char> string_buffer(string_size+1,'\0');
                 fread(&string_buffer[0], sizeof(char), string_size, file);
-                keyframe->shape_keys[j].label = &string_buffer[0];
+                shape_key.label = &string_buffer[0];
             }
         }
         if(version>=6){
@@ -804,13 +798,13 @@ int Animation::ReadFromFile( FILE * file ) {
             fread(&num_status_keys, sizeof(int), 1, file);
             keyframe->status_keys.resize(num_status_keys);
 
-            for(unsigned j=0; j<keyframe->status_keys.size(); j++){
-                fread(&keyframe->status_keys[j].weight, sizeof(float), 1, file);
+            for(auto & status_key : keyframe->status_keys){
+                fread(&status_key.weight, sizeof(float), 1, file);
                 int string_size;
                 fread(&string_size, sizeof(int), 1, file);
                 vector<char> string_buffer(string_size+1,'\0');
                 fread(&string_buffer[0], sizeof(char), string_size, file);
-                keyframe->status_keys[j].label = &string_buffer[0];
+                status_key.label = &string_buffer[0];
             }
         }
         if(centered){
@@ -910,21 +904,21 @@ AnimOutput mix( const AnimOutput &a, const AnimOutput &b, float alpha )
         map<string, BlendedBonePath> ik_bones;
         map<string, BlendedBonePath>::iterator iter;
 
-        for(unsigned i=0; i<a.ik_bones.size(); ++i){
-            const string& label = a.ik_bones[i].ik_bone.label;
-            ik_bones[label] = a.ik_bones[i];
+        for(const auto & ik_bone : a.ik_bones){
+            const string& label = ik_bone.ik_bone.label;
+            ik_bones[label] = ik_bone;
             ik_bones[label].weight *= 1.0f-alpha;
         }
 
-        for(unsigned i=0; i<b.ik_bones.size(); ++i){
-            const string& label = b.ik_bones[i].ik_bone.label;
+        for(const auto & ik_bone : b.ik_bones){
+            const string& label = ik_bone.ik_bone.label;
             iter = ik_bones.find(label);
             if(iter == ik_bones.end()){
-                ik_bones[label] = b.ik_bones[i];
+                ik_bones[label] = ik_bone;
                 ik_bones[label].weight *= alpha;
             } else {
-                ik_bones[label].weight = ik_bones[label].weight + b.ik_bones[i].weight * alpha;
-                ik_bones[label].transform = mix(ik_bones[label].transform, b.ik_bones[i].transform, alpha);
+                ik_bones[label].weight = ik_bones[label].weight + ik_bone.weight * alpha;
+                ik_bones[label].transform = mix(ik_bones[label].transform, ik_bone.transform, alpha);
             }
         }
 
@@ -966,22 +960,22 @@ AnimOutput mix( const AnimOutput &a, const AnimOutput &b, float alpha )
         map<string, ShapeKeyBlend>::iterator iter;
 
         // Add shape keys from A
-        for(unsigned i=0; i<a.shape_keys.size(); ++i){
-            const string& label = a.shape_keys[i].label;
-            shape_keys[label] = a.shape_keys[i];
+        for(const auto & shape_key : a.shape_keys){
+            const string& label = shape_key.label;
+            shape_keys[label] = shape_key;
             shape_keys[label].weight_weight *= 1.0f-alpha;
         }
 
         // Merge shape keys from B
-        for(unsigned i=0; i<b.shape_keys.size(); ++i){
-            const string& label = b.shape_keys[i].label;
+        for(const auto & shape_key : b.shape_keys){
+            const string& label = shape_key.label;
             iter = shape_keys.find(label);
             if(iter == shape_keys.end()){
-                shape_keys[label] = b.shape_keys[i];
+                shape_keys[label] = shape_key;
                 shape_keys[label].weight_weight *= alpha;
             } else {
-                shape_keys[label].weight = mix(shape_keys[label].weight, b.shape_keys[i].weight, alpha);
-                shape_keys[label].weight_weight = shape_keys[label].weight_weight + b.shape_keys[i].weight_weight * alpha;
+                shape_keys[label].weight = mix(shape_keys[label].weight, shape_key.weight, alpha);
+                shape_keys[label].weight_weight = shape_keys[label].weight_weight + shape_key.weight_weight * alpha;
             }
         }
 
@@ -1000,21 +994,21 @@ AnimOutput mix( const AnimOutput &a, const AnimOutput &b, float alpha )
         map<string, StatusKeyBlend> status_keys;
         map<string, StatusKeyBlend>::iterator iter;
 
-        for(unsigned i=0; i<a.status_keys.size(); ++i){
-            const string& label = a.status_keys[i].label;
-            status_keys[label] = a.status_keys[i];
+        for(const auto & status_key : a.status_keys){
+            const string& label = status_key.label;
+            status_keys[label] = status_key;
             status_keys[label].weight_weight *= 1.0f-alpha;
         }
 
-        for(unsigned i=0; i<b.status_keys.size(); ++i){
-            const string& label = b.status_keys[i].label;
+        for(const auto & status_key : b.status_keys){
+            const string& label = status_key.label;
             iter = status_keys.find(label);
             if(iter == status_keys.end()){
-                status_keys[label] = b.status_keys[i];
+                status_keys[label] = status_key;
                 status_keys[label].weight_weight *= alpha;
             } else {
-                status_keys[label].weight = mix(status_keys[label].weight, b.status_keys[i].weight, alpha);
-                status_keys[label].weight_weight = status_keys[label].weight_weight + b.status_keys[i].weight_weight * alpha;
+                status_keys[label].weight = mix(status_keys[label].weight, status_key.weight, alpha);
+                status_keys[label].weight_weight = status_keys[label].weight_weight + status_key.weight_weight * alpha;
             }
         }
 
@@ -1094,21 +1088,21 @@ AnimOutput add_mix( const AnimOutput &a, const AnimOutput &b, float alpha ) {
         map<string, ShapeKeyBlend>::iterator iter;
 
         // Add shape keys from A
-        for(unsigned i=0; i<a.shape_keys.size(); ++i){
-            const string& label = a.shape_keys[i].label;
-            shape_keys[label] = a.shape_keys[i];
+        for(const auto & shape_key : a.shape_keys){
+            const string& label = shape_key.label;
+            shape_keys[label] = shape_key;
         }
 
         // Merge shape keys from B
-        for(unsigned i=0; i<b.shape_keys.size(); ++i){
-            const string& label = b.shape_keys[i].label;
+        for(const auto & shape_key : b.shape_keys){
+            const string& label = shape_key.label;
             iter = shape_keys.find(label);
             if(iter == shape_keys.end()){
-                shape_keys[label] = b.shape_keys[i];
+                shape_keys[label] = shape_key;
                 shape_keys[label].weight_weight *= clamped_alpha;
             } else {
                 ShapeKeyBlend& a_key = shape_keys[label];
-                const ShapeKeyBlend& b_key = b.shape_keys[i];
+                const ShapeKeyBlend& b_key = shape_key;
                 a_key.weight = mix(a_key.weight, b_key.weight, b_key.weight_weight * clamped_alpha);
                 a_key.weight_weight = max(a_key.weight_weight, b_key.weight_weight * clamped_alpha);
             }
@@ -1128,20 +1122,20 @@ AnimOutput add_mix( const AnimOutput &a, const AnimOutput &b, float alpha ) {
         map<string, StatusKeyBlend> status_keys;
         map<string, StatusKeyBlend>::iterator iter;
 
-        for(unsigned i=0; i<a.status_keys.size(); ++i){
-            const string& label = a.status_keys[i].label;
-            status_keys[label] = a.status_keys[i];
+        for(const auto & status_key : a.status_keys){
+            const string& label = status_key.label;
+            status_keys[label] = status_key;
         }
 
-        for(unsigned i=0; i<b.status_keys.size(); ++i){
-            const string& label = b.status_keys[i].label;
+        for(const auto & status_key : b.status_keys){
+            const string& label = status_key.label;
             iter = status_keys.find(label);
             if(iter == status_keys.end()){
-                status_keys[label] = b.status_keys[i];
+                status_keys[label] = status_key;
                 status_keys[label].weight_weight *= clamped_alpha;
             } else {
                 StatusKeyBlend& a_key = status_keys[label];
-                const StatusKeyBlend& b_key = b.status_keys[i];
+                const StatusKeyBlend& b_key = status_key;
                 a_key.weight = mix(a_key.weight, b_key.weight, b_key.weight_weight * clamped_alpha);
                 a_key.weight_weight = max(a_key.weight_weight, b_key.weight_weight * clamped_alpha);
             }
@@ -1422,8 +1416,8 @@ void Animation::GetMatrices( float normalized_time, AnimOutput &anim_output, con
             }
         }
 
-        for(IKBoneMap::iterator iter = ik_bone_weights.begin(); iter != ik_bone_weights.end(); ++iter){
-            BlendedBonePath &blended_bone_path = iter->second;
+        for(auto & ik_bone_weight : ik_bone_weights){
+            BlendedBonePath &blended_bone_path = ik_bone_weight.second;
             int bone = blended_bone_path.ik_bone.bone_path.back();
             BoneTransform bone_transforms[4];
             for(int j=0; j<4; ++j){
@@ -1435,8 +1429,8 @@ void Animation::GetMatrices( float normalized_time, AnimOutput &anim_output, con
 
         anim_output.ik_bones.resize(ik_bone_weights.size());
         int index = 0;
-        for(IKBoneMap::iterator iter = ik_bone_weights.begin(); iter != ik_bone_weights.end(); ++iter){
-            anim_output.ik_bones[index] = (*iter).second;
+        for(auto & ik_bone_weight : ik_bone_weights){
+            anim_output.ik_bones[index] = ik_bone_weight.second;
             ++index;
         }
 
@@ -1539,9 +1533,9 @@ float Animation::GetGroundSpeed( const BlendMap& blendmap ) const {
 vector<NormalizedAnimationEvent> Animation::GetEvents(int& anim_id, bool mirror) const
 {
     vector<NormalizedAnimationEvent> normalized_events;
-    for(unsigned i=0; i<keyframes.size(); i++){
-        for(unsigned j=0; j<keyframes[i].events.size(); j++){
-            const AnimationEvent &the_event = keyframes[i].events[j];
+    for(const auto & keyframe : keyframes){
+        for(unsigned j=0; j<keyframe.events.size(); j++){
+            const AnimationEvent &the_event = keyframe.events[j];
 
             normalized_events.resize(normalized_events.size()+1);
             NormalizedAnimationEvent &normalized_event = 
@@ -1549,7 +1543,7 @@ vector<NormalizedAnimationEvent> Animation::GetEvents(int& anim_id, bool mirror)
 
             normalized_event.event = the_event;
             normalized_event.anim_id = anim_id;
-            normalized_event.time = NormalizedFromLocal((float)keyframes[i].time);
+            normalized_event.time = NormalizedFromLocal((float)keyframe.time);
         }
     }
 
@@ -1559,8 +1553,8 @@ vector<NormalizedAnimationEvent> Animation::GetEvents(int& anim_id, bool mirror)
         SkeletonAssetRef sar = Engine::Instance()->GetAssetManager()->LoadSync<SkeletonAsset>(skeleton_file_path);
         const SkeletonFileData& skeleton_file_data = sar->GetData();
         const vector<int>& symmetry = skeleton_file_data.symmetry;
-        for(size_t i=0, len=normalized_events.size(); i<len; ++i){
-            AnimationEvent& event = normalized_events[i].event;
+        for(auto & normalized_event : normalized_events){
+            AnimationEvent& event = normalized_event.event;
             SwitchStringRightLeft(event.event_string);
             if(symmetry[event.which_bone] != -1){
                 event.which_bone = symmetry[event.which_bone];
@@ -1574,9 +1568,7 @@ vector<NormalizedAnimationEvent> Animation::GetEvents(int& anim_id, bool mirror)
 
 void Animation::RecalcCaches() {
     // Cache which bones use IK in each frame
-    for(unsigned i=0; i<keyframes.size(); i++){
-        Keyframe& k = keyframes[i];
-
+    for(auto & k : keyframes){
         // Initialize uses_ik vector
         size_t num_bones = k.bone_mats.size();
         k.uses_ik.resize(num_bones);
@@ -1653,10 +1645,8 @@ float GetAnimationEventTime( const string& anim_path, const string& event_str ) 
     AnimationAssetRef aar = ReturnAnimationAssetRef(anim_path);
     int anim_id = 0;
     vector<NormalizedAnimationEvent> events = aar->GetEvents(anim_id,false);
-    for(vector<NormalizedAnimationEvent>::const_iterator iter = events.begin();
-        iter != events.end(); ++iter)
+    for(const auto & event : events)
     {
-        const NormalizedAnimationEvent& event = (*iter);
         if(event_str == event.event.event_string){
             return aar->AbsoluteTimeFromNormalized(event.time) * 0.001f;
         }

--- a/Source/Asset/Asset/character.cpp
+++ b/Source/Asset/Asset/character.cpp
@@ -267,23 +267,23 @@ void Character::ReturnPaths( PathSet &path_set ) {
         //Materials::Instance()->ReturnRef(clothing_path)->ReturnPaths(path_set);
         Engine::Instance()->GetAssetManager()->LoadSync<Material>(clothing_path)->ReturnPaths(path_set);
     }
-    for(unsigned i=0; i<morph_info.size(); ++i){
-        if(morph_info[i].num_steps == 1){
-            path_set.insert("morph "+GetMorphPath(ofr->model_name, morph_info[i].label));
+    for(auto & info : morph_info){
+        if(info.num_steps == 1){
+            path_set.insert("morph "+GetMorphPath(ofr->model_name, info.label));
         } else {
-            for(int j=0; j<morph_info[i].num_steps; ++j){
+            for(int j=0; j<info.num_steps; ++j){
                 ostringstream oss;
-                oss << morph_info[i].label << j;
+                oss << info.label << j;
                 path_set.insert("morph "+GetMorphPath(ofr->model_name, oss.str()));
             }
         }
     }
-    for(StringMap::iterator iter = anim_paths.begin(); iter != anim_paths.end(); ++iter) {
-        ReturnAnimationAssetRef(iter->second)->ReturnPaths(path_set);
+    for(auto & anim_path : anim_paths) {
+        ReturnAnimationAssetRef(anim_path.second)->ReturnPaths(path_set);
     }
-    for(StringMap::iterator iter = attack_paths.begin(); iter != attack_paths.end(); ++iter) {
+    for(auto & attack_path : attack_paths) {
         //Attacks::Instance()->ReturnRef(iter->second)->ReturnPaths(path_set);
-        Engine::Instance()->GetAssetManager()->LoadSync<Attack>(iter->second)->ReturnPaths(path_set);
+        Engine::Instance()->GetAssetManager()->LoadSync<Attack>(attack_path.second)->ReturnPaths(path_set);
     }
     if(!voice_path.empty()){
         //VoiceFiles::Instance()->ReturnRef(voice_path)->ReturnPaths(path_set);
@@ -315,10 +315,10 @@ float Character::GetDefaultScale() {
 }
 
 bool Character::GetMorphMeta(const string& label, vec3 & start, vec3 & end) {
-    for(size_t i=0, len=morph_meta.size(); i<len; ++i){
-        if(morph_meta[i].label == label){
-            start = morph_meta[i].start;
-            end = morph_meta[i].end;
+    for(auto & meta : morph_meta){
+        if(meta.label == label){
+            start = meta.start;
+            end = meta.end;
             return true;
         }
     }

--- a/Source/Asset/Asset/item.cpp
+++ b/Source/Asset/Asset/item.cpp
@@ -394,37 +394,33 @@ char Item::GetAnimOverrideFlags( const std::string &anim )
 void Item::ReturnPaths( PathSet &path_set )
 {
     path_set.insert("item "+path_);
-    for(int i=0; i<kMaxAttachments; ++i){
-        if(attachment[i].exists){
-            ReturnAnimationAssetRef(attachment[i].anim)->ReturnPaths(path_set);
-            if(!attachment[i].anim_base.empty()){
-                ReturnAnimationAssetRef(attachment[i].anim_base)->ReturnPaths(path_set);
+    for(auto & i : attachment){
+        if(i.exists){
+            ReturnAnimationAssetRef(i.anim)->ReturnPaths(path_set);
+            if(!i.anim_base.empty()){
+                ReturnAnimationAssetRef(i.anim_base)->ReturnPaths(path_set);
             }
         }
     }
     //ObjectFiles::Instance()->ReturnRef(obj_path)->ReturnPaths(path_set);
     Engine::Instance()->GetAssetManager()->LoadSync<ObjectFile>(obj_path)->ReturnPaths(path_set); 
-    for(std::map<std::string, std::string>::iterator iter = anim_overrides.begin();
-        iter != anim_overrides.end(); ++iter)
+    for(auto & anim_override : anim_overrides)
     {
-        ReturnAnimationAssetRef(iter->second)->ReturnPaths(path_set);
+        ReturnAnimationAssetRef(anim_override.second)->ReturnPaths(path_set);
     }
-    for(std::map<std::string, std::string>::iterator iter = anim_blend.begin();
-        iter != anim_blend.end(); ++iter)
+    for(auto & iter : anim_blend)
     {
-        ReturnAnimationAssetRef(iter->second)->ReturnPaths(path_set);
+        ReturnAnimationAssetRef(iter.second)->ReturnPaths(path_set);
     }
-    for(std::map<std::string, std::string>::iterator iter = attack_overrides.begin();
-        iter != attack_overrides.end(); ++iter)
+    for(auto & attack_override : attack_overrides)
     {
         //Attacks::Instance()->ReturnRef(iter->second)->ReturnPaths(path_set);
-        Engine::Instance()->GetAssetManager()->LoadSync<Attack>(iter->second)->ReturnPaths(path_set);
+        Engine::Instance()->GetAssetManager()->LoadSync<Attack>(attack_override.second)->ReturnPaths(path_set);
     }
-    for(std::map<std::string, std::string>::iterator iter = reaction_overrides.begin();
-        iter != reaction_overrides.end(); ++iter)
+    for(auto & reaction_override : reaction_overrides)
     {
         //Reactions::Instance()->ReturnRef(iter->second)->ReturnPaths(path_set);
-        Engine::Instance()->GetAssetManager()->LoadSync<Reaction>(iter->second)->ReturnPaths(path_set);
+        Engine::Instance()->GetAssetManager()->LoadSync<Reaction>(reaction_override.second)->ReturnPaths(path_set);
     }
 }
 

--- a/Source/Asset/Asset/levelset.cpp
+++ b/Source/Asset/Asset/levelset.cpp
@@ -84,10 +84,9 @@ void LevelSet::ReportLoad() {
 }
 
 void LevelSet::ReturnPaths( PathSet &path_set ) {
-    for(std::list<std::string>::iterator iter = level_paths_.begin(); 
-        iter != level_paths_.end(); ++iter)
+    for(auto & level_path : level_paths_)
     {
-        path_set.insert("level "+(*iter));
+        path_set.insert("level "+level_path);
     }
 }
 

--- a/Source/Asset/Asset/lipsyncfile.cpp
+++ b/Source/Asset/Asset/lipsyncfile.cpp
@@ -144,8 +144,8 @@ void LipSyncFileReader::UpdateWeights() {
         iter->second = 0.0f;
     }
 
-    for(unsigned i=0; i<vis_weights.size(); ++i){
-        morph_weights[id2morph[vis_weights[i].id]] += vis_weights[i].weight;    
+    for(auto & vis_weight : vis_weights){
+        morph_weights[id2morph[vis_weight.id]] += vis_weight.weight;    
     }
 }
 

--- a/Source/Asset/Asset/material.cpp
+++ b/Source/Asset/Asset/material.cpp
@@ -212,10 +212,9 @@ void Material::ReturnPaths( PathSet & path_set )
         iter != event_map.end(); ++iter)
     {
         const std::map<std::string, MaterialEvent> &inner_map = iter->second;
-        for(std::map<std::string, MaterialEvent>::const_iterator iter2 = inner_map.begin();
-            iter2 != inner_map.end(); ++iter2)
+        for(const auto & pair : inner_map)
         {
-            const MaterialEvent &me = iter2 ->second;
+            const MaterialEvent &me = pair.second;
             if(!me.soundgroup.empty()){
                 //SoundGroupInfoCollection::Instance()->ReturnRef(me.soundgroup)->ReturnPaths(path_set);
                 Engine::Instance()->GetAssetManager()->LoadSync<SoundGroupInfo>(me.soundgroup)->ReturnPaths(path_set);

--- a/Source/Asset/Asset/objectfile.cpp
+++ b/Source/Asset/Asset/objectfile.cpp
@@ -292,18 +292,18 @@ void ObjectFile::ReturnPaths( PathSet& path_set )
     if(!palette_map_path.empty()){
         path_set.insert("texture "+palette_map_path);
     }
-    for(unsigned i=0; i<m_detail_color_maps.size(); ++i){
-        path_set.insert("texture "+m_detail_color_maps[i]);
+    for(auto & detail_color_map : m_detail_color_maps){
+        path_set.insert("texture "+detail_color_map);
     }
-    for(unsigned i=0; i<m_detail_normal_maps.size(); ++i){
-        path_set.insert("texture "+m_detail_normal_maps[i]);
+    for(auto & detail_normal_map : m_detail_normal_maps){
+        path_set.insert("texture "+detail_normal_map);
     }
-    for(unsigned i=0; i<m_detail_materials.size(); ++i){
+    for(auto & detail_material : m_detail_materials){
         //Materials::Instance()->ReturnRef(m_detail_materials[i])->ReturnPaths(path_set);
-        Engine::Instance()->GetAssetManager()->LoadSync<Material>(m_detail_materials[i])->ReturnPaths(path_set);
+        Engine::Instance()->GetAssetManager()->LoadSync<Material>(detail_material)->ReturnPaths(path_set);
     }
-    for(unsigned i=0; i<m_detail_object_layers.size(); ++i){
-        m_detail_object_layers[i].ReturnPaths(path_set);
+    for(auto & detail_object_layer : m_detail_object_layers){
+        detail_object_layer.ReturnPaths(path_set);
     }
 }
 

--- a/Source/Asset/Asset/reactions.cpp
+++ b/Source/Asset/Asset/reactions.cpp
@@ -104,8 +104,8 @@ int Reaction::IsMirrored()
 void Reaction::ReturnPaths( PathSet &path_set )
 {
     path_set.insert("reaction "+path_);
-    for(unsigned i=0; i<anim_paths.size(); ++i){
-        ReturnAnimationAssetRef(anim_paths[i]);
+    for(auto & anim_path : anim_paths){
+        ReturnAnimationAssetRef(anim_path);
     }
 }
 

--- a/Source/Asset/Asset/syncedanimation.cpp
+++ b/Source/Asset/Asset/syncedanimation.cpp
@@ -417,9 +417,9 @@ float SyncedAnimationGroup::GetGroundSpeed( const BlendMap& blendmap ) const {
 
 std::vector<NormalizedAnimationEvent> SyncedAnimationGroup::GetEvents(int& anim_id, bool mirrored) const {
     std::vector<NormalizedAnimationEvent> normalized_events;
-    for(unsigned i=0; i<animations.size(); i++){
+    for(const auto & i : animations){
         std::vector<NormalizedAnimationEvent> new_events;
-        const AnimationAsset& animation = (*animations[i].animation);
+        const AnimationAsset& animation = (*i.animation);
         new_events = animation.GetEvents(anim_id, mirrored);
         normalized_events.insert(normalized_events.end(),
                                  new_events.begin(),
@@ -455,8 +455,8 @@ float SyncedAnimationGroup::AbsoluteTimeFromNormalized( float normalized_time ) 
 
 void SyncedAnimationGroup::ReturnPaths( PathSet& path_set ) {
     path_set.insert("synced_animation "+path_);
-    for(unsigned i=0; i<animations.size(); ++i){
-        animations[i].animation->ReturnPaths(path_set);
+    for(auto & animation : animations){
+        animation.animation->ReturnPaths(path_set);
     }
 }
 

--- a/Source/Asset/Asset/voicefile.cpp
+++ b/Source/Asset/Asset/voicefile.cpp
@@ -93,11 +93,10 @@ const std::string & VoiceFile::GetVoicePath( const std::string voice ) {
 void VoiceFile::ReturnPaths( PathSet &path_set )
 {
     path_set.insert("voice "+path_);
-    for(std::map<std::string, std::string>::iterator iter = voice_paths.begin();
-        iter != voice_paths.end(); ++iter)
+    for(auto & voice_path : voice_paths)
     {
         //SoundGroupInfoCollection::Instance()->ReturnRef(iter->second)->ReturnPaths(path_set);
-        Engine::Instance()->GetAssetManager()->LoadSync<SoundGroupInfo>(iter->second)->ReturnPaths(path_set);
+        Engine::Instance()->GetAssetManager()->LoadSync<SoundGroupInfo>(voice_path.second)->ReturnPaths(path_set);
     }
 }
 

--- a/Source/Asset/assetmanagerthreadhandler.cpp
+++ b/Source/Asset/assetmanagerthreadhandler.cpp
@@ -121,8 +121,8 @@ AssetManagerThreadHandler::AssetManagerThreadHandler(int thread_count) : stop(fa
 AssetManagerThreadHandler::~AssetManagerThreadHandler() {
     stop = true;
 
-    for( unsigned i = 0; i < threads.size(); i++ ) {
-        threads[i]->join();
-		threads[i] = NULL;
+    for(auto & thread : threads) {
+        thread->join();
+		thread = NULL;
     }
 }

--- a/Source/Editors/map_editor.cpp
+++ b/Source/Editors/map_editor.cpp
@@ -851,8 +851,8 @@ void MapEditor::Draw() {
                 }
                 if(always_draw_hotspot_connections) {
                     vec3 start = obj->GetTranslation();
-                    for(int j : obj->connected_to) {
-                        vec3 end = scenegraph_->GetObjectFromID(j)->GetTranslation();
+                    for(int id : obj->connected_to) {
+                        vec3 end = scenegraph_->GetObjectFromID(id)->GetTranslation();
                         DebugDraw::Instance()->AddLine(start, end, vec4(0.0f,1.0f,0.0f,0.8f), _delete_on_draw);
                     }
                 }
@@ -953,23 +953,22 @@ void MapEditor::Draw() {
             float highlit_obj_dist = FLT_MAX;
             std::vector<int> connected_ids;
             connected_ids.reserve(64);
-            for(auto & i : selected) {
-                Object* selected_obj = i;
+            for(Object* selected_obj : selected) {
                 box_objects.push_back(selected_obj);
                 connected_ids.clear();
-                i->GetConnectionIDs(&connected_ids);
+                selected_obj->GetConnectionIDs(&connected_ids);
                 for(int connected_id : connected_ids) {
                     Object* obj = scenegraph_->GetObjectFromID(connected_id);
                     GetClosest(mouseray, obj, highlit_obj, highlit_obj_dist);
                     box_objects.push_back(obj);
                 }
-                for(int j : selected_obj->connected_to) {
-                    Object* obj = scenegraph_->GetObjectFromID(j);
+                for(int id : selected_obj->connected_to) {
+                    Object* obj = scenegraph_->GetObjectFromID(id);
                     GetClosest(mouseray, obj, highlit_obj, highlit_obj_dist);
                     box_objects.push_back(obj);
                 }
-                for(int j : selected_obj->connected_from) {
-                    Object* obj = scenegraph_->GetObjectFromID(j);
+                for(int id : selected_obj->connected_from) {
+                    Object* obj = scenegraph_->GetObjectFromID(id);
                     GetClosest(mouseray, obj, highlit_obj, highlit_obj_dist);
                     box_objects.push_back(obj);
                 }
@@ -1292,8 +1291,8 @@ void MapEditor::Update(GameCursor* cursor) {
                     entities.push_back(obj);
                 }
             }
-            for (auto & entitie : entities) {
-                entitie->SaveHistoryState(chunks, state_id);
+            for (auto & entity : entities) {
+                entity->SaveHistoryState(chunks, state_id);
             }
             sky_editor_->SaveHistoryState(chunks, state_id);
             // Find out how many chunks have been changed

--- a/Source/Editors/sky_editor.cpp
+++ b/Source/Editors/sky_editor.cpp
@@ -519,8 +519,7 @@ void SkyEditor::SaveHistoryState( std::list<SavedChunk> &chunk_list, int state_i
 bool SkyEditor::ReadChunk( SavedChunk &the_chunk ) {
     bool something_changed = false;    
     EntityDescription &desc = the_chunk.desc;
-    for(unsigned i=0; i<desc.fields.size(); ++i){
-        EntityDescriptionField& field = desc.fields[i];
+    for(auto & field : desc.fields){
         switch(field.type){
             case EDF_SUN_RADIUS:{
                 float old_m_sun_angular_rad = m_sun_angular_rad;

--- a/Source/GUI/IMUI/im_container.cpp
+++ b/Source/GUI/IMUI/im_container.cpp
@@ -153,10 +153,8 @@ void IMContainer::setOwnerParent( IMGUI* _owner, IMElement* _parent ) {
         contents->setOwnerParent( _owner, this );
     }
     
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
-        it->second->getElement()->setOwnerParent(_owner, this);
+    for(auto & floatingContent : floatingContents) {
+        floatingContent.second->getElement()->setOwnerParent(_owner, this);
     }
 
 }
@@ -254,10 +252,8 @@ void IMContainer::clear() {
 
     floatingContents.clear();
     
-    for( FEMap::iterator it = deletemap.begin();
-         it != deletemap.end();
-         ++it ) {
-        delete it->second;
+    for(auto & it : deletemap) {
+        delete it.second;
     }
 
     // clear the contained element
@@ -306,10 +302,8 @@ void IMContainer::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) 
         contents->update( delta, drawOffset + drawDisplacement + contentsOffset, guistate);
     }   
 
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
-        AHFloatingElement* floatingElement = it->second;
+    for(auto & floatingContent : floatingContents) {
+        AHFloatingElement* floatingElement = floatingContent.second;
         floatingElement->getElement()->update( delta, drawOffset + drawDisplacement + floatingElement->relativePos, guistate );
 
         if(floatingContents.empty()) {
@@ -361,10 +355,8 @@ void IMContainer::render( vec2 drawOffset, vec2 clipPos, vec2 clipSize ) {
     }
 
     // Render the floating elements
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
-        AHFloatingElement* floatingElement = it->second;
+    for(auto & floatingContent : floatingContents) {
+        AHFloatingElement* floatingElement = floatingContent.second;
         floatingElement->getElement()->render( drawOffset + drawDisplacement + floatingElement->relativePos, currentClipPos, currentClipSize );
     }
 
@@ -392,11 +384,9 @@ void IMContainer::render( vec2 drawOffset, vec2 clipPos, vec2 clipSize ) {
     }
     
     // Now trigger the children
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
+    for(auto & floatingContent : floatingContents) {
         
-        AHFloatingElement* felement = it->second;
+        AHFloatingElement* felement = floatingContent.second;
         
         
         // see if we need to center this element
@@ -526,10 +516,8 @@ void IMContainer::checkRegion() {
         contents->doScreenResize();
     }
 
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
-        it->second->getElement()->doScreenResize();
+    for(auto & floatingContent : floatingContents) {
+        floatingContent.second->getElement()->doScreenResize();
     }
 
  }
@@ -841,10 +829,8 @@ void IMContainer::setPauseBehaviors( bool pause ) {
         contents->setPauseBehaviors( pause );
     }
 
-    for( FEMap::iterator it = floatingContents.begin();
-         it != floatingContents.end();
-         ++it ) {
-        AHFloatingElement* floatingElement = it->second;
+    for(auto & floatingContent : floatingContents) {
+        AHFloatingElement* floatingElement = floatingContent.second;
         floatingElement->getElement()->setPauseBehaviors( pause );
     }
 }
@@ -868,8 +854,8 @@ void IMContainer::clense() {
 std::vector<IMElement*> IMContainer::getFloatingContents() {
     std::vector<IMElement*> elements;
     elements.reserve(floatingContents.size());
-    for(FEMap::iterator iter = floatingContents.begin(); iter != floatingContents.end(); ++iter) {
-        IMElement* element = iter->second->getElement();
+    for(auto & floatingContent : floatingContents) {
+        IMElement* element = floatingContent.second->getElement();
         //element->AddRef();
         elements.push_back(element);
     }

--- a/Source/GUI/IMUI/im_divider.cpp
+++ b/Source/GUI/IMUI/im_divider.cpp
@@ -87,8 +87,8 @@ void IMDivider::setOwnerParent( IMGUI* _owner, IMElement* _parent ) {
     parent = _parent;
     
     // Simply pass this on to the children
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
-        containers[i]->setOwnerParent( owner, this );
+    for(auto & container : containers) {
+        container->setOwnerParent( owner, this );
     }
 }
 
@@ -107,8 +107,8 @@ void IMDivider::setAlignment( ContainerAlignment xAlignment, ContainerAlignment 
     contentsYAlignment = yAlignment;
     
     if( reposition ) {
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
-            containers[i]->setAlignment( xAlignment, yAlignment );
+        for(auto & container : containers) {
+            container->setAlignment( xAlignment, yAlignment );
         }
     }
     
@@ -121,10 +121,8 @@ void IMDivider::setAlignment( ContainerAlignment xAlignment, ContainerAlignment 
  */
 void IMDivider::clear() {
     std::vector<IMContainer*> containers_copy = containers;
-    for(std::vector<IMContainer*>::iterator iter = containers_copy.begin();
-        iter != containers_copy.end();
-        ++iter) {
-            (*iter)->Release();
+    for(auto & iter : containers_copy) {
+            iter->Release();
     }
     containers.resize(0);
     onRelayout();
@@ -151,15 +149,15 @@ void IMDivider::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
     vec2 currentDrawOffset = drawOffset + drawDisplacement;
     
     // Simply pass this on to the children
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
+    for(auto & container : containers) {
         
-        containers[i]->update( delta, currentDrawOffset, guistate );
+        container->update( delta, currentDrawOffset, guistate );
         
         if( orientation == DOVertical ) {
-            currentDrawOffset.y() += containers[i]->getSizeY();
+            currentDrawOffset.y() += container->getSizeY();
         }
         else {
-            currentDrawOffset.x() += containers[i]->getSizeX();
+            currentDrawOffset.x() += container->getSizeX();
         }
     }
     
@@ -197,20 +195,20 @@ void IMDivider::render( vec2 drawOffset, vec2 clipPos, vec2 clipSize ) {
     
     // Simply pass this on to the children
     vec2 currentDrawOffset = drawOffset + drawDisplacement;
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
+    for(auto & container : containers) {
         
-        containers[i]->render( currentDrawOffset, currentClipPos, currentClipSize );
+        container->render( currentDrawOffset, currentClipPos, currentClipSize );
         
         if( orientation == DOVertical ) {
             
-            if( containers[i]->getSizeY() > 0 ) {
-                currentDrawOffset.y() += containers[i]->getSizeY();
+            if( container->getSizeY() > 0 ) {
+                currentDrawOffset.y() += container->getSizeY();
             }
         }
         else {
             
-            if( containers[i]->getSizeX() > 0 ) {
-                currentDrawOffset.x() += containers[i]->getSizeX();
+            if( container->getSizeX() > 0 ) {
+                currentDrawOffset.x() += container->getSizeX();
             }
         }
     }
@@ -231,13 +229,13 @@ void IMDivider::checkRegions() {
     if( orientation == DOVertical ) {
         
         // First calculate the height
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
+        for(auto & container : containers) {
             
             // see if this element is a dynamic spacer
             // first check if there is an element in this container
-            if( containers[i]->contents != NULL ) {
+            if( container->contents != NULL ) {
                 // now see if we can cast it
-                if( IMSpacer* spacer = dynamic_cast<IMSpacer*>( containers[i]->contents ) ) {
+                if( IMSpacer* spacer = dynamic_cast<IMSpacer*>( container->contents ) ) {
                     if( spacer != NULL && spacer->isStatic == false ) {
                         // queue this up
                         dynamicSpacers.push_back( spacer );
@@ -248,7 +246,7 @@ void IMDivider::checkRegions() {
             }
             
             // add to our total
-            totalSize += containers[i]->getSizeY();
+            totalSize += container->getSizeY();
             
         }
         
@@ -256,8 +254,8 @@ void IMDivider::checkRegions() {
         // see if we've got dynamic spacers and spare space
         if( dynamicSpacers.size() > 0 && totalSize < parent->getSizeY() ) {
             float spacerSize = (parent->getSizeY() - totalSize )/((float) dynamicSpacers.size() );
-            for( unsigned int i = 0; i < dynamicSpacers.size(); i++ ) {
-                dynamicSpacers[i]->setSizeY( spacerSize );
+            for(auto & dynamicSpacer : dynamicSpacers) {
+                dynamicSpacer->setSizeY( spacerSize );
                 addedSpace += spacerSize;
             }
         }
@@ -268,16 +266,16 @@ void IMDivider::checkRegions() {
         
         // Now just fit the divider to the widest element
         float maxSize = UNDEFINEDSIZE;
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
-            if( containers[i]->getSizeX() > maxSize ) {
-                maxSize = containers[i]->getSizeX();
+        for(auto & container : containers) {
+            if( container->getSizeX() > maxSize ) {
+                maxSize = container->getSizeX();
             }
         }
         
         // if we've grown then resize the container and its elements
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
-            if( containers[i]->getSizeX() != maxSize ) {
-                containers[i]->setSizeX( maxSize );
+        for(auto & container : containers) {
+            if( container->getSizeX() != maxSize ) {
+                container->setSizeX( maxSize );
             }
         }
         
@@ -289,13 +287,13 @@ void IMDivider::checkRegions() {
     else {
         
         // First calculate the height
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
+        for(auto & container : containers) {
             
             // see if this element is a dynamic spacer
             // first check if there is an element in this container
-            if( containers[i]->contents != NULL ) {
+            if( container->contents != NULL ) {
                 // now see if we can cast it
-                IMSpacer* spacer = dynamic_cast<IMSpacer*>( containers[i]->contents );
+                IMSpacer* spacer = dynamic_cast<IMSpacer*>( container->contents );
                 
                 if( spacer != NULL && spacer->isStatic == false ) {
                     // queue this up
@@ -306,7 +304,7 @@ void IMDivider::checkRegions() {
             }
             
             // add to our total
-            totalSize += containers[i]->getSizeX();
+            totalSize += container->getSizeX();
             
         }
         
@@ -314,8 +312,8 @@ void IMDivider::checkRegions() {
         // see if we've got dynamic spacers and spare space
         if( dynamicSpacers.size() > 0 && totalSize < parent->getSizeX() ) {
             float spacerSize = (parent->getSizeX() - totalSize )/((float)dynamicSpacers.size() );
-            for( unsigned int i = 0; i < dynamicSpacers.size(); i++ ) {
-                dynamicSpacers[i]->setSizeX( spacerSize );
+            for(auto & dynamicSpacer : dynamicSpacers) {
+                dynamicSpacer->setSizeX( spacerSize );
                 addedSpace += spacerSize;
             }
         }
@@ -326,16 +324,16 @@ void IMDivider::checkRegions() {
         
         // Now just fit the divider to the widest element
         float maxSize = UNDEFINEDSIZE;
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
-            if( containers[i]->getSizeY() > maxSize ) {
-                maxSize = containers[i]->getSizeY();
+        for(auto & container : containers) {
+            if( container->getSizeY() > maxSize ) {
+                maxSize = container->getSizeY();
             }
         }
         
         // if we've grown then resize the container and its elements
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
-            if( containers[i]->getSizeY() != maxSize ) {
-                containers[i]->setSizeY( maxSize );
+        for(auto & container : containers) {
+            if( container->getSizeY() != maxSize ) {
+                container->setSizeY( maxSize );
             }
         }
         
@@ -357,8 +355,8 @@ void IMDivider::doRelayout() {
     IMElement::doRelayout();
     
     // First pass this down to the children
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
-        containers[i]->doRelayout();
+    for(auto & container : containers) {
+        container->doRelayout();
     }
     
     checkRegions();
@@ -376,8 +374,8 @@ void IMDivider::doScreenResize()  {
     IMElement::doScreenResize();
     
     // Pass this down to the children
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
-        containers[i]->doScreenResize();
+    for(auto & container : containers) {
+        container->doScreenResize();
     }
     
     onRelayout();
@@ -472,10 +470,10 @@ IMContainer* IMDivider::getContainerAt( unsigned int i ) {
  *
  */
 IMContainer* IMDivider::getContainerOf( std::string const& _name ) {
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
+    for(auto & container : containers) {
         
-        if( containers[i]->contents != NULL && containers[i]->contents->getName() == _name ) {
-            return containers[i];
+        if( container->contents != NULL && container->contents->getName() == _name ) {
+            return container;
         }
     }
     return NULL;
@@ -590,9 +588,9 @@ IMElement* IMDivider::findElement( std::string const& elementName ) {
     else {
         // If not, pass the request onto the children
         
-        for( unsigned int i = 0; i < containers.size(); i++ ) {
+        for(auto & container : containers) {
             
-            IMElement* results = containers[i]->findElement( elementName );
+            IMElement* results = container->findElement( elementName );
             
             if( results != NULL ) {
                 return results;
@@ -606,8 +604,8 @@ IMElement* IMDivider::findElement( std::string const& elementName ) {
 
 void IMDivider::setPauseBehaviors( bool pause ) {
     IMElement::setPauseBehaviors( pause );
-    for( unsigned int i = 0; i < containers.size(); i++ ) {
-        containers[i]->setPauseBehaviors( pause );
+    for(auto & container : containers) {
+        container->setPauseBehaviors( pause );
     }
 }
 
@@ -633,10 +631,8 @@ IMDivider::~IMDivider() {
     std::vector<IMContainer*> deletelist = containers;
     containers.clear();
 
-    for( std::vector<IMContainer*>::iterator it = deletelist.begin();
-         it != deletelist.end();
-         ++it ) {
-        (*it)->Release();
+    for(auto & it : deletelist) {
+        it->Release();
     }
 }
 

--- a/Source/GUI/IMUI/im_element.cpp
+++ b/Source/GUI/IMUI/im_element.cpp
@@ -864,10 +864,8 @@ bool IMElement::hasUpdateBehavior(std::string const& behaviorName)
  void IMElement::clearUpdateBehaviors() {
 
      // iterate through all the behaviors and clean them up
-     for( UBMap::iterator it = updateBehaviors.begin();
-         it != updateBehaviors.end();
-         ++it ) {
-        IMUpdateBehavior* updater = it->second;
+     for(auto & updateBehavior : updateBehaviors) {
+        IMUpdateBehavior* updater = updateBehavior.second;
         updater->cleanUp( this );
         updater->Release();
     }
@@ -949,10 +947,8 @@ bool IMElement::hasUpdateBehavior(std::string const& behaviorName)
  void IMElement::clearMouseOverBehaviors() {
 
     // iterate through all the behaviors and clean them up
-    for( MOBMap::iterator it = mouseOverBehaviors.begin();
-         it != mouseOverBehaviors.end();
-         ++it ) {
-        IMMouseOverBehavior* updater = it->second;
+    for(auto & mouseOverBehavior : mouseOverBehaviors) {
+        IMMouseOverBehavior* updater = mouseOverBehavior.second;
         updater->Release();
         updater->cleanUp( this );
     }
@@ -1032,10 +1028,8 @@ void IMElement::addLeftMouseClickBehavior( IMMouseClickBehavior* behavior, std::
 void IMElement::clearLeftMouseClickBehaviors() {
 
     // iterate through all the behaviors and clean them up
-    for( MCBMap::iterator it = leftMouseClickBehaviors.begin();
-        it != leftMouseClickBehaviors.end();
-        ++it ) {
-        IMMouseClickBehavior* updater = it->second;
+    for(auto & leftMouseClickBehavior : leftMouseClickBehaviors) {
+        IMMouseClickBehavior* updater = leftMouseClickBehavior.second;
         updater->cleanUp( this );
         updater->Release();
     }
@@ -1058,18 +1052,16 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
     {
 		std::vector<std::string> remove_list;	
 
-        for( UBMap::iterator it = updateBehaviors.begin();
-            it != updateBehaviors.end();
-            ++it ) {
+        for(auto & updateBehavior : updateBehaviors) {
 
-            IMUpdateBehavior* updater = it->second;
+            IMUpdateBehavior* updater = updateBehavior.second;
             
             // See if this behavior has been initialized
             if( !updater->initialized ) {
 
                 if( !updater->initialize( this, delta, drawOffset, guistate ) ) {
                     // If the behavior has indicated it should not begin remove it
-					remove_list.push_back(it->first);
+					remove_list.push_back(updateBehavior.first);
                     continue;
                 }
                 else {
@@ -1079,7 +1071,7 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
 
             if( !updater->update( this, delta, drawOffset, guistate ) ) {
                 // If the behavior has indicated it is done
-                remove_list.push_back(it->first);
+                remove_list.push_back(updateBehavior.first);
             }
         }
 		
@@ -1103,22 +1095,18 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
             mouseOver = true;
 
             // Update behaviors
-            for( MOBMap::iterator it = mouseOverBehaviors.begin();
-                 it != mouseOverBehaviors.end();
-                 ++it ) {
+            for(auto & mouseOverBehavior : mouseOverBehaviors) {
                 
-                IMMouseOverBehavior* behavior = it->second;
+                IMMouseOverBehavior* behavior = mouseOverBehavior.second;
                 behavior->onStart( this, delta, drawOffset, guistate );
             }
         }
         else {
 
             // Update behaviors
-            for( MOBMap::iterator it = mouseOverBehaviors.begin();
-                it != mouseOverBehaviors.end();
-                ++it ) {
+            for(auto & mouseOverBehavior : mouseOverBehaviors) {
                 
-                IMMouseOverBehavior* behavior = it->second;
+                IMMouseOverBehavior* behavior = mouseOverBehavior.second;
                 behavior->onContinue( this, delta, drawOffset, guistate );
             }
         
@@ -1129,14 +1117,12 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
         if( mouseOver )
         {
             std::vector<std::string> remove_list;
-            for( MOBMap::iterator it = mouseOverBehaviors.begin();
-                it != mouseOverBehaviors.end();
-                ++it ) {
-                IMMouseOverBehavior* behavior = it->second;
+            for(auto & mouseOverBehavior : mouseOverBehaviors) {
+                IMMouseOverBehavior* behavior = mouseOverBehavior.second;
                 
                 if( !behavior->onFinish( this, delta, drawOffset, guistate ) ) {
                     // If the behavior has indicated it is done
-					remove_list.push_back(it->first);
+					remove_list.push_back(mouseOverBehavior.first);
                     
                 }
             }
@@ -1175,16 +1161,14 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
 
 			std::vector<std::string> remove_list;
             // Update behaviors
-            for( MCBMap::iterator it = leftMouseClickBehaviors.begin();
-                it != leftMouseClickBehaviors.end();
-                ++it ) {
+            for(auto & leftMouseClickBehavior : leftMouseClickBehaviors) {
 
                 guistate.clickHandled = true;
 
-                IMMouseClickBehavior* behavior = it->second;
+                IMMouseClickBehavior* behavior = leftMouseClickBehavior.second;
                 if( !behavior->onDown( this, delta, drawOffset, guistate ) ) {
                     // If the behavior has indicated it is done
-                    remove_list.push_back(it->first);
+                    remove_list.push_back(leftMouseClickBehavior.first);
                 }
             }
 
@@ -1203,17 +1187,15 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
             }
             
 			std::vector<std::string> remove_list;
-            for( MCBMap::iterator it = leftMouseClickBehaviors.begin();
-                 it != leftMouseClickBehaviors.end();
-                 ++it ) {
+            for(auto & leftMouseClickBehavior : leftMouseClickBehaviors) {
                 
                 guistate.clickHandled = true;
                 
-                IMMouseClickBehavior* behavior = it->second;
+                IMMouseClickBehavior* behavior = leftMouseClickBehavior.second;
             
                 if( !behavior->onStillDown( this, delta, drawOffset, guistate ) ) {
                     // If the behavior has indicated it is done
-					remove_list.push_back(it->first);
+					remove_list.push_back(leftMouseClickBehavior.first);
                 
                 }
             }
@@ -1229,17 +1211,15 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
         case IMUIContext::kMouseUp: {
             
 			if(mouse_clicking){
-	            for( MCBMap::iterator it = leftMouseClickBehaviors.begin();
-	                 it != leftMouseClickBehaviors.end();
-	                 ++it ) {
+	            for(auto & leftMouseClickBehavior : leftMouseClickBehaviors) {
 
 	                guistate.clickHandled = true;
 
-	                IMMouseClickBehavior* behavior = it->second;
+	                IMMouseClickBehavior* behavior = leftMouseClickBehavior.second;
 
 	                if( !behavior->onUp( this, delta, drawOffset, guistate ) ) {
 	                    // If the behavior has indicated it is done
-	                    removeLeftMouseClickBehavior( it->first );
+	                    removeLeftMouseClickBehavior( leftMouseClickBehavior.first );
 	                }
 
 	            }
@@ -1250,16 +1230,14 @@ void IMElement::update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) {
             mouseOver = false;
             {
 				std::vector<std::string> remove_list;
-                for( MOBMap::iterator it = mouseOverBehaviors.begin();
-                    it != mouseOverBehaviors.end();
-                     ++it ) {
+                for(auto & mouseOverBehavior : mouseOverBehaviors) {
                     
                     guistate.clickHandled = true;
                     
-                    IMMouseOverBehavior* behavior = it->second;
+                    IMMouseOverBehavior* behavior = mouseOverBehavior.second;
                     if( !behavior->onFinish( this, delta, drawOffset, guistate ) ) {
                         // If the behavior has indicated it is done
-						remove_list.push_back( it->first );
+						remove_list.push_back( mouseOverBehavior.first );
                     
                     }
                 }
@@ -1687,24 +1665,18 @@ void IMElement::setScriptMouseOver(bool mouseOver) {
  */
 IMElement::~IMElement() {
 	LOG_ASSERT(refCount == 0);
-    for( UBMap::iterator it = updateBehaviors.begin();
-         it != updateBehaviors.end();
-         ++it ) {
-        it->second->Release();
+    for(auto & updateBehavior : updateBehaviors) {
+        updateBehavior.second->Release();
     }
     updateBehaviors.clear();
     
-    for( MOBMap::iterator it = mouseOverBehaviors.begin();
-        it != mouseOverBehaviors.end();
-        ++it ) {
-        it->second->Release();
+    for(auto & mouseOverBehavior : mouseOverBehaviors) {
+        mouseOverBehavior.second->Release();
     }
     mouseOverBehaviors.clear();
     
-    for( MCBMap::iterator it = leftMouseClickBehaviors.begin();
-         it != leftMouseClickBehaviors.end();
-         ++it ) {
-        it->second->Release();
+    for(auto & leftMouseClickBehavior : leftMouseClickBehaviors) {
+        leftMouseClickBehavior.second->Release();
     }
     leftMouseClickBehaviors.clear();
 

--- a/Source/GUI/IMUI/im_events.cpp
+++ b/Source/GUI/IMUI/im_events.cpp
@@ -41,13 +41,13 @@ void IMEvents::DeRegisterListener( IMEventListener *listener ) {
 }
 
 void IMEvents::TriggerDestroyed(IMElement* elem) {
-    for( unsigned i = 0; i < listeners.size(); i++ ) {
-        listeners[i]->DestroyedIMElement(elem);
+    for(auto & listener : listeners) {
+        listener->DestroyedIMElement(elem);
     }
 }
 
 void IMEvents::TriggerDestroyed(IMGUI* imgui) { 
-    for( unsigned i = 0; i < listeners.size(); i++ ) {
-        listeners[i]->DestroyedIMGUI(imgui);
+    for(auto & listener : listeners) {
+        listener->DestroyedIMGUI(imgui);
     }
 }

--- a/Source/GUI/IMUI/im_support.cpp
+++ b/Source/GUI/IMUI/im_support.cpp
@@ -251,12 +251,10 @@ void IMReferenceCountTracker::logSanityCheck() {
     else {
         LOGI << "Error: There still " << totalRefCountObjs << " LIVE IMGUI elements" << std::endl;
         
-        for( std::map<std::string, int>::iterator it = typeCounts.begin();
-             it != typeCounts.end();
-             ++it ) {
+        for(auto & typeCount : typeCounts) {
             
-            if( it->second != 0 ) {
-                LOGI << it->first << ": " << it->second << std::endl;
+            if( typeCount.second != 0 ) {
+                LOGI << typeCount.first << ": " << typeCount.second << std::endl;
             }
         }
         

--- a/Source/GUI/IMUI/imgui.cpp
+++ b/Source/GUI/IMUI/imgui.cpp
@@ -283,25 +283,19 @@ void IMGUI::setFooterPanels( float first, float second, float third ) {
  */
 void IMGUI::setup() {
     
-    for( std::vector<IMContainer*>::iterator it = header.begin();
-         it != header.end();
-         ++it ) {
+    for(auto & it : header) {
         
-        (*it)->Release();
+        it->Release();
     }
     
-    for( std::vector<IMContainer*>::iterator it = footer.begin();
-        it != footer.end();
-        ++it ) {
+    for(auto & it : footer) {
         
-        (*it)->Release();
+        it->Release();
     }
     
-    for( std::vector<IMContainer*>::iterator it = main.begin();
-        it != main.end();
-        ++it ) {
+    for(auto & it : main) {
         
-        (*it)->Release();
+        it->Release();
     }
     
     header.clear();
@@ -336,17 +330,15 @@ void IMGUI::setup() {
         
         // Go through the list of pending panels, create them and total their widths
         int panelCount = 0;
-        for( std::vector<float>::iterator it = pendingHeaderPanels.begin();
-             it != pendingHeaderPanels.end();
-             ++it ) {
+        for(float & pendingHeaderPanel : pendingHeaderPanels) {
         
             IMContainer* panel = new IMContainer( "header" + numbering[panelCount],
-                                                  SizePolicy(*it),
+                                                  SizePolicy(pendingHeaderPanel),
                                                   SizePolicy(headerHeight) );
             panel->setOwnerParent( this, NULL );
             header.push_back( panel );
             
-            totalWidth += *it;
+            totalWidth += pendingHeaderPanel;
         
         }
         
@@ -373,18 +365,16 @@ void IMGUI::setup() {
         
         // Go through the list of pending panels, create them and total their widths
         int panelCount = 0;
-        for( std::vector<float>::iterator it = pendingFooterPanels.begin();
-            it != pendingFooterPanels.end();
-            ++it ) {
+        for(float & pendingFooterPanel : pendingFooterPanels) {
             
             IMContainer* panel = new IMContainer( "footer" + numbering[panelCount],
-                                                 SizePolicy(*it),
+                                                 SizePolicy(pendingFooterPanel),
                                                  SizePolicy(footerHeight) );
             panel->setOwnerParent( this, NULL );
             
             footer.push_back( panel );
             
-            totalWidth += *it;
+            totalWidth += pendingFooterPanel;
             
         }
         
@@ -411,18 +401,16 @@ void IMGUI::setup() {
         
         // Go through the list of pending panels, create them and total their widths
         int panelCount = 0;
-        for( std::vector<float>::iterator it = pendingMainPanels.begin();
-            it != pendingMainPanels.end();
-            ++it ) {
+        for(float & pendingMainPanel : pendingMainPanels) {
             
             IMContainer* panel = new IMContainer( "main" + numbering[panelCount],
-                                                 SizePolicy(*it),
+                                                 SizePolicy(pendingMainPanel),
                                                  SizePolicy(mainHeight) );
             panel->setOwnerParent( this, NULL );
             
             main.push_back( panel );
             
-            totalWidth += *it;
+            totalWidth += pendingMainPanel;
             
         }
         
@@ -545,8 +533,8 @@ void IMGUI::clear() {
         containerList[i]->Release();
     }
 
-    for( int i = 0; i < int(messageQueue.size()); ++i ) {
-        messageQueue[i]->Release();
+    for(auto & i : messageQueue) {
+        i->Release();
     }
     messageQueue.clear();
 }
@@ -682,26 +670,20 @@ void IMGUI::doRelayout() {
             backgrounds[ layer ]->doRelayout();
         }
         
-        for( std::vector<IMContainer*>::iterator it = header.begin();
-            it != header.end();
-            ++it ) {
-            (*it)->doRelayout();
+        for(auto & it : header) {
+            it->doRelayout();
         }
         
-        for( std::vector<IMContainer*>::iterator it = footer.begin();
-            it != footer.end();
-            ++it ) {
-            (*it)->doRelayout();
+        for(auto & it : footer) {
+            it->doRelayout();
         }
         
-        for( std::vector<IMContainer*>::iterator it = main.begin();
-            it != main.end();
-            ++it ) {
-            (*it)->doRelayout();
+        for(auto & it : main) {
+            it->doRelayout();
         }
         
-        for( unsigned int layer = 0; layer < foregrounds.size(); ++layer ) {
-            foregrounds[ layer ]->doRelayout();
+        for(auto & foreground : foregrounds) {
+            foreground->doRelayout();
         }
         
         // MJB Note: I'm aware that redoing the layout for the whole structure
@@ -856,31 +838,25 @@ void IMGUI::doScreenResize() {
         backgrounds[ layer ]->doScreenResize();
     }
     
-    for( std::vector<IMContainer*>::iterator it = header.begin();
-        it != header.end();
-        ++it ) {
-        (*it)->doScreenResize();
+    for(auto & it : header) {
+        it->doScreenResize();
     }
     
-    for( std::vector<IMContainer*>::iterator it = footer.begin();
-        it != footer.end();
-        ++it ) {
-        (*it)->doScreenResize();
+    for(auto & it : footer) {
+        it->doScreenResize();
     }
     
-    for( std::vector<IMContainer*>::iterator it = main.begin();
-        it != main.end();
-        ++it ) {
-        (*it)->doScreenResize();
+    for(auto & it : main) {
+        it->doScreenResize();
     }
     
-    for( unsigned int layer = 0; layer < foregrounds.size(); ++layer ) {
+    for(auto & foreground : foregrounds) {
         // reset the size
-        foregrounds[ layer ]->setSizePolicy( SizePolicy(screenMetrics.GUISpace.x()),
+        foreground->setSizePolicy( SizePolicy(screenMetrics.GUISpace.x()),
                                              SizePolicy(screenMetrics.GUISpace.y()) );
         
         
-        foregrounds[ layer ]->doScreenResize();
+        foreground->doScreenResize();
     }
     
     doRelayout();
@@ -962,8 +938,8 @@ void IMGUI::render() {
     IMGUI_IMUIContext->render();
     
     // render the foregrounds
-    for( unsigned int layer = 0; layer < foregrounds.size(); ++layer ) {
-        foregrounds[ layer ]->render( origin, origin, vec2( UNDEFINEDSIZE, UNDEFINEDSIZE ) );
+    for(auto & foreground : foregrounds) {
+        foreground->render( origin, origin, vec2( UNDEFINEDSIZE, UNDEFINEDSIZE ) );
         IMGUI_IMUIContext->render();
     }
     
@@ -1069,10 +1045,8 @@ void IMGUI::drawBox( vec2 boxPos, vec2 boxSize, vec4 boxColor, int zOrder, bool 
 IMElement* IMGUI::findElement( std::string const& elementName ) {
     
     
-    for( std::vector<IMContainer*>::iterator it = header.begin();
-         it != header.end();
-         ++it ) {
-        IMElement* foundElement = (*it)->findElement( elementName );
+    for(auto & it : header) {
+        IMElement* foundElement = it->findElement( elementName );
         
         if( foundElement != NULL ) {
             foundElement->AddRef();
@@ -1080,10 +1054,8 @@ IMElement* IMGUI::findElement( std::string const& elementName ) {
         }
     }
     
-    for( std::vector<IMContainer*>::iterator it = footer.begin();
-         it != footer.end();
-         ++it ) {
-        IMElement* foundElement = (*it)->findElement( elementName );
+    for(auto & it : footer) {
+        IMElement* foundElement = it->findElement( elementName );
         
         if( foundElement != NULL ) {
             foundElement->AddRef();
@@ -1091,10 +1063,8 @@ IMElement* IMGUI::findElement( std::string const& elementName ) {
         }
     }
     
-    for( std::vector<IMContainer*>::iterator it = main.begin();
-         it != main.end();
-         ++it ) {
-        IMElement* foundElement = (*it)->findElement( elementName );
+    for(auto & it : main) {
+        IMElement* foundElement = it->findElement( elementName );
         
         if( foundElement != NULL ) {
             foundElement->AddRef();

--- a/Source/GUI/IMUI/imui.cpp
+++ b/Source/GUI/IMUI/imui.cpp
@@ -334,8 +334,7 @@ void IMUIContext::deriveFontDimensions( IMUIText& text ) {
         LOGE << "Got utf8 exception \"" << ner.what() << "\" this might indicate invalid utf-8 data" << std::endl;
     }
     
-    for(unsigned i=0; i<utf32_string.size(); ++i){
-        uint32_t c = utf32_string[i];
+    for(unsigned int c : utf32_string){
         if(c == '\n') {
             
             if( currentLineX > dimensions[ 0 ] ) {

--- a/Source/GUI/IMUI/imui_script.cpp
+++ b/Source/GUI/IMUI/imui_script.cpp
@@ -126,8 +126,8 @@ static CScriptArray* AS_GetFloatingContents(IMContainer* element) {
 
     array->Reserve(vals.size());
 
-    for( unsigned i = 0; i < vals.size(); i++ ) {
-        array->InsertLast((void*)&vals[i]);
+    for(auto & val : vals) {
+        array->InsertLast((void*)&val);
     }
 
     return array;

--- a/Source/GUI/dimgui/modmenu.cpp
+++ b/Source/GUI/dimgui/modmenu.cpp
@@ -88,22 +88,22 @@ static std::vector<std::pair<const char*,std::vector<ModInstance*> > > GetCatego
 
     const std::vector<ModInstance*> mods = ModLoading::Instance().GetAllMods();
 
-    for( uint32_t i = 0; i < mods.size() ; i++ ) {
-        if( mods[i]->IsCore() ) {
-            categorized_mods[5].second.push_back( mods[i] );
-        } else if( mods[i]->modsource == ModSourceLocalModFolder ) {
-            categorized_mods[0].second.push_back( mods[i] );
-        } else if( mods[i]->modsource == ModSourceSteamworks ) {
-            if( mods[i]->IsOwnedByCurrentUser() ) {
-                categorized_mods[3].second.push_back( mods[i] );
+    for(auto mod : mods) {
+        if( mod->IsCore() ) {
+            categorized_mods[5].second.push_back( mod );
+        } else if( mod->modsource == ModSourceLocalModFolder ) {
+            categorized_mods[0].second.push_back( mod );
+        } else if( mod->modsource == ModSourceSteamworks ) {
+            if( mod->IsOwnedByCurrentUser() ) {
+                categorized_mods[3].second.push_back( mod );
             } else {
-                if( mods[i]->IsFavorite() ) {
-                    categorized_mods[4].second.push_back( mods[i] ); 
+                if( mod->IsFavorite() ) {
+                    categorized_mods[4].second.push_back( mod ); 
                 } else {
-                    if( mods[i]->IsSubscribed() ) {
-                        categorized_mods[1].second.push_back( mods[i] );
+                    if( mod->IsSubscribed() ) {
+                        categorized_mods[1].second.push_back( mod );
                     } else {
-                        categorized_mods[2].second.push_back( mods[i] );
+                        categorized_mods[2].second.push_back( mod );
                     }
                 }
             }
@@ -152,8 +152,7 @@ static void DrawSimpleModMenu( ) {
     for(; modcatit != categmods.end(); modcatit++ ) {
         const std::vector<ModInstance*> mods = modcatit->second;
         if( mods.size() > 0 && ImGui::TreeNodeEx(modcatit->first,ImGuiTreeNodeFlags_DefaultOpen) ) {
-            for(uint32_t i = 0; i < mods.size(); ++i) {
-                ModInstance* mod = mods[i];
+            for(auto mod : mods) {
                 bool active = mod->IsActive();
                 ModID sid = mod->GetSid();
                 ImGui::PushID(sid.id);
@@ -262,8 +261,7 @@ static void DrawAdvancedModMenu(Engine* engine) {
     for(; modcatit != categmods.end(); modcatit++ ) {
         const std::vector<ModInstance*> mods = modcatit->second;
         if( mods.size() > 0 && ImGui::TreeNodeEx(modcatit->first,ImGuiTreeNodeFlags_DefaultOpen) ) {
-            for(uint32_t i = 0; i < mods.size(); ++i) {
-                ModInstance* mod = mods[i];
+            for(auto mod : mods) {
                 bool active = mod->IsActive();
                 ModID sid = mod->GetSid();
                 ImGui::PushID(sid.id);
@@ -449,23 +447,23 @@ static void DrawAdvancedModMenu(Engine* engine) {
 
         std::vector<std::string> validity_errors = modi->GetValidityErrorsArr();
         ImGui::Text( "Errors:" );  
-        for( unsigned i = 0; i < validity_errors.size(); i++ ) {
+        for(auto & validity_error : validity_errors) {
             ImGui::NextColumn();
-            ImGui::Text( "%s", validity_errors[i].c_str() );
+            ImGui::Text( "%s", validity_error.c_str() );
             ImGui::NextColumn();
         }
         ImGui::Separator();
         ImGui::Text( "Mod Dependencies:" );  
-        for( unsigned i = 0; i < modi->mod_dependencies.size(); i++ ) {
+        for(auto & mod_dependencie : modi->mod_dependencies) {
             ImGui::NextColumn();
-            ImGui::Text( "%s", modi->mod_dependencies[i].id.c_str() );
+            ImGui::Text( "%s", mod_dependencie.id.c_str() );
             ImGui::NextColumn();
         }
         ImGui::Separator();
         ImGui::Text( "Supported Version:" );
-        for( unsigned i = 0; i < modi->supported_versions.size(); i++ ) {
+        for(auto & supported_version : modi->supported_versions) {
             ImGui::NextColumn();
-            ImGui::Text( "%s", modi->supported_versions[i].c_str() );
+            ImGui::Text( "%s", supported_version.c_str() );
             ImGui::NextColumn();
         }
         ImGui::Separator();
@@ -578,25 +576,25 @@ static void DrawAdvancedModMenu(Engine* engine) {
         ImGui::Separator();
 
         ImGui::Text( "Items:" );  
-        for( unsigned i = 0; i < modi->items.size(); i++ ) {
+        for(auto & item : modi->items) {
             ImGui::NextColumn();
-            ImGui::Text("%s", modi->items[i].title.c_str());
+            ImGui::Text("%s", item.title.c_str());
             ImGui::NextColumn();
         }
         ImGui::Separator();
 
         ImGui::Text( "Levels:" );  
-        for( unsigned i = 0; i < modi->levels.size(); i++ ) {
+        for(auto & level : modi->levels) {
             ImGui::NextColumn();
-            ImGui::Text("%s", modi->levels[i].title.c_str());
+            ImGui::Text("%s", level.title.c_str());
             ImGui::NextColumn();
         }
         ImGui::Separator();
 
         ImGui::Text( "Campaigns:" );
-        for( unsigned i = 0; i < modi->campaigns.size(); ++i) {
+        for(auto & campaign : modi->campaigns) {
             ImGui::NextColumn();
-            ImGui::Text("%s", modi->campaigns[i].title.c_str());
+            ImGui::Text("%s", campaign.title.c_str());
             ImGui::NextColumn();
         }
 
@@ -605,9 +603,9 @@ static void DrawAdvancedModMenu(Engine* engine) {
         for( unsigned i = 0; i < modi->campaigns.size(); i++ ) {
             ImGui::Text("%s levels:", modi->campaigns[i].title.c_str());
 
-            for( unsigned j = 0; j < modi->campaigns[i].levels.size(); j++ ) {
+            for(auto & level : modi->campaigns[i].levels) {
                 ImGui::NextColumn();
-                ImGui::Text("%s", modi->campaigns[i].levels[j].title.c_str());
+                ImGui::Text("%s", level.title.c_str());
                 ImGui::NextColumn();
             }
 
@@ -624,20 +622,20 @@ static void DrawAdvancedModMenu(Engine* engine) {
         ImGui::Text("Parameter Data");
         ImGui::Separator();
 
-        for( unsigned i = 0; i < modi->levels.size(); i++ ) {
-            if(ImGui::TreeNode(modi->levels[i].title.c_str(),"%s level", modi->levels[i].title.c_str())) {
-                ImguiDrawParameter(&modi->levels[i].parameter,"",0);
+        for(auto & level : modi->levels) {
+            if(ImGui::TreeNode(level.title.c_str(),"%s level", level.title.c_str())) {
+                ImguiDrawParameter(&level.parameter,"",0);
                 ImGui::TreePop();
             }
         }
 
-        for(unsigned i = 0; i < modi->campaigns.size(); ++i) {
+        for(auto & campaign : modi->campaigns) {
             ImGui::PushID("campaign_params");
-            if(ImGui::TreeNode(modi->campaigns[i].id.c_str(), "%s campaign", modi->campaigns[i].title.c_str())) {
-                ImguiDrawParameter(&modi->campaigns[i].parameter,"",0);
-                for( unsigned j = 0; j < modi->campaigns[i].levels.size(); j++ ) {
-                    if(ImGui::TreeNode(modi->campaigns[i].levels[j].title.c_str(),"%s level", modi->campaigns[i].levels[j].title.c_str())){
-                        ImguiDrawParameter(&modi->campaigns[i].levels[j].parameter,"",0);
+            if(ImGui::TreeNode(campaign.id.c_str(), "%s campaign", campaign.title.c_str())) {
+                ImguiDrawParameter(&campaign.parameter,"",0);
+                for( unsigned j = 0; j < campaign.levels.size(); j++ ) {
+                    if(ImGui::TreeNode(campaign.levels[j].title.c_str(),"%s level", campaign.levels[j].title.c_str())){
+                        ImguiDrawParameter(&campaign.levels[j].parameter,"",0);
                         ImGui::TreePop();
                     }
                 }
@@ -1183,8 +1181,8 @@ void DrawModMenu(Engine* engine) {
         ImGui::SetNextWindowSize(ImVec2(1024.0f, 768.0f), ImGuiCond_FirstUseEver);
         ImGui::Begin("Manifest", &show_manifest);
         if( modi ) {
-            for( unsigned i = 0; i < modi->manifest.size(); i++ ) {
-                ImGui::Text( "%s", modi->manifest[i].c_str() );
+            for(auto & i : modi->manifest) {
+                ImGui::Text( "%s", i.c_str() );
             }
         }
         ImGui::End();

--- a/Source/GUI/dimgui/settings_screen.cpp
+++ b/Source/GUI/dimgui/settings_screen.cpp
@@ -1167,14 +1167,14 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
             std::vector<std::string> difficulties = config.GetDifficultyPresets();
 
             if(ImGui::BeginMenu("Finish All Levels On Difficulty")) {
-                for(auto & difficultie : difficulties) {
-                    if( ImGui::Button(difficultie.c_str())) {
+                for(auto & difficulty : difficulties) {
+                    if( ImGui::Button(difficulty.c_str())) {
                         std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
                         for(auto camp : campaigns) {
                             for( size_t j = 0; j < camp.levels.size(); j++ ) {
                                 SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign",camp.levels[j].id.str());
-                                if( false == s.ArrayContainsValue("finished_difficulties",difficultie) ) {
-                                    s.AppendArrayValue("finished_difficulties",difficultie);
+                                if( false == s.ArrayContainsValue("finished_difficulties",difficulty) ) {
+                                    s.AppendArrayValue("finished_difficulties",difficulty);
                                 }
                             }
                         }
@@ -1191,11 +1191,11 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
                         for( size_t j = 0; j < camp.levels.size(); j++ ) {
                             ModInstance::Level level = camp.levels[j];
                             if(ImGui::BeginMenu(level.title)) {
-                                for(auto & difficultie : difficulties) {
-                                    if( ImGui::Button(difficultie.c_str())) {
+                                for(auto & difficulty : difficulties) {
+                                    if( ImGui::Button(difficulty.c_str())) {
                                         SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign",level.id.str());
-                                        if( false == s.ArrayContainsValue("finished_difficulties",difficultie) ) {
-                                            s.AppendArrayValue("finished_difficulties",difficultie);
+                                        if( false == s.ArrayContainsValue("finished_difficulties",difficulty) ) {
+                                            s.AppendArrayValue("finished_difficulties",difficulty);
                                         }
                                         Engine::Instance()->save_file_.QueueWriteInPlace();
                                     }

--- a/Source/GUI/dimgui/settings_screen.cpp
+++ b/Source/GUI/dimgui/settings_screen.cpp
@@ -300,8 +300,8 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
         dropdown_item = 0;
         for(int i=0; i<3; ++i){
             Config::Map& map = global_settings[i].map_;
-            for(Config::Map::iterator iter = map.begin(); iter != map.end(); ++iter ){
-                if(config.GetRef(iter->first) != iter->second.data){
+            for(auto & iter : map){
+                if(config.GetRef(iter.first) != iter.second.data){
                     dropdown_item = i + 1;
                     break;
                 }
@@ -320,8 +320,8 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
             if(dropdown_item != 0){
                 int curr_global_setting = dropdown_item-1;
                 Config::Map& map = global_settings[curr_global_setting].map_;
-                for(Config::Map::iterator iter = map.begin(); iter != map.end(); ++iter ){
-                    config.GetRef(iter->first) = iter->second.data;
+                for(auto & iter : map){
+                    config.GetRef(iter.first) = iter.second.data;
                 }
                 UpdateMultisampleSetting(config.GetRef("multisample").toNumber<int>());
                 UpdateAnisotropy(config.GetRef("anisotropy").toNumber<int>());
@@ -1129,8 +1129,7 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
         if (ImGui::BeginMenu("Campaign Progress (Dangerous)")) {
             if(ImGui::Button("Unlock all campaign levels")){
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign","");
                     for( size_t k = 0; k < camp.levels.size(); k++ ) {
                         s.SetArrayValue("unlocked_levels",k,camp.levels[k].id.str());
@@ -1141,8 +1140,7 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
 
             if(ImGui::BeginMenu("Unlock level in campaign")) {
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     if(ImGui::BeginMenu(camp.title.c_str())) {
                         for( size_t k = 0; k < camp.levels.size(); k++ ) {
                             if(ImGui::Button(camp.levels[k].title.c_str())) {
@@ -1159,8 +1157,7 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
 
             if(ImGui::Button("Clear all campaign progress")){
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign","");
                     s.ClearData();
                 }
@@ -1170,15 +1167,14 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
             std::vector<std::string> difficulties = config.GetDifficultyPresets();
 
             if(ImGui::BeginMenu("Finish All Levels On Difficulty")) {
-                for( size_t k = 0; k < difficulties.size(); k++ ) {
-                    if( ImGui::Button(difficulties[k].c_str())) {
+                for(auto & difficultie : difficulties) {
+                    if( ImGui::Button(difficultie.c_str())) {
                         std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                        for( size_t i = 0; i < campaigns.size(); i++ ) {
-                            ModInstance::Campaign camp = campaigns[i];
+                        for(auto camp : campaigns) {
                             for( size_t j = 0; j < camp.levels.size(); j++ ) {
                                 SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign",camp.levels[j].id.str());
-                                if( false == s.ArrayContainsValue("finished_difficulties",difficulties[k]) ) {
-                                    s.AppendArrayValue("finished_difficulties",difficulties[k]);
+                                if( false == s.ArrayContainsValue("finished_difficulties",difficultie) ) {
+                                    s.AppendArrayValue("finished_difficulties",difficultie);
                                 }
                             }
                         }
@@ -1190,17 +1186,16 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
 
             if(ImGui::BeginMenu("Finish Level On Difficulty")) {
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     if(ImGui::BeginMenu(camp.title)) {
                         for( size_t j = 0; j < camp.levels.size(); j++ ) {
                             ModInstance::Level level = camp.levels[j];
                             if(ImGui::BeginMenu(level.title)) {
-                                for( size_t k = 0; k < difficulties.size(); k++ ) {
-                                    if( ImGui::Button(difficulties[k].c_str())) {
+                                for(auto & difficultie : difficulties) {
+                                    if( ImGui::Button(difficultie.c_str())) {
                                         SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign",level.id.str());
-                                        if( false == s.ArrayContainsValue("finished_difficulties",difficulties[k]) ) {
-                                            s.AppendArrayValue("finished_difficulties",difficulties[k]);
+                                        if( false == s.ArrayContainsValue("finished_difficulties",difficultie) ) {
+                                            s.AppendArrayValue("finished_difficulties",difficultie);
                                         }
                                         Engine::Instance()->save_file_.QueueWriteInPlace();
                                     }
@@ -1216,8 +1211,7 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
 
             if(ImGui::Button("Clear All Linear Level Data")) {
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     for( size_t j = 0; j < camp.levels.size(); j++ ) {
                         SavedLevel& s = Engine::Instance()->save_file_.GetSave(camp.id.str(),"linear_campaign",camp.levels[j].id.str());
                         s.ClearData();
@@ -1228,8 +1222,7 @@ void DrawSettingsImGui(SceneGraph* scenegraph, ImGuiSettingsType type){
 
             if(ImGui::BeginMenu("Clear Save Data For Level")) {
                 std::vector<ModInstance::Campaign> campaigns = ModLoading::Instance().GetCampaigns();
-                for( size_t i = 0; i < campaigns.size(); i++ ) {
-                    ModInstance::Campaign camp = campaigns[i];
+                for(auto camp : campaigns) {
                     if(ImGui::BeginMenu(camp.title)) {
                         for( size_t j = 0; j < camp.levels.size(); j++ ) {
                             ModInstance::Level level = camp.levels[j];

--- a/Source/Game/EntityDescription.cpp
+++ b/Source/Game/EntityDescription.cpp
@@ -93,27 +93,27 @@ void EntityDescription::AddString( EntityDescriptionFieldType type, const std::s
 }
 
 const EntityDescriptionField* EntityDescription::GetField( EntityDescriptionFieldType type ) const {
-    for(unsigned i=0; i<fields.size(); ++i){
-        if(fields[i].type == type){
-            return &fields[i];
+    for(const auto & field : fields){
+        if(field.type == type){
+            return &field;
         }
     }
     return NULL;
 }
 
 EntityDescriptionField* EntityDescription::GetField( EntityDescriptionFieldType type ) {
-	for(unsigned i=0; i<fields.size(); ++i){
-		if(fields[i].type == type){
-			return &fields[i];
+	for(auto & field : fields){
+		if(field.type == type){
+			return &field;
 		}
 	}
 	return NULL;
 }
 
 EntityDescriptionField* EntityDescription::GetEditableField( EntityDescriptionFieldType type ){
-    for(unsigned i=0; i<fields.size(); ++i){
-        if(fields[i].type == type){
-            return &fields[i];
+    for(auto & field : fields){
+        if(field.type == type){
+            return &field;
         }
     }
     return NULL;
@@ -132,8 +132,7 @@ void EntityDescription::AddPalette( EntityDescriptionFieldType type, const OGPal
 void EntityDescription::ReturnPaths( PathSet& path_set ){  
     std::string str;
     EntityType type = _no_type;
-    for(unsigned i=0; i<fields.size(); ++i){
-        EntityDescriptionField &field = fields[i];
+    for(auto & field : fields){
         switch(field.type){
             case EDF_FILE_PATH:
                 field.ReadString(&str);
@@ -176,14 +175,12 @@ void EntityDescription::ReturnPaths( PathSet& path_set ){
             Engine::Instance()->GetAssetManager()->LoadSync<Item>(str)->ReturnPaths(path_set);
             break;
         case _group:{
-            for(EntityDescriptionList::iterator iter = children.begin(); iter != children.end(); ++iter){
-                EntityDescription& child = (*iter);
+            for(auto & child : children){
                 child.ReturnPaths(path_set);
             }
             break;}
         case _prefab:{
-            for(EntityDescriptionList::iterator iter = children.begin(); iter != children.end(); ++iter){
-                EntityDescription& child = (*iter);
+            for(auto & child : children){
                 child.ReturnPaths(path_set);
             }
             break;}
@@ -222,8 +219,7 @@ void EntityDescription::AddType( EntityDescriptionFieldType type ) {
 void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
     TiXmlElement* object = new TiXmlElement("Unknown Type");
     parent->LinkEndChild(object);
-    for(unsigned i=0; i<fields.size(); ++i){
-        const EntityDescriptionField &field = fields[i];
+    for(const auto & field : fields){
         switch(field.type){
             case EDF_ID: {
                 int id;
@@ -374,9 +370,9 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
                 // Write connections to XML
                 TiXmlElement* connections_el = new TiXmlElement("Connections");
                 object->LinkEndChild(connections_el);
-                for(size_t i=0, len=connections.size(); i<len; ++i){
+                for(int i : connections){
                     TiXmlElement* connection = new TiXmlElement("Connection");
-                    connection->SetAttribute("id", connections[i]);
+                    connection->SetAttribute("id", i);
                     connections_el->LinkEndChild(connection);
                 }
                 break;}
@@ -387,9 +383,9 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
                 // Write connections to XML
                 TiXmlElement* connections_el = new TiXmlElement("ConnectionsFrom");
                 object->LinkEndChild(connections_el);
-                for(size_t i=0, len=connections.size(); i<len; ++i){
+                for(int i : connections){
                     TiXmlElement* connection = new TiXmlElement("Connection");
-                    connection->SetAttribute("id", connections[i]);
+                    connection->SetAttribute("id", i);
                     connections_el->LinkEndChild(connection);
                 }
                 break;}
@@ -399,8 +395,7 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
                 // Write item connections to XML
                 TiXmlElement* item_connections_el = new TiXmlElement("ItemConnections");
                 object->LinkEndChild(item_connections_el);
-                for(size_t i=0, len=item_connections.size(); i<len; ++i) {
-                    ItemConnectionData& item_connection = item_connections[i];
+                for(auto & item_connection : item_connections) {
                     TiXmlElement* item_connection_el = new TiXmlElement("ItemConnection");
                     item_connection_el->SetAttribute("id", item_connection.id);
                     item_connection_el->SetAttribute("type", item_connection.attachment_type);
@@ -491,14 +486,12 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
                 Deserialize(field.data, aeo_vec);
                 TiXmlElement* env_object_attachments = new TiXmlElement("EnvObjectAttachments");
                 object->LinkEndChild(env_object_attachments);
-                for(unsigned i=0; i<aeo_vec.size(); ++i){
+                for(auto & aeo : aeo_vec){
                     TiXmlElement* connection = new TiXmlElement("EnvObjectAttachment");
                     env_object_attachments->LinkEndChild(connection);
-                    const AttachedEnvObject& aeo = aeo_vec[i];
-                    for(unsigned j=0; j<kMaxBoneConnects; ++j){
+                    for(const auto & bone_connect : aeo.bone_connects){
                         TiXmlElement* bone_connect_el = new TiXmlElement("BoneConnect");
                         connection->LinkEndChild(bone_connect_el);
-                        const BoneConnect &bone_connect = aeo.bone_connects[j];
                         bone_connect_el->SetAttribute("bone_id", bone_connect.bone_id);
                         bone_connect_el->SetAttribute("num_connections", bone_connect.num_connections);
                         int index;
@@ -528,8 +521,7 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
 
                 TiXmlElement* navmesh_connections_el = new TiXmlElement("NavMeshConnections");
                 object->LinkEndChild(navmesh_connections_el);
-                for(size_t i=0, len=navmesh_connections.size(); i<len; ++i) {
-                    NavMeshConnectionData& navmesh_connection = navmesh_connections[i]; 
+                for(auto & navmesh_connection : navmesh_connections) {
                     TiXmlElement* navmesh_connection_el = new TiXmlElement("NavMeshConnection");
                     navmesh_connection_el->SetAttribute("other_object_id", navmesh_connection.other_object_id);
                     navmesh_connection_el->SetAttribute("offmesh_connection_id", navmesh_connection.offmesh_connection_id);
@@ -574,10 +566,8 @@ void EntityDescription::SaveToXML( TiXmlElement* parent ) const {
         }
     }
     
-    for(EntityDescriptionList::const_iterator iter = children.begin();
-        iter != children.end(); ++iter)
+    for(const auto & child : children)
     {
-        const EntityDescription& child = (*iter);
         child.SaveToXML(object);
     }
 }
@@ -1262,10 +1252,9 @@ void ClearDescID(EntityDescription *desc) {
 		memwrite(&null_id, sizeof(int), 1, edf->data);
 	}
 	EntityDescriptionList &children = desc->children;
-	for(EntityDescriptionList::iterator it = children.begin();
-		it != children.end(); ++it)
+	for(auto & it : children)
 	{
-		ClearDescID(&(*it));
+		ClearDescID(&it);
 	}
 }
 

--- a/Source/Game/characterscript.cpp
+++ b/Source/Game/characterscript.cpp
@@ -46,9 +46,9 @@ std::string CharacterScriptGetter::GetSkeletonPath( ) {
 }
 
 std::string CharacterScriptGetter::GetAnimPath( const std::string& action ) {
-    for(unsigned i=0; i<items.size(); ++i){
-        if(items[i]->HasAnimOverride(action)){
-            return items[i]->GetAnimOverride(action);
+    for(auto & item : items){
+        if(item->HasAnimOverride(action)){
+            return item->GetAnimOverride(action);
         }
     }
     CharAnimOverrideMap::iterator iter = char_anim_overrides_.find(action);
@@ -65,18 +65,18 @@ const std::string & CharacterScriptGetter::GetTag(const std::string &key) {
 
 
 char CharacterScriptGetter::GetAnimFlags( const std::string& action ) {
-    for(unsigned i=0; i<items.size(); ++i){
-        if(items[i]->HasAnimOverride(action)){
-            return items[i]->GetAnimOverrideFlags(action);
+    for(auto & item : items){
+        if(item->HasAnimOverride(action)){
+            return item->GetAnimOverrideFlags(action);
         }
     }
     return 0;
 }
 
 std::string CharacterScriptGetter::GetAttackPath( const std::string& action ) {
-    for(unsigned i=0; i<items.size(); ++i){
-        if(items[i]->HasAttackOverride(action)){
-            return items[i]->GetAttackOverride(action);
+    for(auto & item : items){
+        if(item->HasAttackOverride(action)){
+            return item->GetAttackOverride(action);
         }
     }
     return character_ref->GetAttackPath(action);
@@ -86,11 +86,9 @@ int CharacterScriptGetter::OnSameTeam( const std::string& char_path ) {
     //CharacterRef other = Characters::Instance()->ReturnRef(char_path);
     CharacterRef other = Engine::Instance()->GetAssetManager()->LoadSync<Character>(char_path);
     const std::set<std::string> &team_set = character_ref->GetTeamSet();
-    for(std::set<std::string>::const_iterator iter = team_set.begin();
-        iter != team_set.end();
-        ++iter)
+    for(const auto & iter : team_set)
     {
-        if(other->IsOnTeam(*iter)){
+        if(other->IsOnTeam(iter)){
             return 1;
         }
     }

--- a/Source/Game/color_tint_component.cpp
+++ b/Source/Game/color_tint_component.cpp
@@ -58,8 +58,7 @@ void ColorTintComponent::LoadDescriptionFromXML( EntityDescription& desc, const 
 }
 
 void ColorTintComponent::SetFromDescription( const EntityDescription& desc ) {
-    for(unsigned i=0; i<desc.fields.size(); ++i){
-        const EntityDescriptionField& field = desc.fields[i];
+    for(const auto & field : desc.fields){
         switch(field.type){
             case EDF_COLOR:
                 memread(tint_.entries, sizeof(float), 3, field.data);

--- a/Source/Game/level.cpp
+++ b/Source/Game/level.cpp
@@ -69,18 +69,18 @@ Level::~Level() {
 void Level::Dispose() {
     Message("dispose_level");
 
-    for( uint32_t i = 0; i < as_contexts_.size(); i++ ) {
-        delete as_contexts_[i].ctx;
-        as_contexts_[i].ctx = NULL;
+    for(auto & as_context : as_contexts_) {
+        delete as_context.ctx;
+        as_context.ctx = NULL;
     }
     as_contexts_.clear();
 
     Engine::Instance()->GetASNetwork()->DeRegisterASNetworkCallback(this);
 
     old_col_map_.clear();
-    for(int i=0; i<kMaxTextElements; ++i){
-        text_elements[i].in_use = false;
-        text_elements[i].text_canvas_texture.Reset();
+    for(auto & text_element : text_elements){
+        text_element.in_use = false;
+        text_element.text_canvas_texture.Reset();
     }
 }
 
@@ -96,17 +96,17 @@ Path Level::FindScript(const std::string& path) {
 void Level::StartDialogue(const std::string& dialogue) const {
     ASArglist args;
     args.AddObject((void*)&dialogue);
-    for (unsigned i = 0; i < as_contexts_.size(); i++) {
-        if (as_contexts_[i].ctx->HasFunction(as_contexts_[i].as_funcs.start_dialogue)) {
-            as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.start_dialogue);
+    for (const auto & as_context : as_contexts_) {
+        if (as_context.ctx->HasFunction(as_context.as_funcs.start_dialogue)) {
+            as_context.ctx->CallScriptFunction(as_context.as_funcs.start_dialogue);
         }
     }
 }
 
 void Level::RegisterMPCallbacks() const {
-	for (unsigned i = 0; i < as_contexts_.size(); i++) {
-		if (as_contexts_[i].ctx->HasFunction(as_contexts_[i].as_funcs.register_mp_callbacks)) {
-			as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.register_mp_callbacks);
+	for (const auto & as_context : as_contexts_) {
+		if (as_context.ctx->HasFunction(as_context.as_funcs.register_mp_callbacks)) {
+			as_context.ctx->CallScriptFunction(as_context.as_funcs.register_mp_callbacks);
 		}
 	}
 }
@@ -163,8 +163,8 @@ void Level::Initialize(SceneGraph *scenegraph, GUI* gui) {
     }
 
     if(!npc_script_.empty()) {
-        for(size_t i = 0; i < scenegraph->movement_objects_.size(); ++i) {
-            MovementObject* obj = (MovementObject*)scenegraph->movement_objects_[i];
+        for(auto & movement_object : scenegraph->movement_objects_) {
+            MovementObject* obj = (MovementObject*)movement_object;
             if(obj->GetNPCObjectScript().empty()) {
                 obj->ChangeControlScript(npc_script_);
             }
@@ -191,8 +191,8 @@ void Level::Initialize(SceneGraph *scenegraph, GUI* gui) {
 
     as_collisions.reset(new ASCollisions(scenegraph));
 
-    for(unsigned i = 0; i < as_contexts_.size(); i++) {
-        ASContext* ctx = new ASContext(as_contexts_[i].context_name.c_str(),as_data);
+    for(auto & as_context : as_contexts_) {
+        ASContext* ctx = new ASContext(as_context.context_name.c_str(),as_data);
 
         AttachASNetwork(ctx);
         AttachUIQueries(ctx);
@@ -220,40 +220,40 @@ void Level::Initialize(SceneGraph *scenegraph, GUI* gui) {
         character_script_getter_.AttachToScript(ctx, "character_getter");
         as_collisions->AttachToContext(ctx);
 
-        as_contexts_[i].as_funcs.init                       = ctx->RegisterExpectedFunction("void Init(string level_name)", true);
-        as_contexts_[i].as_funcs.update                     = ctx->RegisterExpectedFunction("void Update(int is_paused)", false);
-        as_contexts_[i].as_funcs.update_deprecated          = ctx->RegisterExpectedFunction("void Update()", false);
+        as_context.as_funcs.init                       = ctx->RegisterExpectedFunction("void Init(string level_name)", true);
+        as_context.as_funcs.update                     = ctx->RegisterExpectedFunction("void Update(int is_paused)", false);
+        as_context.as_funcs.update_deprecated          = ctx->RegisterExpectedFunction("void Update()", false);
 
-        as_contexts_[i].as_funcs.hotspot_exit               = ctx->RegisterExpectedFunction("void HotspotExit(string event, MovementObject @mo)", false);
-        as_contexts_[i].as_funcs.hotspot_enter              = ctx->RegisterExpectedFunction("void HotspotEnter(string event, MovementObject @mo)", false);
-        as_contexts_[i].as_funcs.receive_message            = ctx->RegisterExpectedFunction("void ReceiveMessage(string message)", false);
-        as_contexts_[i].as_funcs.draw_gui                   = ctx->RegisterExpectedFunction("void DrawGUI()", false);
-        as_contexts_[i].as_funcs.draw_gui2                  = ctx->RegisterExpectedFunction("void DrawGUI2()", false);
-        as_contexts_[i].as_funcs.draw_gui3                  = ctx->RegisterExpectedFunction("void DrawGUI3()", false);
-        as_contexts_[i].as_funcs.has_focus                  = ctx->RegisterExpectedFunction("bool HasFocus()", false);
-        as_contexts_[i].as_funcs.dialogue_camera_control    = ctx->RegisterExpectedFunction("bool DialogueCameraControl()", false);
-        as_contexts_[i].as_funcs.save_history_state         = ctx->RegisterExpectedFunction("void SaveHistoryState(SavedChunk@ chunk)", false);
-        as_contexts_[i].as_funcs.read_chunk                 = ctx->RegisterExpectedFunction("void ReadChunk(SavedChunk@ chunk)", false);
-        as_contexts_[i].as_funcs.set_window_dimensions      = ctx->RegisterExpectedFunction("void SetWindowDimensions(int width, int height)", false);
-        as_contexts_[i].as_funcs.incoming_tcp_data          = ctx->RegisterExpectedFunction("void IncomingTCPData(uint socket, array<uint8>@ data)", false);
+        as_context.as_funcs.hotspot_exit               = ctx->RegisterExpectedFunction("void HotspotExit(string event, MovementObject @mo)", false);
+        as_context.as_funcs.hotspot_enter              = ctx->RegisterExpectedFunction("void HotspotEnter(string event, MovementObject @mo)", false);
+        as_context.as_funcs.receive_message            = ctx->RegisterExpectedFunction("void ReceiveMessage(string message)", false);
+        as_context.as_funcs.draw_gui                   = ctx->RegisterExpectedFunction("void DrawGUI()", false);
+        as_context.as_funcs.draw_gui2                  = ctx->RegisterExpectedFunction("void DrawGUI2()", false);
+        as_context.as_funcs.draw_gui3                  = ctx->RegisterExpectedFunction("void DrawGUI3()", false);
+        as_context.as_funcs.has_focus                  = ctx->RegisterExpectedFunction("bool HasFocus()", false);
+        as_context.as_funcs.dialogue_camera_control    = ctx->RegisterExpectedFunction("bool DialogueCameraControl()", false);
+        as_context.as_funcs.save_history_state         = ctx->RegisterExpectedFunction("void SaveHistoryState(SavedChunk@ chunk)", false);
+        as_context.as_funcs.read_chunk                 = ctx->RegisterExpectedFunction("void ReadChunk(SavedChunk@ chunk)", false);
+        as_context.as_funcs.set_window_dimensions      = ctx->RegisterExpectedFunction("void SetWindowDimensions(int width, int height)", false);
+        as_context.as_funcs.incoming_tcp_data          = ctx->RegisterExpectedFunction("void IncomingTCPData(uint socket, array<uint8>@ data)", false);
 
-        as_contexts_[i].as_funcs.pre_script_reload          = ctx->RegisterExpectedFunction("void PreScriptReload()", false);
-        as_contexts_[i].as_funcs.post_script_reload         = ctx->RegisterExpectedFunction("void PostScriptReload()", false);
+        as_context.as_funcs.pre_script_reload          = ctx->RegisterExpectedFunction("void PreScriptReload()", false);
+        as_context.as_funcs.post_script_reload         = ctx->RegisterExpectedFunction("void PostScriptReload()", false);
 
-        as_contexts_[i].as_funcs.menu                       = ctx->RegisterExpectedFunction("void Menu()", false);
-		as_contexts_[i].as_funcs.register_mp_callbacks		= ctx->RegisterExpectedFunction("void RegisterMPCallBacks()", false);
-        as_contexts_[i].as_funcs.start_dialogue             = ctx->RegisterExpectedFunction("void StartDialogue(const string &in name", false);
+        as_context.as_funcs.menu                       = ctx->RegisterExpectedFunction("void Menu()", false);
+		as_context.as_funcs.register_mp_callbacks		= ctx->RegisterExpectedFunction("void RegisterMPCallBacks()", false);
+        as_context.as_funcs.start_dialogue             = ctx->RegisterExpectedFunction("void StartDialogue(const string &in name", false);
  
-        ctx->LoadScript(as_contexts_[i].path);
+        ctx->LoadScript(as_context.path);
 
-        as_contexts_[i].ctx = ctx;
+        as_context.ctx = ctx;
     }
 
-    for(unsigned i = 0; i < as_contexts_.size(); i++) {
+    for(auto & as_context : as_contexts_) {
         LOGI << "Calling void Init(string level_name) for level hook file." << std::endl; 
         ASArglist args;
         args.AddObject(&scenegraph->level_name_);
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.init, &args);
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.init, &args);
 
     }
 
@@ -272,10 +272,10 @@ void Level::Update(bool paused) {
 	args.Add(paused?1:0);
 	std::vector<HookedASContext >::iterator cit = as_contexts_.begin();
     PROFILER_ENTER(g_profiler_ctx, "Level script Update()");
-    for( unsigned i = 0; i < as_contexts_.size(); i++ ) {
-		if( as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.update, &args) == false) {
+    for(auto & as_context : as_contexts_) {
+		if( as_context.ctx->CallScriptFunction(as_context.as_funcs.update, &args) == false) {
             if(paused == false) {
-		        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.update_deprecated, &args2);
+		        as_context.ctx->CallScriptFunction(as_context.as_funcs.update_deprecated, &args2);
             }
         }
 	}
@@ -290,8 +290,8 @@ void Level::Update(bool paused) {
 			
 			bool angelscriptCallSuccesfull = false;
 
-			for (unsigned i = 0; i < as_contexts_.size(); i++) {
-				if (as_contexts_[i].ctx->CallMPCallBack(update.state, temp) ) { 
+			for (auto & as_context : as_contexts_) {
+				if (as_context.ctx->CallMPCallBack(update.state, temp) ) { 
 					angelscriptCallSuccesfull = true;
 				}
 			}
@@ -308,8 +308,8 @@ void Level::Update(bool paused) {
 
 			bool angelscriptCallSuccesfull = false;
 
-			for (unsigned i = 0; i < as_contexts_.size(); i++) {
-				if (as_contexts_[i].ctx->CallMPCallBack(update.state, temp)) {
+			for (auto & as_context : as_contexts_) {
+				if (as_context.ctx->CallMPCallBack(update.state, temp)) {
 					angelscriptCallSuccesfull = true;
 				}
 			}
@@ -342,14 +342,13 @@ void Level::HandleCollisions( CollisionPtrMap &col_map, SceneGraph &scenegraph )
 		old_col_ptr_map.clear();
 		{
 			CollisionMap &map = old_col_map_;
-			for(CollisionMap::iterator iter = map.begin(); iter != map.end(); ++iter){
-				int id = iter->first;
+			for(auto & iter : map){
+				int id = iter.first;
 				Object* obj_a_ptr = scenegraph.GetObjectFromID(id);
 				if(obj_a_ptr){
-					CollisionSet &set = iter->second;
-					for(CollisionSet::iterator iter = set.begin(); iter != set.end(); ++iter){
-						int id = *iter;
-						Object* obj_b_ptr = scenegraph.GetObjectFromID(id);
+					CollisionSet &set = iter.second;
+					for(int id : set){
+							Object* obj_b_ptr = scenegraph.GetObjectFromID(id);
 						if(obj_b_ptr){
 							old_col_ptr_map[obj_a_ptr].insert(obj_b_ptr);
 						}
@@ -450,11 +449,11 @@ void Level::HandleCollisions( CollisionPtrMap &col_map, SceneGraph &scenegraph )
 		// Convert old collision pointers to ids
 		CollisionPtrMap &map = col_map;
 		old_col_map_.clear();
-		for(CollisionPtrMap::iterator iter = map.begin(); iter != map.end(); ++iter){
-			int id_a = ((Object*)iter->first)->GetID();
-			CollisionPtrSet &set = iter->second;
-			for(CollisionPtrSet::iterator iter = set.begin(); iter != set.end(); ++iter){
-				int id_b = ((Object*)(*iter))->GetID();
+		for(auto & iter : map){
+			int id_a = ((Object*)iter.first)->GetID();
+			CollisionPtrSet &set = iter.second;
+			for(auto iter : set){
+				int id_b = ((Object*)iter)->GetID();
 				old_col_map_[id_a].insert(id_b);
 			}
 		}
@@ -470,8 +469,8 @@ void Level::HandleCollisions( CollisionPtrMap &col_map, SceneGraph &scenegraph )
 			args.AddObject((void*)&exit_call_queue_it->first->GetScriptFile());
 			args.AddAddress((void*)exit_call_queue_it->second);
 
-            for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-			    as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.hotspot_exit, &args);
+            for(auto & as_context : as_contexts_) {
+			    as_context.ctx->CallScriptFunction(as_context.as_funcs.hotspot_exit, &args);
             }
 		}
 
@@ -482,8 +481,8 @@ void Level::HandleCollisions( CollisionPtrMap &col_map, SceneGraph &scenegraph )
 			args.AddObject((void*)&enter_call_queue_it->first->GetScriptFile());
 			args.AddAddress((void*)enter_call_queue_it->second);
 
-            for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-			    as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.hotspot_enter, &args);
+            for(auto & as_context : as_contexts_) {
+			    as_context.ctx->CallScriptFunction(as_context.as_funcs.hotspot_enter, &args);
             }
 		}
 	}
@@ -526,18 +525,18 @@ void Level::Message( const std::string &msg ) {
         online->SendLevelMessage(msg);
     }
 
-    for( unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.receive_message, &args);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.receive_message, &args);
     }
 
-    for(int i=0, len=level_event_receivers.size(); i<len; ++i){
-        Object* obj = scenegraph->GetObjectFromID(level_event_receivers[i]);
+    for(int level_event_receiver : level_event_receivers){
+        Object* obj = scenegraph->GetObjectFromID(level_event_receiver);
         if(obj){
             obj->ReceiveScriptMessage("level_event " + msg);
         } else {
             const int kBufSize = 256;
             char buf[kBufSize];
-            FormatString(buf, kBufSize, "Could not find level event receiver with id %d", level_event_receivers[i]);
+            FormatString(buf, kBufSize, "Could not find level event receiver with id %d", level_event_receiver);
             DisplayError("Error", buf);
         }
     }
@@ -789,11 +788,11 @@ void Level::DefineLevelTypePublic(ASContext *as_context) {
 
 void Level::GetCollidingObjects( int id, CScriptArray *array ) {
     int collision[2];
-    for(CollisionMap::iterator iter = old_col_map_.begin(); iter != old_col_map_.end(); ++iter){
-        collision[0] = iter->first;
-        CollisionSet &set = iter->second;
-        for(CollisionSet::iterator iter = set.begin(); iter != set.end(); ++iter){
-            collision[1] = *iter;
+    for(auto & iter : old_col_map_){
+        collision[0] = iter.first;
+        CollisionSet &set = iter.second;
+        for(int iter : set){
+            collision[1] = iter;
             if(collision[0] == id){
                 array->InsertLast(&collision[1]);
             } else if(collision[1] == id){
@@ -805,16 +804,16 @@ void Level::GetCollidingObjects( int id, CScriptArray *array ) {
 
 void Level::Draw() {
 	PROFILER_GPU_ZONE(g_profiler_ctx, "Level::Draw");
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.draw_gui);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.draw_gui);
     }
 	hud_images.Draw();
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-		as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.draw_gui2);
+    for(auto & as_context : as_contexts_) {
+		as_context.ctx->CallScriptFunction(as_context.as_funcs.draw_gui2);
 	}
     hud_images.Draw();
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.draw_gui3);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.draw_gui3);
     }
     hud_images.Draw();
 }
@@ -824,8 +823,7 @@ void Level::SetFromLevelInfo( const LevelInfo &li ) {
     pc_script_ = li.pc_script_;
     npc_script_ = li.npc_script_;
     level_script_paths.clear();
-    for(int i=0, len=li.script_paths_.size(); i<len; ++i){
-        const LevelInfo::StrPair &script_path = li.script_paths_[i];
+    for(const auto & script_path : li.script_paths_){
         level_script_paths[script_path.first] = script_path.second;
     }
     recently_created_items_ = li.recently_created_items_; 
@@ -843,8 +841,8 @@ bool Level::HasFocus() {
     ASArg return_arg;
     return_arg.data = &has_focus;
     return_arg.type = _as_bool;
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.has_focus, &args, &return_arg);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.has_focus, &args, &return_arg);
         if(has_focus) {
             return true;
         }
@@ -858,8 +856,8 @@ bool Level::DialogueCameraControl() {
     ASArg return_arg;
     return_arg.data = &dialogue_control;
     return_arg.type = _as_bool;
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.dialogue_camera_control, &args, &return_arg);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.dialogue_camera_control, &args, &return_arg);
         if(dialogue_control) {
             return true;
         }
@@ -890,8 +888,8 @@ void Level::SaveHistoryState(std::list<SavedChunk> & chunks, int state_id) {
 
     ASArglist args;
     args.AddAddress(&saved_chunk);
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.save_history_state, &args);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.save_history_state, &args);
     }
     AddChunkToHistory(chunks, state_id, saved_chunk);
 }
@@ -900,8 +898,8 @@ void Level::ReadChunk(const SavedChunk &the_chunk) {
     ASArglist args;
     args.AddAddress((void*)&the_chunk);
 
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.read_chunk, &args);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.read_chunk, &args);
     }
 }
 
@@ -910,9 +908,9 @@ bool Level::isMetaDataDirty() {
         return true;
     }
 
-    for(size_t i = 0; i < scenegraph->objects_.size(); ++i) {
-        if(scenegraph->objects_[i]->GetType() == _placeholder_object) {
-            PlaceholderObject* obj = (PlaceholderObject*)scenegraph->objects_[i];
+    for(auto & object : scenegraph->objects_) {
+        if(object->GetType() == _placeholder_object) {
+            PlaceholderObject* obj = (PlaceholderObject*)object;
             if(obj->GetScriptParams()->HasParam("Dialogue")) {
                 if(obj->unsaved_changes) {
                     return true;
@@ -926,9 +924,9 @@ bool Level::isMetaDataDirty() {
 
 void Level::setMetaDataClean() {
     metaDataDirty = false;
-    for(size_t i = 0; i < scenegraph->objects_.size(); ++i) {
-        if(scenegraph->objects_[i]->GetType() == _placeholder_object) {
-            ((PlaceholderObject*)scenegraph->objects_[i])->unsaved_changes = false;
+    for(auto & object : scenegraph->objects_) {
+        if(object->GetType() == _placeholder_object) {
+            ((PlaceholderObject*)object)->unsaved_changes = false;
         }
     }
 }
@@ -954,8 +952,8 @@ void Level::WindowResized(ivec2 value ) {
     ASArglist args;
     args.Add(value[0]);
     args.Add(value[1]);
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.set_window_dimensions, &args);
+    for(auto & as_context : as_contexts_) {
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.set_window_dimensions, &args);
     }
 }
 
@@ -977,8 +975,8 @@ std::vector<SpawnerItem> Level::GetRecentlyCreatedItems() {
 }
 
 void Level::IncomingTCPData(SocketID socket, uint8_t* data, size_t len) {
-    for(unsigned i = 0; i < as_contexts_.size(); i++ ) {
-        asIScriptEngine *engine = as_contexts_[i].ctx->GetEngine();
+    for(auto & as_context : as_contexts_) {
+        asIScriptEngine *engine = as_context.ctx->GetEngine();
         asITypeInfo *arrayType = engine->GetTypeInfoByDecl("array<uint8>");
 
         CScriptArray* array = CScriptArray::Create(arrayType);
@@ -992,7 +990,7 @@ void Level::IncomingTCPData(SocketID socket, uint8_t* data, size_t len) {
         args.Add(socket);
         args.AddAddress((void*)array);
 
-        as_contexts_[i].ctx->CallScriptFunction(as_contexts_[i].as_funcs.incoming_tcp_data, &args, NULL); 
+        as_context.ctx->CallScriptFunction(as_context.as_funcs.incoming_tcp_data, &args, NULL); 
 
         array->Release();
     }

--- a/Source/Game/levelinfo.cpp
+++ b/Source/Game/levelinfo.cpp
@@ -43,8 +43,8 @@ void LevelInfo::Print()
     LOGI << "Script: " << script_ << std::endl;
     terrain_info_.Print();
 
-    for(unsigned i=0; i<ambient_sounds_.size(); ++i){
-        LOGI << "Ambient sound: " << ambient_sounds_[i] << std::endl;
+    for(auto & ambient_sound : ambient_sounds_){
+        LOGI << "Ambient sound: " << ambient_sound << std::endl;
     }
 
     sky_info_.Print();
@@ -76,17 +76,17 @@ void LevelInfo::ReturnPaths( PathSet &path_set )
     static const int kBufSize = 256;
     char buf[kBufSize];
     path_set.insert("level "+path_);
-    for(unsigned i=0; i<ambient_sounds_.size(); ++i){
-        path_set.insert("sound "+ambient_sounds_[i]+"_1.wav");
-        path_set.insert("sound "+ambient_sounds_[i]+"_2.wav");
-        path_set.insert("sound "+ambient_sounds_[i]+"_3.wav");
+    for(auto & ambient_sound : ambient_sounds_){
+        path_set.insert("sound "+ambient_sound+"_1.wav");
+        path_set.insert("sound "+ambient_sound+"_2.wav");
+        path_set.insert("sound "+ambient_sound+"_3.wav");
     }
     terrain_info_.ReturnPaths(path_set);
     sky_info_.ReturnPaths(path_set);
-    for(unsigned i=0; i<script_paths_.size(); ++i){
-        FormatString(buf, kBufSize, "Finding script paths: %s", script_paths_[i].first.c_str());
+    for(auto & script_path : script_paths_){
+        FormatString(buf, kBufSize, "Finding script paths: %s", script_path.first.c_str());
         PROFILER_ZONE_DYNAMIC_STRING(g_profiler_ctx, buf);
-        ReturnPathUtil::ReturnPathsFromPath(script_paths_[i].second, path_set);
+        ReturnPathUtil::ReturnPathsFromPath(script_path.second, path_set);
     }
     for(unsigned i=0; i<desc_list_.size(); ++i){
         FormatString(buf, kBufSize, "Finding desc_list paths: %d", i);

--- a/Source/Game/paths.cpp
+++ b/Source/Game/paths.cpp
@@ -39,9 +39,9 @@ void AIPaths::Draw() {
                                              vec4(0.0f,0.5f,0.5f,0.5f),
                                              _delete_on_draw);
     }
-    for(unsigned i=0; i<connections.size(); ++i){
-        DebugDraw::Instance()->AddLine(GetPointPosition(connections[i].point_ids[0]),
-                                       GetPointPosition(connections[i].point_ids[1]),
+    for(auto & connection : connections){
+        DebugDraw::Instance()->AddLine(GetPointPosition(connection.point_ids[0]),
+                                       GetPointPosition(connection.point_ids[1]),
                                        vec4(0.0f,0.5f,0.5f,0.5f), 
                                        _delete_on_draw);
     }
@@ -78,12 +78,12 @@ vec3 AIPaths::GetPointPosition( int point_id ) {
 
 int AIPaths::GetConnectedPoint( int point_id )
 {
-    for(unsigned i=0; i<connections.size(); ++i){
-        if(connections[i].point_ids[0] == point_id){
-            return connections[i].point_ids[1];
+    for(auto & connection : connections){
+        if(connection.point_ids[0] == point_id){
+            return connection.point_ids[1];
         }
-        if(connections[i].point_ids[1] == point_id){
-            return connections[i].point_ids[0];
+        if(connection.point_ids[1] == point_id){
+            return connection.point_ids[0];
         }
     }
     return -1;
@@ -91,14 +91,14 @@ int AIPaths::GetConnectedPoint( int point_id )
 
 int AIPaths::GetOtherConnectedPoint( int point_id, int other_id )
 {
-    for(unsigned i=0; i<connections.size(); ++i){
-        if(connections[i].point_ids[0] == point_id &&
-           connections[i].point_ids[1] != other_id){
-            return connections[i].point_ids[1];
+    for(auto & connection : connections){
+        if(connection.point_ids[0] == point_id &&
+           connection.point_ids[1] != other_id){
+            return connection.point_ids[1];
         }
-        if(connections[i].point_ids[1] == point_id &&
-           connections[i].point_ids[0] != other_id){
-            return connections[i].point_ids[0];
+        if(connection.point_ids[1] == point_id &&
+           connection.point_ids[0] != other_id){
+            return connection.point_ids[0];
         }
     }
     return -1;

--- a/Source/Game/reactionscript.cpp
+++ b/Source/Game/reactionscript.cpp
@@ -36,9 +36,9 @@ void ReactionScriptGetter::Load( std::string _path ) {
     } else {
         mirror = false;
     }
-    for(unsigned i=0; i<items.size(); ++i){
-        if(items[i]->HasReactionOverride(path)){
-            path = items[i]->GetReactionOverride(path);
+    for(auto & item : items){
+        if(item->HasReactionOverride(path)){
+            path = item->GetReactionOverride(path);
         }
     }
     //reaction_ref = Reactions::Instance()->ReturnRef(path);

--- a/Source/Game/savefile.cpp
+++ b/Source/Game/savefile.cpp
@@ -102,11 +102,11 @@ namespace {
 }
 
 SavedLevel& SaveFile::GetSavedLevelDeprecated( const std::string& name ) {
-    for( size_t i = 0; i < levels_.size(); i++ ) {
-        if( levels_[i].campaign_id_ == "" &&
-            levels_[i].save_category_ == "" &&
-            levels_[i].save_name_ == name ) {
-                return levels_[i];
+    for(auto & level : levels_) {
+        if( level.campaign_id_ == "" &&
+            level.save_category_ == "" &&
+            level.save_name_ == name ) {
+                return level;
         }
     }
 
@@ -119,11 +119,11 @@ SavedLevel& SaveFile::GetSavedLevelDeprecated( const std::string& name ) {
 }
 
 SavedLevel& SaveFile::GetSave(const std::string campaign_id, const std::string save_category, const std::string level_name) {
-    for( size_t i = 0; i < levels_.size(); i++ ) {
-        if( levels_[i].campaign_id_ == campaign_id &&
-            levels_[i].save_category_ == save_category &&
-            levels_[i].save_name_ == level_name ) {
-                return levels_[i];
+    for(auto & level : levels_) {
+        if( level.campaign_id_ == campaign_id &&
+            level.save_category_ == save_category &&
+            level.save_name_ == level_name ) {
+                return level;
         }
     }
 
@@ -146,10 +146,10 @@ size_t SaveFile::GetSaveCount() {
 }
 
 bool SaveFile::SaveExist(const std::string campaign_id, const std::string save_category, const std::string level_name) {
-    for( size_t i = 0; i < levels_.size(); i++ ) {
-        if( levels_[i].campaign_id_ == campaign_id &&
-            levels_[i].save_category_ == save_category &&
-            levels_[i].save_name_ == level_name ) {
+    for(auto & level : levels_) {
+        if( level.campaign_id_ == campaign_id &&
+            level.save_category_ == save_category &&
+            level.save_name_ == level_name ) {
                 return true;
         }
     }
@@ -313,17 +313,17 @@ bool SaveFile::SerializeToRAM( std::vector<uint8_t> *mem_ptr ) {
     if(!file.WriteBytes(&num_levels, sizeof(num_levels))){
         return false;
     }
-    for(std::vector<SavedLevel>::iterator it = levels_.begin(); it != levels_.end(); ++it){
-        if(!WriteString(&file, &it->campaign_id_)){
+    for(auto & level : levels_){
+        if(!WriteString(&file, &level.campaign_id_)){
             return false;
         }
-        if(!WriteString(&file, &it->save_category_)){
+        if(!WriteString(&file, &level.save_category_)){
             return false;
         }
-        if(!WriteString(&file, &it->save_name_)){
+        if(!WriteString(&file, &level.save_name_)){
             return false;
         }
-        if(!it->SerializeToRAM(&file)){
+        if(!level.SerializeToRAM(&file)){
             return false;
         }
     }
@@ -442,8 +442,8 @@ void SavedLevel::AppendArrayValue(const std::string &key, const std::string& val
 
 bool SavedLevel::ArrayContainsValue(const std::string &key, const std::string& val) {
     std::vector<std::string> &v = array_data_[key];
-    for( size_t i = 0; i < v.size(); i++ ) {
-        if(v[i] == val){
+    for(auto & i : v) {
+        if(i == val){
             return true; 
         }
     }
@@ -497,11 +497,11 @@ bool SavedLevel::SerializeToRAM( MemWriteFileDescriptor *file_ptr ) {
         if(!file.WriteBytes(&num_saved_vals, sizeof(num_saved_vals))){
             return false;
         }
-        for(DataMap::iterator it = data_.begin(); it != data_.end(); ++it){
-            if(!WriteString(&file, &it->first)){
+        for(auto & it : data_){
+            if(!WriteString(&file, &it.first)){
                 return false;
             }
-            if(!WriteString(&file, &it->second)){
+            if(!WriteString(&file, &it.second)){
                 return false;
             }
         }
@@ -512,17 +512,17 @@ bool SavedLevel::SerializeToRAM( MemWriteFileDescriptor *file_ptr ) {
         if(!file.WriteBytes(&num_saved_array_vals, sizeof(num_saved_array_vals))){
             return false;
         }
-        for(ArrayDataMap::iterator it = array_data_.begin(); it != array_data_.end(); it++) {
-            if(!WriteString(&file, &it->first)){
+        for(auto & it : array_data_) {
+            if(!WriteString(&file, &it.first)){
                 return false;
             }
 
-            uint16_t num_saved_array_sub_vals = it->second.size();
+            uint16_t num_saved_array_sub_vals = it.second.size();
             if(!file.WriteBytes(&num_saved_array_sub_vals, sizeof(num_saved_array_sub_vals))){
                 return false;
             }
 
-            for(std::vector<std::string>::iterator it2 = it->second.begin(); it2 != it->second.end(); it2++) {
+            for(std::vector<std::string>::iterator it2 = it.second.begin(); it2 != it.second.end(); it2++) {
                 if(!WriteString(&file, &(*it2))){
                     return false; 
                 } 
@@ -535,11 +535,11 @@ bool SavedLevel::SerializeToRAM( MemWriteFileDescriptor *file_ptr ) {
         if(!file.WriteBytes(&num_saved_int32_vals, sizeof(num_saved_int32_vals))){
             return false;
         }
-        for(Int32Map::iterator it = data_int32_.begin(); it != data_int32_.end(); ++it){
-            if(!WriteString(&file, &it->first)){
+        for(auto & it : data_int32_){
+            if(!WriteString(&file, &it.first)){
                 return false;
             }
-            int32_t val = it->second;
+            int32_t val = it.second;
             if(!file.WriteBytes(&val, sizeof(val))){
                 return false;
             }

--- a/Source/Game/terraininfo.cpp
+++ b/Source/Game/terraininfo.cpp
@@ -43,14 +43,14 @@ void TerrainInfo::Print()
     LOGI << "Model Override: " << model_override << std::endl;
     LOGI << "Shader Extra: " << shader_extra << std::endl;
     LOGI << "Detail maps:" << std::endl;
-    for (unsigned i=0; i<detail_map_info.size(); ++i)
+    for (auto & i : detail_map_info)
     {
-        detail_map_info[i].Print();
+        i.Print();
     }
     LOGI << "Detail objects: " << std::endl;
-    for (unsigned i=0; i<detail_object_info.size(); ++i)
+    for (auto & i : detail_object_info)
     {
-        LOGI << "Obj path: " << detail_object_info[i].obj_path << std::endl;
+        LOGI << "Obj path: " << i.obj_path << std::endl;
     }    
 }
 
@@ -76,10 +76,10 @@ void TerrainInfo::ReturnPaths( PathSet &path_set )
     if(!model_override.empty()){
         path_set.insert("model "+model_override);
     }
-    for(unsigned i=0; i<detail_map_info.size(); ++i){
-        detail_map_info[i].ReturnPaths(path_set);
+    for(auto & i : detail_map_info){
+        i.ReturnPaths(path_set);
     }
-    for(unsigned i=0; i<detail_object_info.size(); ++i){
-        detail_object_info[i].ReturnPaths(path_set);
+    for(auto & i : detail_object_info){
+        i.ReturnPaths(path_set);
     }
 }

--- a/Source/Graphics/animationclient.cpp
+++ b/Source/Graphics/animationclient.cpp
@@ -129,8 +129,8 @@ std::queue<AnimationEvent> AnimationClient::GetActiveEvents() {
             events.pop();
         }
     }
-    for(unsigned i=0; i<layers.size(); ++i){
-        std::queue<AnimationEvent> &events = layers[i].reader.GetActiveEvents();
+    for(auto & layer : layers){
+        std::queue<AnimationEvent> &events = layer.reader.GetActiveEvents();
         while(!events.empty()){
             total_events.push(events.front());
             events.pop();
@@ -157,8 +157,8 @@ void AnimationClient::Update(float timestep) {
         }
     }
     fade_out.Update(blendmap, as_context, timestep);
-    for(unsigned i=0; i<layers.size(); ++i){
-        layers[i].fade_out.Update(blendmap, as_context, timestep);
+    for(auto & layer : layers){
+        layer.fade_out.Update(blendmap, as_context, timestep);
     }
     UpdateLayers(timestep);
 }
@@ -240,8 +240,8 @@ void AnimationClient::GetMatrices( AnimOutput &anim_output, const std::vector<in
 
 	// Apply character rotation modifier
     std::map<int, WeapAnimInfo> &weap_anim_info_map = ang_anim_output.weap_anim_info_map;
-    for(int i=0, len=ang_anim_output.ik_bones.size(); i<len; ++i){
-        ang_anim_output.ik_bones[i].unmodified_transform = ang_anim_output.ik_bones[i].transform;
+    for(auto & ik_bone : ang_anim_output.ik_bones){
+        ik_bone.unmodified_transform = ik_bone.transform;
     }
 
     anim_output.unmodified_matrices = matrices;
@@ -348,8 +348,8 @@ void FadeCollection::clear()
 float FadeCollection::GetOpac()
 {
     float opac = 1.0f;
-    for(unsigned i=0; i<fade_out.size(); ++i){
-        opac *= (1.0f-fade_out[i].opac);
+    for(auto & i : fade_out){
+        opac *= (1.0f-i.opac);
     }
     return opac;
 }

--- a/Source/Graphics/animationreader.cpp
+++ b/Source/Graphics/animationreader.cpp
@@ -102,10 +102,10 @@ bool AnimationReader::IncrementTime( const BlendMap &blendmap, float timestep ) 
 }
 
 float AnimationReader::GetTimeUntilEvent(const std::string &event){
-    for(unsigned i=0; i<events.size(); ++i){
-        if(events[i].event.event_string == event){
-            if(events[i].time > normalized_time){
-                return (*anim).AbsoluteTimeFromNormalized(events[i].time - normalized_time) / speed_mult * 0.001f;
+    for(auto & i : events){
+        if(i.event.event_string == event){
+            if(i.time > normalized_time){
+                return (*anim).AbsoluteTimeFromNormalized(i.time - normalized_time) / speed_mult * 0.001f;
             }
         }
     }
@@ -207,8 +207,8 @@ void AnimationReader::AttachTo( const AnimationAssetRef &_ref ) {
     last_rotation = 0.0f;
     skip_offset = false;
     callback_string.clear();
-    for(int i=0; i<_max_animated_items; ++i){
-        animated_item_ids[i] = -1;
+    for(int & animated_item_id : animated_item_ids){
+        animated_item_id = -1;
     }
     const AnimationAsset &anim = (*_ref);
     int anim_id = 0;
@@ -280,8 +280,8 @@ AnimationReader::AnimationReader():
     mirrored(false),
     speed_mult(1.0f)
 {
-    for(int i=0; i<_max_animated_items; ++i){
-        animated_item_ids[i] = -1;
+    for(int & animated_item_id : animated_item_ids){
+        animated_item_id = -1;
     }
 }
 
@@ -348,9 +348,9 @@ void AnimationReader::GetPrevEvents( const BlendMap &blendmap, float timestep ) 
 
 float AnimationReader::GetAnimationEventTime( const std::string & event_name, const BlendMap &blend_map ) const
 {
-    for(unsigned i=0; i<events.size(); ++i){
-        if(events[i].time > normalized_time && events[i].event.event_string == event_name){
-            float time = events[i].time - normalized_time;
+    for(const auto & event : events){
+        if(event.time > normalized_time && event.event.event_string == event_name){
+            float time = event.time - normalized_time;
             const AnimationAsset &anim_asset = (*anim);
             time /= anim_asset.GetFrequency(blend_map);
             return time;

--- a/Source/Graphics/bloodsurface.cpp
+++ b/Source/Graphics/bloodsurface.cpp
@@ -310,8 +310,8 @@ void BloodSurface::Update(SceneGraph *scenegraph, float timestep, bool force_upd
             }
 
             PROFILER_ENTER(g_profiler_ctx, "Fill blood_points in Update texture");
-            for(std::vector<WalkLine>::iterator iter = trace[i].begin(); iter != trace[i].end(); ++iter) {
-                const int face_index = (*iter).tri*3;
+            for(auto & iter : trace[i]) {
+                const int face_index = iter.tri*3;
                 vec2 tex_coords[3];
                 for(int i=0; i<3; ++i){
                     int index = model->faces[face_index+i]*2;
@@ -320,12 +320,12 @@ void BloodSurface::Update(SceneGraph *scenegraph, float timestep, bool force_upd
                     }
                 }
 
-                const vec3 &start = (*iter).start;
+                const vec3 &start = iter.start;
                 vec2 start_uv = tex_coords[0] * start[0] +
                     tex_coords[1] * start[1] +
                     tex_coords[2] * start[2];
 
-                const vec3 &end = (*iter).end;
+                const vec3 &end = iter.end;
                 vec2 end_uv = tex_coords[0] * end[0] +
                     tex_coords[1] * end[1] +
                     tex_coords[2] * end[2];
@@ -341,17 +341,15 @@ void BloodSurface::Update(SceneGraph *scenegraph, float timestep, bool force_upd
             }
             if(i==0){
                 blood_points.reserve(blood_points.size()+cut_lines.size()*40);
-                for(std::vector<CutLine>::iterator iter = cut_lines.begin();
-                    iter != cut_lines.end();
-                    ++iter)
+                for(auto & cut_line : cut_lines)
                 {
                     for(unsigned i=0; i<10; ++i){
                         vec2 test_offset(RangedRandomFloat(-ts,ts),
                             RangedRandomFloat(-ts,ts));
-                        blood_points.push_back(iter->start[0]+test_offset[0]);
-                        blood_points.push_back(iter->start[1]+test_offset[1]);
-                        blood_points.push_back(iter->end[0]+test_offset[0]);
-                        blood_points.push_back(iter->end[1]+test_offset[1]);
+                        blood_points.push_back(cut_line.start[0]+test_offset[0]);
+                        blood_points.push_back(cut_line.start[1]+test_offset[1]);
+                        blood_points.push_back(cut_line.end[0]+test_offset[0]);
+                        blood_points.push_back(cut_line.end[1]+test_offset[1]);
                     }
                 }
                 cut_lines.clear();

--- a/Source/Graphics/camera.cpp
+++ b/Source/Graphics/camera.cpp
@@ -643,12 +643,12 @@ void Camera::calcFrustumPlanes( const mat4 &_p, const mat4 &_mv ) {
 //Check if a sphere is visible
 int Camera::checkSphereInFrustum( vec3 where, float radius ) const {
     int sphere_in_frustum = 2;
-    for (int i = 0; i < 6; ++i ) {
+    for (auto frustumPlane : frustumPlanes) {
         float d = 
-            frustumPlanes[i][0] * where.x() +
-            frustumPlanes[i][1] * where.y() +
-            frustumPlanes[i][2] * where.z() +
-            frustumPlanes[i][3];
+            frustumPlane[0] * where.x() +
+            frustumPlane[1] * where.y() +
+            frustumPlane[2] * where.z() +
+            frustumPlane[3];
         if( d <= -radius ) {
             return 0; // Sphere is entirely outside one of the frustum planes
         } else if(d < radius){
@@ -704,13 +704,13 @@ void Camera::checkSpheresInFrustum(int count, float* where_x, float* where_y, fl
         __m128 is_in_view_distance = _mm_cmplt_ps(distance_squared, cull_distance_squared4);
         inside = _mm_and_ps(inside, is_in_view_distance);
 
-        for (unsigned p = 0; p < 6; ++p) {
-            const __m128& plane_n_x4 = simdFrustumPlanes[p].normal_x;
-            const __m128& plane_n_y4 = simdFrustumPlanes[p].normal_y;
-            const __m128& plane_n_z4 = simdFrustumPlanes[p].normal_z;
+        for (const auto & simdFrustumPlane : simdFrustumPlanes) {
+            const __m128& plane_n_x4 = simdFrustumPlane.normal_x;
+            const __m128& plane_n_y4 = simdFrustumPlane.normal_y;
+            const __m128& plane_n_z4 = simdFrustumPlane.normal_z;
             __m128 n_dot_pos = simd_dot_product(where_x4, where_y4, where_z4, plane_n_x4, plane_n_y4, plane_n_z4);
 
-            __m128 plane_test = _mm_cmpgt_ps(_mm_add_ps(n_dot_pos, simdFrustumPlanes[p].d), neg_radius4);
+            __m128 plane_test = _mm_cmpgt_ps(_mm_add_ps(n_dot_pos, simdFrustumPlane.d), neg_radius4);
             inside = _mm_and_ps(inside, plane_test);
         }
 
@@ -731,12 +731,12 @@ void Camera::checkSpheresInFrustum(int count, float* where_x, float* where_y, fl
             center_to_cam[2] * center_to_cam[2];
 
         if (distance_squared < cull_distance_squared) {
-            for (int p = 0; p < 6; ++p) {
+            for (auto frustumPlane : frustumPlanes) {
                 float n_dot_pos =
-                    frustumPlanes[p][0] * where_x[i] +
-                    frustumPlanes[p][1] * where_y[i] +
-                    frustumPlanes[p][2] * where_z[i];
-                bool plane_test = n_dot_pos + frustumPlanes[p][3] > -radius;
+                    frustumPlane[0] * where_x[i] +
+                    frustumPlane[1] * where_y[i] +
+                    frustumPlane[2] * where_z[i];
+                bool plane_test = n_dot_pos + frustumPlane[3] > -radius;
                 inside = inside && plane_test;
             }
         } else {
@@ -754,7 +754,7 @@ int Camera::checkBoxInFrustum(vec3 start, vec3 end) const
     int total_in = 0;
     vec3 point;
 
-    for(int p = 0; p < 6; ++p) {
+    for(auto frustumPlane : frustumPlanes) {
     
         int in_count = 8;
         bool box_in_frustum = 1;
@@ -768,10 +768,10 @@ int Camera::checkBoxInFrustum(vec3 start, vec3 end) const
             else point.z()=end.z();
 
             // test this point against the planes
-            if( frustumPlanes[p][0] * point.x() +
-                frustumPlanes[p][1] * point.y() +
-                frustumPlanes[p][2] * point.z() +
-                frustumPlanes[p][3] < 0) {
+            if( frustumPlane[0] * point.x() +
+                frustumPlane[1] * point.y() +
+                frustumPlane[2] * point.z() +
+                frustumPlane[3] < 0) {
                 box_in_frustum = 0;
                 in_count--;
             }

--- a/Source/Graphics/csg.cpp
+++ b/Source/Graphics/csg.cpp
@@ -203,13 +203,13 @@ namespace {
     struct vec3d {
         double entries[3];
         vec3d(double val){
-            for(double & entrie : entries){
-                entrie = val;
+            for(double & entry : entries){
+                entry = val;
             }
         }
         vec3d(){
-            for(double & entrie : entries){
-                entrie = 0.0;
+            for(double & entry : entries){
+                entry = 0.0;
             }
         }
         double& operator[](int which){
@@ -1056,8 +1056,8 @@ void AddCSGResult(const CSGResult &result, CSGModelInfo *csg_model, const Model&
     csg_model->faces.reserve(csg_model->faces.size()+result.indices.size());
     int old_faces = csg_model->verts.size()/3;
     if(!flip){
-        for(int indice : result.indices){
-            csg_model->faces.push_back(indice + old_faces);
+        for(int index : result.indices){
+            csg_model->faces.push_back(index + old_faces);
         }
     } else {
         for(int i=0, len=result.indices.size(); i<len; i+=3){

--- a/Source/Graphics/csg.cpp
+++ b/Source/Graphics/csg.cpp
@@ -58,9 +58,9 @@ namespace Test {
         temp_points[0][1] = a.edge->points[1];
         temp_points[1][0] = b.edge->points[0];
         temp_points[1][1] = b.edge->points[1];
-        for(int i=0; i<2; ++i){
-            if(temp_points[i][0] > temp_points[i][1]){
-                std::swap(temp_points[i][0], temp_points[i][1]);
+        for(auto & temp_point : temp_points){
+            if(temp_point[0] > temp_point[1]){
+                std::swap(temp_point[0], temp_point[1]);
             }
         }
         if(temp_points[0][0] == temp_points[1][0]){
@@ -119,9 +119,9 @@ namespace {
             points[0][i] = a.points[i];
             points[1][i] = b.points[i];
         }
-        for(int i=0; i<2; ++i){
-            if(points[i][0] > points[i][1]){
-                std::swap(points[i][0], points[i][1]);
+        for(auto & point : points){
+            if(point[0] > point[1]){
+                std::swap(point[0], point[1]);
             }
         }
         if(points[0][0] == points[1][0]){
@@ -203,13 +203,13 @@ namespace {
     struct vec3d {
         double entries[3];
         vec3d(double val){
-            for(int i=0; i<3; ++i){
-                entries[i] = val;
+            for(double & entrie : entries){
+                entrie = val;
             }
         }
         vec3d(){
-            for(int i=0; i<3; ++i){
-                entries[i] = 0.0;
+            for(double & entrie : entries){
+                entrie = 0.0;
             }
         }
         double& operator[](int which){
@@ -583,8 +583,8 @@ namespace {
         }
         std::sort(vert_sort.begin(), vert_sort.end(), VertSortById);
         // -- set faces to use merge targets
-        for(int i=0, len=faces.size(); i<len; ++i){
-            faces[i] = vert_sort[faces[i]].merge_target;
+        for(int & face : faces){
+            face = vert_sort[face].merge_target;
         }
         if(remove_degenerate_faces){
             // -- remove degenerate faces
@@ -618,8 +618,8 @@ namespace {
             shape->vertices.push_back(vec[2]);
         }
         shape->faces.reserve(model.faces.size());
-        for(int i=0, len=model.faces.size(); i<len; ++i){
-            shape->faces.push_back(model.faces[i]);
+        for(unsigned int face : model.faces){
+            shape->faces.push_back(face);
         }
         // Create Bullet collision shape
         shape->vertices_float.reserve(shape->vertices.size());
@@ -765,10 +765,10 @@ namespace {
                 edge_angle.reserve(on_edge.size());
                 vec2d mid_point;
                 mid_point = (triangle_points[0].flat_coord + triangle_points[1].flat_coord + triangle_points[2].flat_coord) * (1.0 / 3.0);
-                for(int j=0, len=on_edge.size(); j<len; ++j){
+                for(int j : on_edge){
                     EdgeAngleSort eas;
-                    eas.second = on_edge[j];
-                    vec2d offset = triangle_points[on_edge[j]].flat_coord - mid_point;
+                    eas.second = j;
+                    vec2d offset = triangle_points[j].flat_coord - mid_point;
                     eas.first = atan2(offset[1], offset[0]);
                     edge_angle.push_back(eas);
                 }
@@ -817,21 +817,21 @@ namespace {
                     triangle_points.resize(index+1);
                 }
                 // Remap edges to new points
-                for(int i=0, len=edges.size(); i<len; ++i){
-                    edges[i] = triangle_point_remap[edges[i]];
+                for(int & edge : edges){
+                    edge = triangle_point_remap[edge];
                 }
-                for(int i=0, len=labeled_edges.size(); i<len; ++i){
-                    labeled_edges[i].points[0] = triangle_point_remap[labeled_edges[i].points[0]];
-                    labeled_edges[i].points[1] = triangle_point_remap[labeled_edges[i].points[1]];
-                    if(labeled_edges[i].points[0] > labeled_edges[i].points[1]){
-                        std::swap(labeled_edges[i].points[0], labeled_edges[i].points[1]);
+                for(auto & labeled_edge : labeled_edges){
+                    labeled_edge.points[0] = triangle_point_remap[labeled_edge.points[0]];
+                    labeled_edge.points[1] = triangle_point_remap[labeled_edge.points[1]];
+                    if(labeled_edge.points[0] > labeled_edge.points[1]){
+                        std::swap(labeled_edge.points[0], labeled_edge.points[1]);
                     }
                 }
                 // Get points to input to triangulation
                 std::vector<float> points;
-                for(int i=0, len=triangle_points.size(); i<len; ++i){
+                for(auto & triangle_point : triangle_points){
                     for(int j=0; j<2; ++j){
-                        points.push_back((float)triangle_points[i].flat_coord[j]);
+                        points.push_back((float)triangle_point.flat_coord[j]);
                     }
                 }
                 // Triangulate
@@ -839,10 +839,10 @@ namespace {
                 TriangulateWrapper(points, edges, faces);
                 // Add new vertices
                 int vert_start = output.new_bary->size()/3;
-                for(int j=0, len=triangle_points.size(); j<len; ++j){
+                for(auto & triangle_point : triangle_points){
                     for(int k=0; k<3; ++k){
-                        output.new_vertices->push_back(triangle_points[j].coord[k]);
-                        output.new_bary->push_back(triangle_points[j].bary[k]);
+                        output.new_vertices->push_back(triangle_point.coord[k]);
+                        output.new_bary->push_back(triangle_point.bary[k]);
                         output.new_vert_tri_points->push_back(tri_vert_id[k]);
                     }
                 }
@@ -937,8 +937,7 @@ namespace {
                 }
                 std::vector<TrianglePoint::Side> triangle_side(faces.size()/3, TrianglePoint::UNKNOWN);
                 // Get outside/inside of edges neighboring edge
-                for(int i=0, len=labeled_edges.size(); i<len; ++i){
-                    LabeledEdge &edge = labeled_edges[i];
+                for(auto & edge : labeled_edges){
                     if(edge.side == TrianglePoint::EDGE && edge.points[2] != -1){
                         vec3d opposite_vert = triangle_points[edge.points[2]].coord;
                         vec3d mid_point = (triangle_points[edge.points[0]].coord + triangle_points[edge.points[1]].coord)*0.5f;
@@ -978,11 +977,11 @@ namespace {
                     }
                     tri_queue.pop();
                 }
-                for(int j=0, len=faces.size(); j<len; ++j){
-                    output.new_faces->push_back(faces[j]+vert_start);
+                for(unsigned int face : faces){
+                    output.new_faces->push_back(face+vert_start);
                 }
-                for(int j=0, len=triangle_side.size(); j<len; ++j){
-                    output.new_triangle_sides->push_back(triangle_side[j]);
+                for(auto & j : triangle_side){
+                    output.new_triangle_sides->push_back(j);
                 }
                 old_index = new_index;
             }
@@ -1006,8 +1005,7 @@ namespace {
     void MergeTriIntersects(std::vector<TriIntersectInfo> &tri_intersect_info) {
         std::vector<vec3d> test_points;
         std::vector<MergeDist> test_point_distances;
-        for(int i=0, len=tri_intersect_info.size(); i<len; ++i){
-            TriIntersectInfo& tii = tri_intersect_info[i];
+        for(auto & tii : tri_intersect_info){
             test_points.push_back(tii.tri_intersect.true_intersect[0]);
             test_points.push_back(tii.tri_intersect.true_intersect[1]);
         }
@@ -1029,8 +1027,7 @@ namespace {
             }
         }
         std::sort(test_point_distances.begin(), test_point_distances.end());
-        for(int i=0, len=test_point_distances.size(); i<len; ++i){
-            MergeDist &tpd = test_point_distances[i];
+        for(auto & tpd : test_point_distances){
             test_points[tpd.point[1]] = test_points[tpd.point[0]];
         }
         for(int i=0, index=0, len=tri_intersect_info.size(); i<len; ++i, index+=2){
@@ -1047,8 +1044,8 @@ bool CheckShapeValid(const std::vector<int> &faces, const std::vector<double> &v
     TriNeighborInfo tri_neighbor_info;
     GetTriNeighbors(merged_faces, vertices, &tri_neighbor_info, true);
     bool non_three_neighbor = false;
-    for(int i=0, len=tri_neighbor_info.num_tri_neighbors.size(); i<len; ++i){
-        if(tri_neighbor_info.num_tri_neighbors[i] != 3){
+    for(int num_tri_neighbor : tri_neighbor_info.num_tri_neighbors){
+        if(num_tri_neighbor != 3){
             non_three_neighbor = true;
         }
     }
@@ -1059,8 +1056,8 @@ void AddCSGResult(const CSGResult &result, CSGModelInfo *csg_model, const Model&
     csg_model->faces.reserve(csg_model->faces.size()+result.indices.size());
     int old_faces = csg_model->verts.size()/3;
     if(!flip){
-        for(int i=0, len=result.indices.size(); i<len; ++i){
-            csg_model->faces.push_back(result.indices[i] + old_faces);
+        for(int indice : result.indices){
+            csg_model->faces.push_back(indice + old_faces);
         }
     } else {
         for(int i=0, len=result.indices.size(); i<len; i+=3){
@@ -1152,10 +1149,9 @@ bool CollideObjects(BulletWorld& bw, const Model &model_a, const mat4 &transform
     bw.GetPairCollisions(shape[1].col_obj, shape[0].col_obj, cb);
     // Process triangle intersections to eliminate false positives and get precise intersection segments
     std::vector<TriIntersectInfo> tri_intersect_info;
-    for(MeshCollisionCallback::TriPairSet::iterator iter = cb.tri_pairs.begin(); iter != cb.tri_pairs.end(); ++iter){
+    for(const auto & tri_pair : cb.tri_pairs){
         // Get triangle vertices
         vec3d tri[2][3];
-        const MeshCollisionCallback::TriPair &tri_pair = *iter;
         int tri_index = tri_pair.first*3;
         for(int j=0; j<3; ++j){
             int vert_index = shape[1].faces[tri_index+j]*3;

--- a/Source/Graphics/detailobjectsurface.cpp
+++ b/Source/Graphics/detailobjectsurface.cpp
@@ -73,7 +73,7 @@ void DetailObjectSurface::AttachTo( const Model& model, mat4 transform ) {
     vec3 verts[3];
     int face_index = 0;
     int vert_index;
-    for(unsigned i=0; i<triangle_area.size(); ++i){
+    for(float & i : triangle_area){
         for(unsigned j=0; j<3; ++j){
             vert_index = model.faces[face_index+j]*3;
             verts[j] = vec3(model.vertices[vert_index+0],
@@ -81,7 +81,7 @@ void DetailObjectSurface::AttachTo( const Model& model, mat4 transform ) {
                             model.vertices[vert_index+2]);
             verts[j] = transform * verts[j];
         }
-        triangle_area[i] = length(cross(verts[2]-verts[0], verts[1]-verts[0]))*0.5f;
+        i = length(cross(verts[2]-verts[0], verts[1]-verts[0]))*0.5f;
         face_index += 3;
         static const bool debug_draw = false;
         if(debug_draw){
@@ -784,14 +784,14 @@ void DetailObjectSurface::CalcPatchInstances( const TriInt &coords, DOPatch &pat
 	if(!patch.detail_instance_transforms.empty()){
 		PROFILER_ZONE(g_profiler_ctx, "Get bounding sphere");
         vec3 sphere_center;
-        for(unsigned j=0; j<patch.detail_instance_transforms.size(); ++j){
-            sphere_center += patch.detail_instance_transforms[j].GetTranslationPart();
+        for(auto & detail_instance_transform : patch.detail_instance_transforms){
+            sphere_center += detail_instance_transform.GetTranslationPart();
         }
         sphere_center /= (float)patch.detail_instance_transforms.size();
         float least_distance = distance_squared(sphere_center, patch.detail_instance_transforms[0].GetTranslationPart());
-        for(unsigned j=0; j<patch.detail_instance_transforms.size(); ++j){
+        for(auto & detail_instance_transform : patch.detail_instance_transforms){
             least_distance = max(least_distance,
-                distance_squared(sphere_center, patch.detail_instance_transforms[j].GetTranslationPart()));
+                distance_squared(sphere_center, detail_instance_transform.GetTranslationPart()));
         }
         patch.sphere_center = sphere_center;
         patch.sphere_radius = sqrtf(least_distance);

--- a/Source/Graphics/drawbatch.cpp
+++ b/Source/Graphics/drawbatch.cpp
@@ -100,8 +100,8 @@ DrawBatch::DrawBatch() : visible(true),
         tex_coord_elements[i] = 0;
         use_vbo_texcoords[i] = true;
     }
-    for(int i=0; i<kMaxTextures; i++){
-        texture_ref[i].clear();
+    for(auto & i : texture_ref){
+        i.clear();
     }
 }
 
@@ -126,21 +126,21 @@ void DrawBatch::Draw() {
     } else {
         const Camera& camera = (*ActiveCameras::Get());
         SetupVertexArrays();
-        for(unsigned i=0; i<added_batches.size(); i++){
-            if(camera.checkSphereInFrustum(added_batches[i].batch->bounding_sphere_center,
-                                           added_batches[i].batch->bounding_sphere_radius)){
-                added_batches[i].batch->SetStartState();
+        for(auto & added_batche : added_batches){
+            if(camera.checkSphereInFrustum(added_batche.batch->bounding_sphere_center,
+                                           added_batche.batch->bounding_sphere_radius)){
+                added_batche.batch->SetStartState();
                 //glPushMatrix();
                 //glMultMatrixf(added_batches[i].batch->transform);
                 
-                Graphics::Instance()->SetModelMatrix(added_batches[i].batch->transform, added_batches[i].batch->inv_transpose_transform);
+                Graphics::Instance()->SetModelMatrix(added_batche.batch->transform, added_batche.batch->inv_transpose_transform);
                 
-                DrawVertexArrayRange(added_batches[i].start_face,
-                                     added_batches[i].end_face,
-                                     added_batches[i].start_vertex,
-                                     added_batches[i].end_vertex);
+                DrawVertexArrayRange(added_batche.start_face,
+                                     added_batche.end_face,
+                                     added_batche.start_vertex,
+                                     added_batche.end_vertex);
                 //glPopMatrix();
-                added_batches[i].batch->SetEndState();
+                added_batche.batch->SetEndState();
             }
         }
         EndVertexArrays();
@@ -212,8 +212,8 @@ void DrawBatch::DrawElements( GLuint size, const GLuint* data ) {
     face_ptr = NULL;
     normal_ptr = NULL;
     vertex_ptr = NULL;
-    for(int i=0; i<8; i++){
-        tex_coord_ptr[i] = NULL;
+    for(auto & i : tex_coord_ptr){
+        i = NULL;
     }
 }
 
@@ -223,8 +223,8 @@ void DrawBatch::AddBatch( const DrawBatch &other ) {
     }
 
     if(other.added_batches.size()){
-        for(unsigned i=0; i<other.added_batches.size(); i++){
-            AddBatch(*(other.added_batches[i].batch));
+        for(const auto & added_batche : other.added_batches){
+            AddBatch(*(added_batche.batch));
         }
         return;
     }
@@ -321,8 +321,8 @@ Uniform::Uniform():
 void DrawBatch::Dispose() {
     normals.clear();
     vertices.clear();
-    for(int i=0; i<8; i++){
-       tex_coords[i].clear();
+    for(auto & tex_coord : tex_coords){
+       tex_coord.clear();
     }
     faces.clear();
     uniforms.clear();
@@ -330,8 +330,8 @@ void DrawBatch::Dispose() {
     vbo_faces->Dispose();
     vbo_vertices->Dispose();
     vbo_normals->Dispose();
-    for(int i=0; i<8; i++){
-        vbo_tex_coords[i]->Dispose();
+    for(auto & vbo_tex_coord : vbo_tex_coords){
+        vbo_tex_coord->Dispose();
     }
 
     draw_times = 0;
@@ -348,8 +348,8 @@ void DrawBatch::SetStartState() const {
 
     shaders->setProgram(shader_id);
     
-    for(unsigned i=0; i<uniforms.size(); i++){
-        uniforms[i].Apply();
+    for(const auto & uniform : uniforms){
+        uniform.Apply();
     }
 
     if(use_cam_pos){
@@ -453,9 +453,9 @@ void DrawBatch::SetupVertexArrays() const {
 
 void DrawBatch::SetUniformFloat( std::string _name, GLfloat data )
 {
-    for(unsigned i=0; i<uniforms.size(); ++i){
-        if(uniforms[i].name == _name){
-            uniforms[i].data[0] = data;
+    for(auto & uniform : uniforms){
+        if(uniform.name == _name){
+            uniform.data[0] = data;
             return;
         }
     }
@@ -464,27 +464,27 @@ void DrawBatch::SetUniformFloat( std::string _name, GLfloat data )
 
 void DrawBatch::MakeUniformIndividual( std::string _name )
 {
-    for(unsigned i=0; i<uniforms.size(); ++i){
-        if(uniforms[i].name == _name){
-            uniforms[i].individual = true;
+    for(auto & uniform : uniforms){
+        if(uniform.name == _name){
+            uniform.individual = true;
         }
     }
 }
 
 void DrawBatch::ApplyIndividualUniforms() const
 {
-    for(unsigned i=0; i<uniforms.size(); i++){
-        if(uniforms[i].individual){
-            uniforms[i].Apply();
+    for(const auto & uniform : uniforms){
+        if(uniform.individual){
+            uniform.Apply();
         }
     }
 }
 
 void DrawBatch::SetUniformVec3( std::string _name, const vec3 &_data )
 {
-    for(unsigned i=0; i<uniforms.size(); ++i){
-        if(uniforms[i].name == _name){
-            memcpy(&uniforms[i].data[0], 
+    for(auto & uniform : uniforms){
+        if(uniform.name == _name){
+            memcpy(&uniform.data[0], 
                    (const GLfloat*)_data.entries, 
                    3*sizeof(GLfloat));
         }
@@ -504,9 +504,9 @@ void DrawBatch::AddUniformVec4( std::string _name, const vec4 &_data ) {
 }
 
 void DrawBatch::SetUniformVec4( std::string _name, const vec4 &_data ) {
-    for(unsigned i=0; i<uniforms.size(); ++i){
-        if(uniforms[i].name == _name){
-            memcpy(&uniforms[i].data[0], 
+    for(auto & uniform : uniforms){
+        if(uniform.name == _name){
+            memcpy(&uniform.data[0], 
                 (const GLfloat*)_data.entries, 
                 4*sizeof(GLfloat));
         }

--- a/Source/Graphics/dynamiclightcollection.cpp
+++ b/Source/Graphics/dynamiclightcollection.cpp
@@ -84,9 +84,9 @@ void DynamicLightCollection::Dispose() {
 }
 
 DynamicLight* DynamicLightCollection::GetLightFromID(int id) {
-    for(int i=0, len=dynamic_lights.size(); i<len; ++i){
-        if(dynamic_lights[i].id == id) {
-            return &dynamic_lights[i];
+    for(auto & dynamic_light : dynamic_lights){
+        if(dynamic_light.id == id) {
+            return &dynamic_light;
         }
     }
     return NULL;

--- a/Source/Graphics/flares.cpp
+++ b/Source/Graphics/flares.cpp
@@ -394,8 +394,7 @@ void Flares::Update(float timestep) {
         old_angle = new_angle;
         new_angle = RangedRandomFloat(0.0f,360.0f);
     }
-    for (unsigned i=0; i<flares.size(); i++) {
-        Flare* flare = flares[i];
+    for (auto flare : flares) {
         flare->old_position = flare->position;
         flare->slow_visible = mix(flare->visible,flare->slow_visible,_slow_visible_inertia);
         if(flare->visible == 0.0f && flare->slow_visible < 0.01f){
@@ -444,9 +443,9 @@ void Flares::DeleteFlare(Flare* flare){
     std::vector<Flare*>::iterator flare_iter = std::find(flares.begin(), flares.end(), flare);
     if(flare_iter != flares.end()){
         Flare* flare = (*flare_iter);
-        for(unsigned i=0; i<flare->query.size(); ++i){
-            if(flare->query[i].created){
-                glDeleteQueries(1,&flare->query[i].id);
+        for(auto & i : flare->query){
+            if(i.created){
+                glDeleteQueries(1,&i.id);
             }
         }
         delete flare;
@@ -463,9 +462,9 @@ void Flares::CleanupFlares() {
     for(;it != flares.end(); ++it)
     {
         Flare* flare = (*it);
-        for(unsigned i=0; i<flare->query.size(); ++i){
-            if(flare->query[i].created){
-                glDeleteQueries(1,&flare->query[i].id);
+        for(auto & i : flare->query){
+            if(i.created){
+                glDeleteQueries(1,&i.id);
             }
         }
         delete (*it);

--- a/Source/Graphics/font_renderer.cpp
+++ b/Source/Graphics/font_renderer.cpp
@@ -104,8 +104,8 @@ struct FontRendererImpl {
 
 
 FontRendererImpl::~FontRendererImpl() {
-    for (FontMap::iterator it = faces_.begin(); it != faces_.end(); ++it) {
-        FontFace &face = it->second;
+    for (auto & it : faces_) {
+        FontFace &face = it.second;
         FT_Done_Face(face.face);
         face.face = NULL;
     }

--- a/Source/Graphics/halfedge.cpp
+++ b/Source/Graphics/halfedge.cpp
@@ -125,12 +125,10 @@ void CollapseParentRecord(ParentRecordList &a, ParentRecordList &b, float weight
     if(&a == &b){
         return;
     }
-    for(ParentRecordList::iterator iter = a.begin(); iter != a.end(); ++iter){
-        ParentRecord &pr = *iter;
+    for(auto & pr : a){
         pr.weight *= (1.0f - weight);
     }
-    for(ParentRecordList::iterator iter = b.begin(); iter != b.end(); ++iter){
-        ParentRecord &pr = *iter;
+    for(auto & pr : b){
         pr.weight *= weight;
     }
     a.splice(a.end(), b);
@@ -146,8 +144,7 @@ void CollapseEdge(HalfEdgeNodeHeap &heap, HalfEdge *edge, std::vector<float>& ve
     CollapseParentRecord(vert_parents[edge->vert[0]], vert_parents[edge->vert[1]], edge->pos);
     CollapseVertPositions(vertices, edge->vert, edge->pos);
     HalfEdgeSet vert_edge_set = vert_edges[edge->vert[1]];
-    for(HalfEdgeSet::iterator iter = vert_edge_set.begin(); iter != vert_edge_set.end(); ++iter){
-        HalfEdge* change_edge = *iter;
+    for(auto change_edge : vert_edge_set){
         if(change_edge == edge || !change_edge->valid){
             continue;
         }
@@ -164,8 +161,7 @@ void CollapseEdge(HalfEdgeNodeHeap &heap, HalfEdge *edge, std::vector<float>& ve
         CollapseParentRecord(tex_parents[edge->tex[0]], tex_parents[edge->tex[1]], edge->pos);
         CollapseTexPositions(tex_coords, edge->tex, edge->pos);
         HalfEdgeSet tex_edge_set = tex_edges[edge->tex[1]];
-        for(HalfEdgeSet::iterator iter = tex_edge_set.begin(); iter != tex_edge_set.end(); ++iter){
-            HalfEdge* change_edge = *iter;
+        for(auto change_edge : tex_edge_set){
             if(change_edge == edge || !change_edge->valid){
                 continue;
             }
@@ -185,8 +181,7 @@ void CollapseEdge(HalfEdgeNodeHeap &heap, HalfEdge *edge, std::vector<float>& ve
             CollapseTexPositions(tex_coords, rev_tex, edge->pos);
             CollapseParentRecord(tex_parents[rev_tex[0]], tex_parents[rev_tex[1]], edge->pos);
             HalfEdgeSet tex_edge_set = tex_edges[rev_tex[1]];
-            for(HalfEdgeSet::iterator iter = tex_edge_set.begin(); iter != tex_edge_set.end(); ++iter){
-                HalfEdge* change_edge = *iter;
+            for(auto change_edge : tex_edge_set){
                 if(change_edge == edge || !change_edge->valid){
                     continue;
                 }
@@ -208,8 +203,7 @@ void CollapseEdge(HalfEdgeNodeHeap &heap, HalfEdge *edge, std::vector<float>& ve
         CollapseHalfEdge(heap, edge->twin);
     }
     // Recalc err and update heap
-    for(std::set<HalfEdge*>::iterator iter = affected_edges.begin(); iter != affected_edges.end(); ++iter){
-        HalfEdge* affected_edge = *iter;
+    for(auto affected_edge : affected_edges){
         if(!affected_edge->valid){
             continue;
         }

--- a/Source/Graphics/hudimage.cpp
+++ b/Source/Graphics/hudimage.cpp
@@ -94,10 +94,9 @@ void HUDImages::Draw() {
 
     {
         PROFILER_ZONE(g_profiler_ctx, "HUDImages draw loop");
-        for(unsigned i=0; i<hud_images.size(); ++i){
+        for(auto & hi : hud_images){
             PROFILER_GPU_ZONE(g_profiler_ctx, "HUDImages draw iteration");
             CHECK_GL_ERROR();
-            const HUDImage& hi = hud_images[i];
             if(hi.color[3] <= 0.0f){
                 continue;
             }

--- a/Source/Graphics/kdtreecluster.cpp
+++ b/Source/Graphics/kdtreecluster.cpp
@@ -35,9 +35,9 @@ void GetClosestClusters( KDNode &node, const std::vector<vec3> &cluster_center, 
     node.cluster_info.closest_clusters.clear();
     if(candidates.size() == 1){
         node.cluster_info.closest_clusters.push_back(candidates[0]);
-        for(unsigned i=0; i<2; ++i){
-            if(node.child[i]){
-                GetClosestClusters(*node.child[i], 
+        for(auto & i : node.child){
+            if(i){
+                GetClosestClusters(*i, 
                                    cluster_center, 
                                    node.cluster_info.closest_clusters);
             }  
@@ -103,9 +103,9 @@ void GetClosestClusters( KDNode &node, const std::vector<vec3> &cluster_center, 
             node.cluster_info.closest_clusters.push_back(candidates[i]);
         }*/
     }
-    for(unsigned i=0; i<2; ++i){
-        if(node.child[i]){
-            GetClosestClusters(*node.child[i], 
+    for(auto & i : node.child){
+        if(i){
+            GetClosestClusters(*i, 
                 cluster_center, 
                 node.cluster_info.closest_clusters);
         }  
@@ -253,8 +253,8 @@ KDNode::KDNode( const vec3 &_min_bounds, const vec3 &_max_bounds, std::vector<ve
     const int _rand_pick_threshold = 20;
     if((int)points.size()>_rand_pick_threshold){
         std::vector<vec3> median_points(_rand_pick_threshold);
-        for(unsigned i=0; i<median_points.size(); ++i){
-            median_points[i] = points[rand()%points.size()];
+        for(auto & median_point : median_points){
+            median_point = points[rand()%points.size()];
         }
         if(axis == 0){
             std::sort(median_points.begin(), median_points.end(), Vec3XCompare());
@@ -308,22 +308,22 @@ KDNode::KDNode( const vec3 &_min_bounds, const vec3 &_max_bounds, std::vector<ve
     vec3 child_max = _max_bounds;
     child_max[axis] = plane_coord;
     std::vector<vec3> child_points;
-    for(unsigned i=0; i<points.size(); ++i){
-        if(points[i].entries[axis] < plane_coord){
-            child_points.push_back(points[i]);
+    for(auto & point : points){
+        if(point.entries[axis] < plane_coord){
+            child_points.push_back(point);
         }
     }
     child[0] = new KDNode(child_min, child_max, child_points, depth+1);
 
     child[0]->content_bounds[0] = median_point;
     child[0]->content_bounds[1] = median_point;
-    for(unsigned i=0; i<child_points.size(); ++i){
+    for(auto & child_point : child_points){
         for(unsigned j=0; j<3; ++j){
-            if(child_points[i][j] < child[0]->content_bounds[0][j]){
-                child[0]->content_bounds[0][j] = child_points[i][j];
+            if(child_point[j] < child[0]->content_bounds[0][j]){
+                child[0]->content_bounds[0][j] = child_point[j];
             }
-            if(child_points[i][j] > child[0]->content_bounds[1][j]){
-                child[0]->content_bounds[1][j] = child_points[i][j];
+            if(child_point[j] > child[0]->content_bounds[1][j]){
+                child[0]->content_bounds[1][j] = child_point[j];
             }
         }
     }
@@ -332,22 +332,22 @@ KDNode::KDNode( const vec3 &_min_bounds, const vec3 &_max_bounds, std::vector<ve
     child_max = _max_bounds;
     child_min[axis] = plane_coord;
     child_points.clear();
-    for(unsigned i=0; i<points.size(); ++i){
-        if(points[i].entries[axis] > plane_coord){
-            child_points.push_back(points[i]);
+    for(auto & point : points){
+        if(point.entries[axis] > plane_coord){
+            child_points.push_back(point);
         }
     }
     child[1] = new KDNode(child_min, child_max, child_points, depth+1);
 
     child[1]->content_bounds[0] = child_points[0];
     child[1]->content_bounds[1] = child_points[0];
-    for(unsigned i=0; i<child_points.size(); ++i){
+    for(auto & child_point : child_points){
         for(unsigned j=0; j<3; ++j){
-            if(child_points[i][j] < child[1]->content_bounds[0][j]){
-                child[1]->content_bounds[0][j] = child_points[i][j];
+            if(child_point[j] < child[1]->content_bounds[0][j]){
+                child[1]->content_bounds[0][j] = child_point[j];
             }
-            if(child_points[i][j] > child[1]->content_bounds[1][j]){
-                child[1]->content_bounds[1][j] = child_points[i][j];
+            if(child_point[j] > child[1]->content_bounds[1][j]){
+                child[1]->content_bounds[1][j] = child_point[j];
             }
         }
     }

--- a/Source/Graphics/lightprobecollection.cpp
+++ b/Source/Graphics/lightprobecollection.cpp
@@ -934,15 +934,15 @@ void LightProbeCollection::Draw(BulletWorld& bw) {
             CHECK_GL_ERROR();
 
             // Check long name if short name is not found
-            for(unsigned int indice : indices){
-                if(indice == GL_INVALID_INDEX){
+            for(unsigned int index : indices){
+                if(index == GL_INVALID_INDEX){
                     glGetUniformIndices(programHandle, 5, &names[5], indices);
                     break;
                 }
             }
 
-            for(unsigned int indice : indices){
-                if(indice == GL_INVALID_INDEX){
+            for(unsigned int index : indices){
+                if(index == GL_INVALID_INDEX){
                     return;
                 }
             }

--- a/Source/Graphics/lightprobecollection.cpp
+++ b/Source/Graphics/lightprobecollection.cpp
@@ -183,9 +183,9 @@ LightProbe* LightProbeCollection::GetNextProbeToProcess() {
 }
 
 LightProbe* LightProbeCollection::GetProbeFromID(int id) {
-    for(int i=0, len=light_probes.size(); i<len; ++i){
-        if(light_probes[i].id == id) {
-            return &light_probes[i];
+    for(auto & light_probe : light_probes){
+        if(light_probe.id == id) {
+            return &light_probe;
         }
     }
     return NULL;
@@ -585,9 +585,9 @@ void LightProbeCollection::UpdateTextureBuffer(BulletWorld& bw) {
                             ++index;
                         }
                     } else {
-                        for(int face=0; face<6; ++face){
+                        for(auto & face : probe.ambient_cube_color){
                             for(int channel=0; channel<3; ++channel){
-                                unsigned val = (unsigned)(probe.ambient_cube_color[face][channel] * 255.0f / 4.0f);
+                                unsigned val = (unsigned)(face[channel] * 255.0f / 4.0f);
                                 tet_colors[index] = (val > 255)?255:val;
                                 ++index;
                             }
@@ -624,8 +624,8 @@ void LightProbeCollection::UpdateTextureBuffer(BulletWorld& bw) {
                             }
                         }
                     }
-                    for(int avg_index=0; avg_index<18; ++avg_index){
-                        avg_col[avg_index] /= num_positive;
+                    for(int & avg_index : avg_col){
+                        avg_index /= num_positive;
                     }
                     // Assign average color to negative probes in this tet
                     for(int point=0; point<4; ++point){
@@ -720,8 +720,8 @@ void LightProbeCollection::UpdateTextureBuffer(BulletWorld& bw) {
             buf_u[buf_index++] = neighbors_u[2];
             buf_u[buf_index++] = neighbors_u[3];
 
-            for(int i=0; i<18; ++i){
-                buf_u[buf_index++] = colors_u[i];
+            for(unsigned int i : colors_u){
+                buf_u[buf_index++] = i;
             }
             buf_u[buf_index++] = 0;
             buf_u[buf_index++] = 0;
@@ -934,15 +934,15 @@ void LightProbeCollection::Draw(BulletWorld& bw) {
             CHECK_GL_ERROR();
 
             // Check long name if short name is not found
-            for(int i=0; i<5; ++i){
-                if(indices[i] == GL_INVALID_INDEX){
+            for(unsigned int indice : indices){
+                if(indice == GL_INVALID_INDEX){
                     glGetUniformIndices(programHandle, 5, &names[5], indices);
                     break;
                 }
             }
 
-            for(int i=0; i<5; ++i){
-                if(indices[i] == GL_INVALID_INDEX){
+            for(unsigned int indice : indices){
+                if(indice == GL_INVALID_INDEX){
                     return;
                 }
             }

--- a/Source/Graphics/model.cpp
+++ b/Source/Graphics/model.cpp
@@ -858,9 +858,9 @@ void CopyTexCoords2( Model &a, const Model& b ) {
         [floorf(n_i[2]*100.0f)];
         normal_index += 3;
         vert_index += 3;
-        for(int indice : indices){
-            a.tex_coords2[indice*2+0] = b.tex_coords[i*2+0];
-            a.tex_coords2[indice*2+1] = b.tex_coords[i*2+1];
+        for(int index : indices){
+            a.tex_coords2[index*2+0] = b.tex_coords[i*2+0];
+            a.tex_coords2[index*2+1] = b.tex_coords[i*2+1];
         }
     }
 
@@ -900,12 +900,12 @@ void CopyTexCoords2( Model &a, const Model& b ) {
         [floorf(n_i[2]*10.0f+0.5f)];
         normal_index += 3;
         vert_index += 3;
-        for(int indice : indices){
-            if(a.tex_coords2[indice*2+0] == 0.0f &&
-               a.tex_coords2[indice*2+1] == 0.0f)
+        for(int index : indices){
+            if(a.tex_coords2[index*2+0] == 0.0f &&
+               a.tex_coords2[index*2+1] == 0.0f)
             {
-                a.tex_coords2[indice*2+0] = b.tex_coords[i*2+0];
-                a.tex_coords2[indice*2+1] = b.tex_coords[i*2+1];
+                a.tex_coords2[index*2+0] = b.tex_coords[i*2+0];
+                a.tex_coords2[index*2+1] = b.tex_coords[i*2+1];
             }
         }
     }
@@ -946,12 +946,12 @@ void CopyTexCoords2( Model &a, const Model& b ) {
         [floorf(n_i[2]*1.0f+0.5f)];
         normal_index += 3;
         vert_index += 3;
-        for(int indice : indices){
-            if(a.tex_coords2[indice*2+0] == 0.0f &&
-                a.tex_coords2[indice*2+1] == 0.0f)
+        for(int index : indices){
+            if(a.tex_coords2[index*2+0] == 0.0f &&
+                a.tex_coords2[index*2+1] == 0.0f)
             {
-                a.tex_coords2[indice*2+0] = b.tex_coords[i*2+0];
-                a.tex_coords2[indice*2+1] = b.tex_coords[i*2+1];
+                a.tex_coords2[index*2+0] = b.tex_coords[i*2+0];
+                a.tex_coords2[index*2+1] = b.tex_coords[i*2+1];
             }
         }
     }

--- a/Source/Graphics/modelsurfacewalker.cpp
+++ b/Source/Graphics/modelsurfacewalker.cpp
@@ -107,16 +107,16 @@ void ModelSurfaceWalker::AttachTo(const std::vector<float> &vertices, const std:
     std::vector<Tri> tris(faces.size()/3);
 
     int index = 0;
-    for(int i=0, len=tris.size(); i<len; ++i){
+    for(auto & tri : tris){
         for(int j=0; j<3; ++j) {
             for(int k=0; k<2; ++k){
-                tris[i].edges[j].points[k] = first_dup[faces[index+(j+k)%3]];
+                tri.edges[j].points[k] = first_dup[faces[index+(j+k)%3]];
             }
-            if(tris[i].edges[j].points[0] > tris[i].edges[j].points[1]){
-                std::swap(tris[i].edges[j].points[0], tris[i].edges[j].points[1]);
-                tris[i].edge_swapped[j] = true;
+            if(tri.edges[j].points[0] > tri.edges[j].points[1]){
+                std::swap(tri.edges[j].points[0], tri.edges[j].points[1]);
+                tri.edge_swapped[j] = true;
             } else {
-                tris[i].edge_swapped[j] = false;
+                tri.edge_swapped[j] = false;
             }
         }
         index += 3;
@@ -133,12 +133,10 @@ void ModelSurfaceWalker::AttachTo(const std::vector<float> &vertices, const std:
     // Use the list of triangles for each edge to get a list of neighbors for
     // each triangle
     tri_info.resize(tris.size());
-    for(std::map<Edge, std::vector<int> >::iterator iter = edge_tris.begin(); 
-        iter != edge_tris.end(); 
-        ++iter)
+    for(auto & edge_tri : edge_tris)
     {
-        const Edge& edge = iter->first;
-        const std::vector<int> &faces = iter->second;
+        const Edge& edge = edge_tri.first;
+        const std::vector<int> &faces = edge_tri.second;
         if(faces.size() == 2){
             for(unsigned i=0; i<2; ++i){
                 const int &face = faces[i];
@@ -158,16 +156,16 @@ void ModelSurfaceWalker::AttachTo(const std::vector<float> &vertices, const std:
     // Get the length of each edge of each triangle
     vec3 points[3];
     int face_index = 0;
-    for(unsigned i=0; i<tri_info.size(); ++i){
-        for(unsigned j=0; j<3; ++j){
-            points[j] = vec3(vertices[faces[face_index]*3+0],
+    for(auto & i : tri_info){
+        for(auto & point : points){
+            point = vec3(vertices[faces[face_index]*3+0],
                              vertices[faces[face_index]*3+1],
                              vertices[faces[face_index]*3+2]);
             ++face_index;
         }
-        tri_info[i].edge_length[0] = distance(points[0], points[1]);
-        tri_info[i].edge_length[1] = distance(points[1], points[2]);
-        tri_info[i].edge_length[2] = distance(points[2], points[0]);
+        i.edge_length[0] = distance(points[0], points[1]);
+        i.edge_length[1] = distance(points[1], points[2]);
+        i.edge_length[2] = distance(points[2], points[0]);
     }
 }
 

--- a/Source/Graphics/palette.cpp
+++ b/Source/Graphics/palette.cpp
@@ -60,12 +60,12 @@ void WritePaletteToRAM( const OGPalette& palette, std::vector<char> &data )
 
 void WritePaletteToXML( const OGPalette & palette, TiXmlElement* palette_el )
 {
-    for(unsigned i=0; i<palette.size(); ++i){
+    for(const auto & i : palette){
         TiXmlElement* color_el = new TiXmlElement("Color");
         palette_el->LinkEndChild(color_el);
-        const std::string &label = palette[i].label;
-        const vec3 &color = palette[i].color;
-        const char& channel = palette[i].channel;
+        const std::string &label = i.label;
+        const vec3 &color = i.color;
+        const char& channel = i.channel;
         color_el->SetAttribute("label", label.c_str());
         color_el->SetAttribute("channel", channel);
         color_el->SetDoubleAttribute("red", color[0]);

--- a/Source/Graphics/particles.cpp
+++ b/Source/Graphics/particles.cpp
@@ -197,8 +197,7 @@ void DrawGPUParticleField(SceneGraph *scenegraph, const char* type) {
 
     std::vector<mat4> light_volume_matrix;
     std::vector<mat4> light_volume_matrix_inverse;
-    for(int i=0, len=scenegraph->light_volume_objects_.size(); i<len; ++i){
-        Object* obj = scenegraph->light_volume_objects_[i];
+    for(auto obj : scenegraph->light_volume_objects_){
         const mat4 &mat = obj->GetTransform();
         light_volume_matrix.push_back(mat);
         light_volume_matrix_inverse.push_back(invert(mat));
@@ -243,8 +242,8 @@ void DrawGPUParticleField(SceneGraph *scenegraph, const char* type) {
         static GLfloat data_vec[20*1000];
         int val=0;
         for(int i=0; i<1000; ++i){
-            for(int j=0; j<20; ++j){
-                data_vec[val++] = data[j];
+            for(float j : data){
+                data_vec[val++] = j;
             }
         }
         data_vbo.Fill(kVBOStatic | kVBOFloat,sizeof(data_vec), (void*)data_vec);
@@ -256,8 +255,8 @@ void DrawGPUParticleField(SceneGraph *scenegraph, const char* type) {
         int val = 0;
         int val2 = 0;
         for(int i=0; i<1000; ++i){
-            for(int j=0; j<6; ++j){
-                index_vec[val2++]=index[j]+val;
+            for(unsigned int j : index){
+                index_vec[val2++]=j+val;
             }
             val += 4;
         }
@@ -379,8 +378,7 @@ void Particle::Draw(SceneGraph *scenegraph, DrawType draw_type, const mat4& proj
 
         std::vector<mat4> light_volume_matrix;
         std::vector<mat4> light_volume_matrix_inverse;
-        for(int i=0, len=scenegraph->objects_.size(); i<len; ++i){
-            Object* obj = scenegraph->objects_[i];
+        for(auto obj : scenegraph->objects_){
             const mat4 &mat = obj->GetTransform();
             light_volume_matrix.push_back(mat);
             light_volume_matrix_inverse.push_back(invert(mat));
@@ -538,11 +536,11 @@ void Particle::Draw(SceneGraph *scenegraph, DrawType draw_type, const mat4& proj
         graphics->ResetVertexAttribArrays();
         CHECK_GL_ERROR();
     }
-    for(ParticleList::iterator iter = connected.begin(); iter != connected.end(); ++iter) {
-        if(this < (*iter)) {
+    for(auto & iter : connected) {
+        if(this < iter) {
             float thickness = interp_size;
             vec3 a = interp_position;
-            vec3 b = (*iter)->interp_position;
+            vec3 b = iter->interp_position;
 
             vec3 up,right,cam_to_particle;
             vec3 vertices[4];
@@ -871,8 +869,8 @@ void ParticleSystem::Draw(SceneGraph *scenegraph) {
 
         PROFILER_ENTER(g_profiler_ctx, "Interpolate particles");
         float interp = game_timer.GetInterpWeight();
-        for (unsigned i=0, len=particles.size(); i<len; ++i) {
-            Particle& p = *particles[i];
+        for (auto & particle : particles) {
+            Particle& p = *particle;
             p.interp_position = mix(p.old_position, p.position, interp);
             p.interp_rotation  = mix(p.old_rotation,  p.rotation,  interp);
             p.interp_size     = mix(p.old_size,     p.size,     interp);
@@ -881,8 +879,8 @@ void ParticleSystem::Draw(SceneGraph *scenegraph) {
         PROFILER_LEAVE(g_profiler_ctx);  // Interpolate particles
 
         vec3 cam_pos = ActiveCameras::Get()->GetPos();
-        for (unsigned i=0;i<particles.size();i++){
-            particles[i]->cam_dist=distance_squared(particles[i]->interp_position, cam_pos);
+        for (auto & particle : particles){
+            particle->cam_dist=distance_squared(particle->interp_position, cam_pos);
         }
         PROFILER_ENTER(g_profiler_ctx, "Sort particles");
         std::sort(particles.begin(), particles.end(), CParticleCompare);
@@ -945,9 +943,8 @@ void ParticleSystem::Draw(SceneGraph *scenegraph) {
 					} else {
 						std::vector<mat4> light_volume_matrix;
 						std::vector<mat4> light_volume_matrix_inverse;
-						for(int i=0, len=scenegraph->light_volume_objects_.size(); i<len; ++i){
-							Object* obj = scenegraph->light_volume_objects_[i];
-							const mat4 &mat = obj->GetTransform();
+						for(auto obj : scenegraph->light_volume_objects_){
+								const mat4 &mat = obj->GetTransform();
 							light_volume_matrix.push_back(mat);
 							light_volume_matrix_inverse.push_back(invert(mat));
 						}
@@ -1309,8 +1306,8 @@ unsigned ParticleSystem::MakeParticle( SceneGraph *scenegraph, const std::string
 
 //Dispose of particle system
 void ParticleSystem::Dispose() {
-    for(ParticleVector::iterator it = particles.begin(); it != particles.end(); ++it){
-        delete (*it);
+    for(auto & particle : particles){
+        delete particle;
     }
     particles.clear();
 }

--- a/Source/Graphics/shaders.cpp
+++ b/Source/Graphics/shaders.cpp
@@ -45,20 +45,19 @@ extern bool g_single_pass_shadow_cascade;
 
 void Shaders::Dispose() {
     CHECK_GL_ERROR();
-    for(unsigned i=0; i<programs.size(); ++i){
-        Program& program = programs[i];
+    for(auto & program : programs){
         if(program.gl_program != UNLOADED_SHADER_ID) {
-            for(int i=0; i<kMaxShaderTypes; ++i){
-                if( program.shader_ids[i] >= 0 ) {
-                    glDetachShader(program.gl_program, shaders[program.shader_ids[i]].gl_shader);
+            for(int shader_id : program.shader_ids){
+                if( shader_id >= 0 ) {
+                    glDetachShader(program.gl_program, shaders[shader_id].gl_shader);
                 }
             }
             glDeleteProgram(program.gl_program);
         }
     }
-    for(unsigned i=0; i<shaders.size(); ++i){
-        if(shaders[i].gl_shader != UNLOADED_SHADER_ID) {
-            glDeleteShader(shaders[i].gl_shader);
+    for(auto & shader : shaders){
+        if(shader.gl_shader != UNLOADED_SHADER_ID) {
+            glDeleteShader(shader.gl_shader);
         }
     }
 
@@ -190,20 +189,20 @@ static void Preprocess(Shader* shader, ShaderType type, const std::vector<std::s
     
     bool no_velocity_buf_defined = false;
 
-    for(unsigned i=0; i<definitions.size(); ++i){
-        if(definitions[i] == "TANGENT"){
+    for(const auto & definition : definitions){
+        if(definition == "TANGENT"){
             shader->use_tangent = true;
         }
-        if(definitions[i] == "ALPHA"){
+        if(definition == "ALPHA"){
             shader->transparent = true;
         }
-        if(definitions[i] == "DEPTH_ONLY") {
+        if(definition == "DEPTH_ONLY") {
             shader->depth_only = true;
         }
-        if(definitions[i] == "PARTICLE") {
+        if(definition == "PARTICLE") {
             shader->particle = true;
         }
-        if(definitions[i] == "NO_VELOCITY_BUF") {
+        if(definition == "NO_VELOCITY_BUF") {
             no_velocity_buf_defined = true;
         }
     }
@@ -297,8 +296,8 @@ static void Preprocess(Shader* shader, ShaderType type, const std::vector<std::s
         AddShaderDefinition(&text, "TESSELATION_EVALUATOR_SHADER");
     }
 
-    for(unsigned i=0; i<definitions.size(); ++i){
-        AddShaderDefinition(&text, definitions[i]);
+    for(const auto & definition : definitions){
+        AddShaderDefinition(&text, definition);
     }
     if (GLAD_GL_ARB_sample_shading) {
         AddShaderDefinition(&text, "ARB_sample_shading_available");
@@ -367,8 +366,8 @@ void Shaders::Reload(bool force) {
         Program& program = programs[i];
         if(program.gl_program != UNLOADED_SHADER_ID) {
             bool unloaded = false;
-            for(int j=0; j<kMaxShaderTypes; ++j){
-                if(program.shader_ids[j] >= 0 && shaders[program.shader_ids[j]].gl_shader == UNLOADED_SHADER_ID){
+            for(int shader_id : program.shader_ids){
+                if(shader_id >= 0 && shaders[shader_id].gl_shader == UNLOADED_SHADER_ID){
                     unloaded = true;
                     break;
                 }
@@ -386,8 +385,8 @@ void Shaders::Reload(bool force) {
 int Shaders::returnShader(const char *path, ShaderType type, const std::vector<std::string> &definitions) {
     std::string full_path;
     full_path = path;
-    for(unsigned i=0; i<definitions.size(); ++i){
-        full_path += " #" + definitions[i];
+    for(const auto & definition : definitions){
+        full_path += " #" + definition;
     }
 
     for (unsigned i=0; i<shaders.size(); ++i){
@@ -659,8 +658,8 @@ int Shaders::returnProgram(std::string name, OptionalShaders optional_shaders) {
         } 
     }
 
-    for(int i=0; i<kMaxShaderTypes; ++i){
-        program.shader_ids[i] = MISSING_GEOM_SHADER_ID;
+    for(int & shader_id : program.shader_ids){
+        shader_id = MISSING_GEOM_SHADER_ID;
     }
 
     program.shader_ids[_vertex] = returnShader(vertex_path.c_str(), _vertex, definitions);
@@ -1174,15 +1173,15 @@ void Shaders::SetUniformVec3Array(GLint var_id, const vec3* val, int size) {
 
 void Shaders::ResetVRAM()
 {
-    for(unsigned i=0; i<shaders.size(); ++i){
-        shaders[i].gl_shader = UNLOADED_SHADER_ID;
+    for(auto & shader : shaders){
+        shader.gl_shader = UNLOADED_SHADER_ID;
     }
-    for(unsigned i=0; i<programs.size(); ++i){
-        programs[i].gl_program = UNLOADED_SHADER_ID;
-        programs[i].attrib_address_cache.clear();
-        programs[i].uniform_address_cache.clear();
-        programs[i].uniform_value_cache.clear();
-        programs[i].uniform_offset_cache.clear();
+    for(auto & program : programs){
+        program.gl_program = UNLOADED_SHADER_ID;
+        program.attrib_address_cache.clear();
+        program.uniform_address_cache.clear();
+        program.uniform_value_cache.clear();
+        program.uniform_offset_cache.clear();
     }
 }
 

--- a/Source/Graphics/simplify.cpp
+++ b/Source/Graphics/simplify.cpp
@@ -142,9 +142,9 @@ static void GetTexCoordNumPerVertex(const SimplifyModel *model, std::vector<int>
     // Count number of times each vertex is called in vert_indices
     num_tc.clear();
     num_tc.resize(model->vertices.size()/3, 0);
-    for(int i=0, len=model->vert_indices.size(); i<len; ++i){
-        if(model->vert_indices[i] != -1){
-            ++num_tc[model->vert_indices[i]];
+    for(int vert_indice : model->vert_indices){
+        if(vert_indice != -1){
+            ++num_tc[vert_indice];
         }
     }
     // Index for fast access
@@ -154,8 +154,8 @@ static void GetTexCoordNumPerVertex(const SimplifyModel *model, std::vector<int>
         index += num_tc[i];
     }
     // Clear num_tc for reuse
-    for(int i=0, len=num_tc.size(); i<len; ++i){
-        num_tc[i] = 0;
+    for(int & i : num_tc){
+        i = 0;
     }
     // Record texture indices
     std::vector<int> tc(model->vert_indices.size());
@@ -338,10 +338,10 @@ static bool GenerateEdgePairs(WOLFIRE_SIMPLIFY::SimplifyModel& processed_model, 
     LOGI << "Validating edge pairs." << std::endl;
     bool missing_pair = false;
     bool invalid_pair = false;
-    for(size_t i=0, len=half_edges.size(); i<len; ++i){
-        if(half_edges[i].twin == NULL){
+    for(auto & half_edge : half_edges){
+        if(half_edge.twin == NULL){
             missing_pair = true;
-        } else if(half_edges[i].twin->twin == NULL || half_edges[i].twin->twin != &half_edges[i]){
+        } else if(half_edge.twin->twin == NULL || half_edge.twin->twin != &half_edge){
             invalid_pair = true;
         }
     }
@@ -363,8 +363,7 @@ static bool GenerateEdgePairs(WOLFIRE_SIMPLIFY::SimplifyModel& processed_model, 
 
 static void CalculateEdgeErrors(vector<HalfEdge>& half_edges, SimplifyModel& processed_model, vector<glm::mat4>& quadrics_, bool include_tex) {
     LOGI << "Calculating edge error..." << std::endl;
-    for(int i=0, len=half_edges.size(); i<len; ++i){
-        HalfEdge& edge = half_edges[i];
+    for(auto & edge : half_edges){
         if(edge.err == UNDEFINED_ERROR){
             int edge_tc[2];
             if(include_tex) {
@@ -385,13 +384,13 @@ static void CalculateEdgeErrors(vector<HalfEdge>& half_edges, SimplifyModel& pro
 
 static void InitHeap(vector<HalfEdge>& half_edges, HalfEdgeNodeHeap& heap, HalfEdgeSetVec& vert_edges, HalfEdgeSetVec& tex_edges, bool include_tex) {
     LOGI << "Adding edges to heap..." << std::endl;
-    for(int i=0, len=half_edges.size(); i<len; ++i){
+    for(auto & half_edge : half_edges){
         HalfEdgeNode node;
-        node.edge = &half_edges[i];
-        half_edges[i].handle = heap.insert(node);
+        node.edge = &half_edge;
+        half_edge.handle = heap.insert(node);
     }
-    for(int i=0, len=half_edges.size(); i<len; ++i){
-        HalfEdge *edge = &half_edges[i];
+    for(auto & half_edge : half_edges){
+        HalfEdge *edge = &half_edge;
         vert_edges[edge->vert[0]].insert(edge);
         vert_edges[edge->vert[1]].insert(edge);
         if(include_tex) {
@@ -650,15 +649,15 @@ bool WOLFIRE_SIMPLIFY::SimplifySimpleModel(const Model& input, Model* output, in
         }
     }
 
-    for(int i=0, len=processed_model.vert_indices.size(); i<len; ++i){
-        if(vert_parents[processed_model.vert_indices[i]].empty()) {
-            processed_model.vert_indices[i] = reverse_vert_parents[processed_model.vert_indices[i]];
+    for(int & vert_indice : processed_model.vert_indices){
+        if(vert_parents[vert_indice].empty()) {
+            vert_indice = reverse_vert_parents[vert_indice];
         }
     }
 
-    for(int i=0, len=processed_model.tex_indices.size(); i<len; ++i){
-        if(tex_parents[processed_model.tex_indices[i]].empty()){
-            processed_model.tex_indices[i] = reverse_tex_parents[processed_model.tex_indices[i]];
+    for(int & tex_indice : processed_model.tex_indices){
+        if(tex_parents[tex_indice].empty()){
+            tex_indice = reverse_tex_parents[tex_indice];
         }
     }
 
@@ -730,14 +729,14 @@ bool WOLFIRE_SIMPLIFY::SimplifyMorphLOD( const SimplifyModelInput &model_input, 
             }
             vert_parent_vec[curr_lod] = vert_parents;
             tex_parent_vec[curr_lod] = tex_parents;            
-            for(int i=0, len=working_model.vert_indices.size(); i<len; ++i){
-                if(vert_parents[working_model.vert_indices[i]].empty()){
-                    working_model.vert_indices[i] = reverse_vert_parents[working_model.vert_indices[i]];
+            for(int & vert_indice : working_model.vert_indices){
+                if(vert_parents[vert_indice].empty()){
+                    vert_indice = reverse_vert_parents[vert_indice];
                 }
             }
-            for(int i=0, len=working_model.tex_indices.size(); i<len; ++i){
-                if(tex_parents[working_model.tex_indices[i]].empty()){
-                    working_model.tex_indices[i] = reverse_tex_parents[working_model.tex_indices[i]];
+            for(int & tex_indice : working_model.tex_indices){
+                if(tex_parents[tex_indice].empty()){
+                    tex_indice = reverse_tex_parents[tex_indice];
                 }
             }
             last_lod_model = working_model;

--- a/Source/Graphics/terrain.cpp
+++ b/Source/Graphics/terrain.cpp
@@ -99,10 +99,9 @@ void Terrain::Dispose() {
     LOGI << "Clearing detail maps" << std::endl;
     detail_maps_info.clear();
     LOGI << "Clearing detail object surfaces" << std::endl;    
-    for(std::list<DetailObjectSurface*>::iterator iter = detail_object_surfaces.begin();
-        iter != detail_object_surfaces.end(); ++iter)
+    for(auto & detail_object_surface : detail_object_surfaces)
     {
-        delete (*iter);
+        delete detail_object_surface;
     }
     detail_object_surfaces.clear();
     detail_maps_info.clear();
@@ -204,10 +203,9 @@ void Terrain::GLInit(Sky* sky) {
 
         sky->BakeSecondPass(&baked_texture_ref);
         heightmap_.LoadData(heightmap_.path(), HeightmapImage::DOWNSAMPLED);
-        for(std::list<DetailObjectSurface*>::iterator iter = detail_object_surfaces.begin();
-            iter != detail_object_surfaces.end(); ++iter)
+        for(auto & detail_object_surface : detail_object_surfaces)
         {
-            (*iter)->SetBaseTextures(color_texture_ref, normal_map_ref);
+            detail_object_surface->SetBaseTextures(color_texture_ref, normal_map_ref);
         }
         CHECK_GL_ERROR();
     }
@@ -383,16 +381,16 @@ void RemoveDoubledTriangles(Model *model) {
     }
 
     // Mark triangles with normals facing down as bad
-    for(unsigned i=0; i<possible_bad_faces.size(); i++){
-        if(model->face_normals[possible_bad_faces[i]][1]<0){
-            bad_faces.push_back(possible_bad_faces[i]);
+    for(int & possible_bad_face : possible_bad_faces){
+        if(model->face_normals[possible_bad_face][1]<0){
+            bad_faces.push_back(possible_bad_face);
         }
     }
 
-    for(unsigned i=0; i<bad_faces.size(); i++){
-        model->faces[bad_faces[i]*3+0] = 0;
-        model->faces[bad_faces[i]*3+1] = 0;
-        model->faces[bad_faces[i]*3+2] = 0;
+    for(int bad_face : bad_faces){
+        model->faces[bad_face*3+0] = 0;
+        model->faces[bad_face*3+1] = 0;
+        model->faces[bad_face*3+2] = 0;
     }
 }
 
@@ -478,8 +476,8 @@ void Terrain::CalculateSimplifiedTerrain() {
         Model temp;
         temp.SimpleLoadTriangleCutObj(abs_uv2_path);
         CopyTexCoords2(terrain_simplified_model, temp);
-        for(unsigned i=0; i<terrain_simplified_model.tex_coords2.size(); ++i){
-            terrain_simplified_model.tex_coords2[i] *= 2048.0f;
+        for(float & i : terrain_simplified_model.tex_coords2){
+            i *= 2048.0f;
         }
     }
 
@@ -617,8 +615,8 @@ void Terrain::Load(const char* name, const std::string& model_override) {
     if(!model_override.empty()){
         Model &terrain_simplified_model = Models::Instance()->GetModel(model_id);
         terrain_simplified_model.LoadObj(model_override, 0);
-        for(unsigned i=0; i<terrain_simplified_model.tex_coords2.size(); ++i){
-            terrain_simplified_model.tex_coords2[i] *= 2048.0f;
+        for(float & i : terrain_simplified_model.tex_coords2){
+            i *= 2048.0f;
         }
     }
 
@@ -1005,12 +1003,11 @@ void Terrain::SetDetailObjectLayers( const std::vector<DetailObjectLayer> &_deta
     detail_object_surfaces.resize(detail_object_layers.size());
     int counter = 0;
     Model &terrain_simplified_model = Models::Instance()->GetModel(model_id);
-    for(std::list<DetailObjectSurface*>::iterator iter = detail_object_surfaces.begin();
-        iter != detail_object_surfaces.end(); ++iter)
+    for(auto & detail_object_surface : detail_object_surfaces)
     {
         static const mat4 identity;
-        *iter = new DetailObjectSurface();
-        DetailObjectSurface& dos = *(*iter);
+        detail_object_surface = new DetailObjectSurface();
+        DetailObjectSurface& dos = *detail_object_surface;
         dos.AttachTo(terrain_simplified_model, identity);
         dos.GetTrisInPatches(identity);
         dos.LoadDetailModel(detail_object_layers[counter].obj_path);
@@ -1029,10 +1026,9 @@ void Terrain::SetDetailObjectLayers( const std::vector<DetailObjectLayer> &_deta
         ++counter;
     }
     if(normal_map_ref.valid()){
-        for(std::list<DetailObjectSurface*>::iterator iter = detail_object_surfaces.begin();
-            iter != detail_object_surfaces.end(); ++iter)
+        for(auto & detail_object_surface : detail_object_surfaces)
         {
-            (*iter)->SetBaseTextures(color_texture_ref, normal_map_ref);
+            detail_object_surface->SetBaseTextures(color_texture_ref, normal_map_ref);
         }
     }
 }

--- a/Source/Graphics/text.cpp
+++ b/Source/Graphics/text.cpp
@@ -158,8 +158,8 @@ void TextCanvas::GetBGRA( MemoryBlock *mem_to_fill ) {
 }
 
 void TextCanvas::Clear() {
-    for(unsigned i=0, len=pixels_.size(); i<len; ++i){
-        pixels_[i] = 0;
+    for(unsigned char & pixel : pixels_){
+        pixel = 0;
     }
 }
 

--- a/Source/Graphics/textures.cpp
+++ b/Source/Graphics/textures.cpp
@@ -349,8 +349,8 @@ void Textures::DrawImGuiDebug() {
 Textures::Textures() {
     process_pool = new ProcessPool(worker_app_path);
     PROFILED_TEXTURE_MUTEX_LOCK
-    for(unsigned int i=0; i<_texture_units; i++){
-        bound_texture[i]=INVALID_ID;
+    for(unsigned int & i : bound_texture){
+        i=INVALID_ID;
     }
     m_wrap_t = _default_wrap;
     m_wrap_s = _default_wrap;
@@ -467,8 +467,8 @@ void Textures::DisposeTexture(int which, bool free_space) {
         LOGI << "Disposed texture " << texture.name  << " with gl id " << texture.gl_texture_id << std::endl;
     }
 
-    for (unsigned int i = 0; i < texture.sub_textures.size(); i++) {
-        delete texture.sub_textures[i].texture_data;
+    for (auto & sub_texture : texture.sub_textures) {
+        delete sub_texture.texture_data;
     }
 
     texture.sub_textures.clear();
@@ -824,8 +824,7 @@ void Textures::TextureToVRAM(unsigned int which) {
     CHECK_GL_ERROR();
 
     if (!deferred_delete_textures.empty()) {
-        for (std::list<GLuint>::iterator it = deferred_delete_textures.begin(); it != deferred_delete_textures.end(); it++) {
-            GLuint tex_id = *it;
+        for (unsigned int tex_id : deferred_delete_textures) {
             LOGI << "Deferred delete of texture " << tex_id << std::endl;
             glDeleteTextures(1, &tex_id);
         }
@@ -853,8 +852,8 @@ void Textures::TextureToVRAM(unsigned int which) {
 
     if(tex.gl_texture_id != UNLOADED_ID)return;
 
-    for( unsigned i = 0; i < tex.sub_textures.size(); i++ ) {
-        tex.sub_textures[i].texture_data->EnsureInRAM();
+    for(auto & sub_texture : tex.sub_textures) {
+        sub_texture.texture_data->EnsureInRAM();
     }
                 
     bool is_array = (tex.sub_textures.size() > 1);
@@ -2670,8 +2669,8 @@ bool Textures::ReloadAsCompressed(const TextureRef& texref) {
 
     CreateParentDirs(newPath.c_str());
 
-    for (unsigned int i = 0; i < texture.sub_textures.size(); i++) {
-        TextureData *tex_data = texture.sub_textures[i].texture_data;
+    for (auto & sub_texture : texture.sub_textures) {
+        TextureData *tex_data = sub_texture.texture_data;
         LOG_ASSERT(tex_data != NULL);
         if (!tex_data->HasMipmaps()) {
             tex_data->GenerateMipmaps();

--- a/Source/Images/nv_image.cpp
+++ b/Source/Images/nv_image.cpp
@@ -58,8 +58,8 @@ Image::~Image() {
 //
 ////////////////////////////////////////////////////////////
 void Image::freeData() {
-    for (vector<GLubyte*>::iterator it = _data.begin(); it != _data.end(); it++) {
-        delete []*it;
+    for (auto & it : _data) {
+        delete []it;
     }
     _data.clear();
 }

--- a/Source/Images/texture_data.cpp
+++ b/Source/Images/texture_data.cpp
@@ -230,8 +230,8 @@ bool TextureData::Load(const char *abs_path) {
     
     // try to determine color space
     string src(abs_path);
-    for (string::size_type i = 0; i < src.size(); i++) {
-        src[i] = tolower(src[i]);
+    for (char & i : src) {
+        i = tolower(i);
     }
     if (src.rfind("_c.") != string::npos) {
         m_colorSpace = TextureData::sRGB;

--- a/Source/Internal/config.cpp
+++ b/Source/Internal/config.cpp
@@ -181,8 +181,8 @@ std::vector<Resolution> Config::GetPossibleResolutions() {
 		if ((mode.h <= desktopDisplayMode.h && mode.w <= desktopDisplayMode.w && std::fabs(resolutionAspect - desktopAspect) < 0.01f)
             || static_cast<FullscreenMode::Mode>(config["fullscreen"].toNumber<int>()) == FullscreenMode::kFullscreen) {
 			bool resolutionFound = false;
-			for (size_t i = 0; i < commonResolutions.size(); ++i) {
-				if (commonResolutions[i].w == mode.w && commonResolutions[i].h == mode.h) {
+			for (auto & commonResolution : commonResolutions) {
+				if (commonResolution.w == mode.w && commonResolution.h == mode.h) {
 					resolutionFound = true;
 					break;
 				}
@@ -312,8 +312,8 @@ void Config::SetSettingsToPreset(std::string preset_name )
 		return;
 	}
 	Config::Map& map = GetPresets()[index].map_;
-	for(Config::Map::iterator iter = map.begin(); iter != map.end(); ++iter ){
-		config.GetRef(iter->first) = iter->second.data;
+	for(auto & iter : map){
+		config.GetRef(iter.first) = iter.second.data;
 	}
 }
 
@@ -323,8 +323,8 @@ std::string Config::GetSettingsPreset(){
 	// Determine if we match any of the global_settings presets
 	for(int i=0; i<4; ++i){
 		Config::Map& map = GetPresets()[i].map_;
-		for(Config::Map::iterator iter = map.begin(); iter != map.end(); ++iter ){
-			if(config.GetRef(iter->first) != iter->second.data){
+		for(auto & iter : map){
+			if(config.GetRef(iter.first) != iter.second.data){
 				preset = i + 1;
 				break;
 			}
@@ -512,9 +512,9 @@ bool Config::Save(const std::string& filename) {
     std::vector<std::pair<std::string, ConfigVal> > vec(map_.begin(), map_.end());
     std::sort(vec.begin(), vec.end(), ConfigValCompare());
 
-    for(unsigned i=0; i<vec.size(); ++i)
+    for(auto & i : vec)
     {
-        file << vec[i].first << ": " << vec[i].second.data.str() << "\n";
+        file << i.first << ": " << i.second.data.str() << "\n";
     }
 
     file.close();

--- a/Source/Internal/error.cpp
+++ b/Source/Internal/error.cpp
@@ -202,8 +202,8 @@ ErrorResponse DisplayError(const char* title, const char* contents, ErrorType ty
     bool active_mods = false;
     int active_count = 0;
     std::vector<ModInstance*> mods = ModLoading::Instance().GetAllMods();
-    for( unsigned i = 0; i < mods.size(); i++ ) {
-        if( mods[i]->IsActive() && mods[i]->IsCore() == false) {
+    for(auto & mod : mods) {
+        if( mod->IsActive() && mod->IsCore() == false) {
             if( active_mods == false ) {
                 modlist << "Following mods are active" << std::endl;
                 active_mods = true;
@@ -214,7 +214,7 @@ ErrorResponse DisplayError(const char* title, const char* contents, ErrorType ty
                     modlist << ", ";
                 }
             }
-            modlist << mods[i]->id;
+            modlist << mod->id;
             active_count++;
         }
     }

--- a/Source/Internal/filesystem.cpp
+++ b/Source/Internal/filesystem.cpp
@@ -1112,10 +1112,10 @@ void ClearCache( bool dry_run )
     modids = ModLoading::Instance().GetModsSid();
 #endif
     modids.push_back(CoreGameModID);
-    for( unsigned i = 0; i < modids.size(); i++ ) 
+    for(auto & modid : modids) 
     {
         stringstream write_data_path;
-        write_data_path << GetWritePath(modids[i]);
+        write_data_path << GetWritePath(modid);
         write_data_path << "Data/";
 
         vector<string> write_dir_files;
@@ -1185,16 +1185,12 @@ void ClearCache( bool dry_run )
         vector<string> keep_files;
         vector<string> remove_files;
 
-        for( vector<string>::iterator pit = write_dir_files.begin();
-             pit != write_dir_files.end();
-             pit++ ) 
+        for(auto & write_dir_file : write_dir_files) 
         {
             bool found = false;
-            for( vector<pair<string,string> >::iterator fit = remove_with_ending.begin();
-                 fit != remove_with_ending.end();
-                 fit++ )
+            for(auto & fit : remove_with_ending)
             {
-                if( hasBeginning( *pit, fit->first) && hasEnding( *pit, fit->second ) )
+                if( hasBeginning( write_dir_file, fit.first) && hasEnding( write_dir_file, fit.second ) )
                 {
                     found = true;
                 }
@@ -1203,11 +1199,9 @@ void ClearCache( bool dry_run )
             if( found ) 
             {
                 /* Second pass with exclusion, if there's one match, regret inclusion, exclusion overrides */
-                for( vector<pair<string,string> >::iterator fit = exclude_with_ending.begin();
-                     fit != exclude_with_ending.end();
-                     fit++ )
+                for(auto & fit : exclude_with_ending)
                 {
-                    if( hasBeginning( *pit, fit->first) && ( fit->second.empty() || hasEnding( *pit, fit->second ) ) )
+                    if( hasBeginning( write_dir_file, fit.first) && ( fit.second.empty() || hasEnding( write_dir_file, fit.second ) ) )
                     {
                         found = false;
                     }
@@ -1216,17 +1210,17 @@ void ClearCache( bool dry_run )
 
             if( found )
             {
-                remove_files.push_back( *pit );
+                remove_files.push_back( write_dir_file );
             }
             else
             {
-                keep_files.push_back( *pit );
+                keep_files.push_back( write_dir_file );
             }
         }
 
-        for( unsigned int i = 0; i < remove_files.size(); i++ )
+        for(auto & remove_file : remove_files)
         {
-            string path = write_data_path.str() + remove_files[i];
+            string path = write_data_path.str() + remove_file;
             LOGI << "Removing: " << path  << endl;
             if( dry_run == false )
             {
@@ -1242,9 +1236,9 @@ void ClearCache( bool dry_run )
         {
             //Create a set with all unique folder paths
             set<string> folder_paths; 
-            for( unsigned int i = 0; i < remove_files.size(); i++ )
+            for(auto & remove_file : remove_files)
             {
-                string base = SplitPathFileName( remove_files[i] ).first;
+                string base = SplitPathFileName( remove_file ).first;
 
                 while( base.empty() == false )
                 {
@@ -1268,9 +1262,9 @@ void ClearCache( bool dry_run )
 
             sort(empty_folder_paths.begin(), empty_folder_paths.end(), string_sort_by_length_r );
 
-            for( unsigned i = 0; i < empty_folder_paths.size(); i++ )
+            for(auto & empty_folder_path : empty_folder_paths)
             {
-                string path = write_data_path.str() + empty_folder_paths[i];
+                string path = write_data_path.str() + empty_folder_path;
                 LOGI << "Removing Empty Folder:" << path << endl;
                 if( deletefile(path.c_str()) != 0 )
                 {
@@ -1280,9 +1274,9 @@ void ClearCache( bool dry_run )
             }
         }
 
-        for( unsigned int i = 0; i < keep_files.size(); i++ )
+        for(auto & keep_file : keep_files)
         {
-            string path = write_data_path.str() + keep_files[i];
+            string path = write_data_path.str() + keep_file;
             LOGI << "Keeping: " << path << endl;
         }
     }

--- a/Source/Internal/hardware_specs.cpp
+++ b/Source/Internal/hardware_specs.cpp
@@ -155,20 +155,20 @@ static std::vector<std::string> extensions;
 
 static void LazyInit() {
     if(initialized == false) {
-        for (unsigned int i = 0; i < ARRAYSIZE(GLQUERY_INFOS); ++i) {
+        for (auto i : GLQUERY_INFOS) {
             GLint values[2];
-            glGetIntegerv(GLQUERY_INFOS[i].m_GLint, values);
+            glGetIntegerv(i.m_GLint, values);
             GLenum err = glGetError();
             if (err != GL_NONE) {
-                integer_limits[GLQUERY_INFOS[i].m_name] = -1;
-            } else if (GLQUERY_INFOS[i].m_numValues == 1) {
-                integer_limits[GLQUERY_INFOS[i].m_name] = values[0];
+                integer_limits[i.m_name] = -1;
+            } else if (i.m_numValues == 1) {
+                integer_limits[i.m_name] = values[0];
 
-                if( GLQUERY_INFOS[i].m_GLint == GL_MAX_TEXTURE_SIZE ) {
+                if( i.m_GLint == GL_MAX_TEXTURE_SIZE ) {
                     max_texture_size = values[0];
                 }
             } else {
-                ivec2_limits[GLQUERY_INFOS[i].m_name] = ivec2(values[0],values[1]);
+                ivec2_limits[i.m_name] = ivec2(values[0],values[1]);
             }
         }
 
@@ -271,8 +271,8 @@ void PrintGPU(std::string &total_string, bool short_output)
         }
 
         total_string += "\n[Available OpenGL extensions]\n";
-        for (int i = 0; i < extensions.size(); i++) {
-            FormatString(temp_string, TEMP_STRING_LENGTH, "%s\n", extensions[i].c_str());
+        for (auto & extension : extensions) {
+            FormatString(temp_string, TEMP_STRING_LENGTH, "%s\n", extension.c_str());
             total_string += temp_string;
         }
     }

--- a/Source/Internal/locale.cpp
+++ b/Source/Internal/locale.cpp
@@ -78,11 +78,11 @@ static CScriptArray* ASGetLocaleShortcodes() {
     CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
     array->Reserve(locales.size());
 
-    for(LocaleMap::iterator iter = locales.begin(); iter != locales.end(); ++iter) {
+    for(auto & locale : locales) {
         // InsertLast doesn't actually do anything but copy from the pointer,
         // so a const_cast would be fine, but maybe an update to AS could change
         // that
-        std::string str = iter->first;
+        std::string str = locale.first;
         array->InsertLast(&str);
     }
 
@@ -96,11 +96,11 @@ static CScriptArray* ASGetLocaleNames() {
     CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
     array->Reserve(locales.size());
 
-    for(LocaleMap::iterator iter = locales.begin(); iter != locales.end(); ++iter) {
+    for(auto & locale : locales) {
         // InsertLast doesn't actually do anything but copy from the pointer,
         // so a const_cast would be fine, but maybe an update to AS could change
         // that
-        std::string str = iter->second;
+        std::string str = locale.second;
         array->InsertLast(&str);
     }
 

--- a/Source/Internal/modloading.cpp
+++ b/Source/Internal/modloading.cpp
@@ -1131,12 +1131,11 @@ void ModInstance::Reload( ) {
         }
 
         //Check if mod has files in root folder we don't like.
-        for( unsigned i = 0; i < manifest.size(); i++ ) {
+        for(auto & str : manifest) {
             bool is_root = true;
 
-            std::string &str = manifest[i];
-            for( unsigned k = 0; k < str.size(); k++ ) {
-                if( str[k] == '/' ) {
+            for(char k : str) {
+                if( k == '/' ) {
                     is_root = false;
                 }
             }
@@ -1740,11 +1739,11 @@ std::vector<ModID> ModInstance::GetIDCollisionsWithActiveMods() const {
     std::vector<ModInstance*>::iterator modit = ModLoading::Instance().mods.begin();
 
     std::set<const char*, CharLess> campaign_ids;
-    for(size_t i = 0; i < campaigns.size(); i++) {
-        if(campaign_ids.count(campaigns[i].id) != 0)
+    for(const auto & campaign : campaigns) {
+        if(campaign_ids.count(campaign.id) != 0)
             colliding_sids.push_back(sid);
         else
-            campaign_ids.insert(campaigns[i].id);
+            campaign_ids.insert(campaign.id);
     }
 
     for(; modit != ModLoading::Instance().mods.end(); modit++ ) {
@@ -2143,10 +2142,10 @@ std::vector<ModInstance*>::iterator ModLoading::GetMod( const std::string& path 
 }
 
 bool ModLoading::IsCampaignPresent(const std::string& campaign) {
-	for (uint32_t i = 0; i < mods.size(); i++) {
-		if (mods[i]->IsActive()) {
-			for (uint32_t j = 0; j < mods[i]->campaigns.size(); j++) {
-				if (strmtch(mods[i]->campaigns[j].id, campaign)) {
+	for (auto & mod : mods) {
+		if (mod->IsActive()) {
+			for (uint32_t j = 0; j < mod->campaigns.size(); j++) {
+				if (strmtch(mod->campaigns[j].id, campaign)) {
 					return true;
 				}
 			}
@@ -2156,11 +2155,11 @@ bool ModLoading::IsCampaignPresent(const std::string& campaign) {
 }
 
 bool ModLoading::CampaignHasLevel(const std::string& campaign, const std::string& level_path)  {
-	for (uint32_t i = 0; i < mods.size(); i++) {
-		if (mods[i]->IsActive()) {
-			for (uint32_t j = 0; j < mods[i]->campaigns.size(); j++) {
-				if (strmtch(mods[i]->campaigns[j].id, campaign)) {
-					for (const auto& level : mods[i]->campaigns[j].levels){
+	for (auto & mod : mods) {
+		if (mod->IsActive()) {
+			for (uint32_t j = 0; j < mod->campaigns.size(); j++) {
+				if (strmtch(mod->campaigns[j].id, campaign)) {
+					for (const auto& level : mod->campaigns[j].levels){
 						LOGI << "path: " << std::string("Data/Levels/") + level.path.str() << std::endl;
 						LOGI << "Level path: " << level_path << std::endl;
 						if (level.path.str() == level_path) {
@@ -2248,11 +2247,11 @@ bool ModLoading::IsActive( std::string id ) {
 }
 
 ModInstance::Campaign ModLoading::GetCampaign(std::string& campaign_id) {
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if( mods[i]->IsActive() ) {
-            for( uint32_t j = 0; j < mods[i]->campaigns.size(); j++) {
-                if( strmtch( mods[i]->campaigns[j].id, campaign_id ) ) {
-                    return mods[i]->campaigns[j];
+    for(auto & mod : mods) {
+        if( mod->IsActive() ) {
+            for( uint32_t j = 0; j < mod->campaigns.size(); j++) {
+                if( strmtch( mod->campaigns[j].id, campaign_id ) ) {
+                    return mod->campaigns[j];
                 }
             }
         }
@@ -2261,11 +2260,11 @@ ModInstance::Campaign ModLoading::GetCampaign(std::string& campaign_id) {
 }
 
 ModInstance* ModLoading::GetModInstance(const std::string& campaign_id) {
-    for (uint32_t i = 0; i < mods.size(); i++) {
-        if (mods[i]->IsActive()) {
-            for (uint32_t j = 0; j < mods[i]->campaigns.size(); j++) {
-                if (strmtch(mods[i]->campaigns[j].id, campaign_id)) {
-                    return mods[i];
+    for (auto & mod : mods) {
+        if (mod->IsActive()) {
+            for (uint32_t j = 0; j < mod->campaigns.size(); j++) {
+                if (strmtch(mod->campaigns[j].id, campaign_id)) {
+                    return mod;
                 }
             }
         }
@@ -2275,11 +2274,11 @@ ModInstance* ModLoading::GetModInstance(const std::string& campaign_id) {
 
 std::vector<ModInstance::Campaign> ModLoading::GetCampaigns() {
     std::vector<ModInstance::Campaign> campaigns;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if( mods[i]->IsActive() ) {
-            for( uint32_t j = 0; j < mods[i]->campaigns.size(); j++ ) {
-                if(strlen( mods[i]->campaigns[j].title ) > 0 ) {
-                    campaigns.push_back(mods[i]->campaigns[j]);
+    for(auto & mod : mods) {
+        if( mod->IsActive() ) {
+            for( uint32_t j = 0; j < mod->campaigns.size(); j++ ) {
+                if(strlen( mod->campaigns[j].title ) > 0 ) {
+                    campaigns.push_back(mod->campaigns[j]);
                 }
             }
         }
@@ -2290,9 +2289,9 @@ std::vector<ModInstance::Campaign> ModLoading::GetCampaigns() {
 
 std::vector<ModInstance*> ModLoading::GetModsMatchingID(std::string id) {
     std::vector<ModInstance*> lmods;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if( strmtch( mods[i]->id, id ) ) {
-            lmods.push_back(mods[i]);
+    for(auto & mod : mods) {
+        if( strmtch( mod->id, id ) ) {
+            lmods.push_back(mod);
         }
     }
     return lmods;
@@ -2300,9 +2299,9 @@ std::vector<ModInstance*> ModLoading::GetModsMatchingID(std::string id) {
 
 std::vector<ModInstance*> ModLoading::GetSteamModsMatchingID(std::string id) {
     std::vector<ModInstance*> lmods;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if( strmtch( mods[i]->id, id ) && mods[i]->modsource == ModSourceSteamworks) {
-            lmods.push_back(mods[i]);
+    for(auto & mod : mods) {
+        if( strmtch( mod->id, id ) && mod->modsource == ModSourceSteamworks) {
+            lmods.push_back(mod);
         }
     }
     return lmods;
@@ -2310,9 +2309,9 @@ std::vector<ModInstance*> ModLoading::GetSteamModsMatchingID(std::string id) {
 
 std::vector<ModInstance*> ModLoading::GetLocalModsMatchingID(std::string id) {
     std::vector<ModInstance*> lmods;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if( strmtch( mods[i]->id, id ) && mods[i]->modsource == ModSourceLocalModFolder) {
-            lmods.push_back(mods[i]);
+    for(auto & mod : mods) {
+        if( strmtch( mod->id, id ) && mod->modsource == ModSourceLocalModFolder) {
+            lmods.push_back(mod);
         }
     }
     return lmods;
@@ -2320,9 +2319,9 @@ std::vector<ModInstance*> ModLoading::GetLocalModsMatchingID(std::string id) {
 
 std::vector<ModInstance*> ModLoading::GetLocalMods() {
     std::vector<ModInstance*> lmods;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        if(mods[i]->modsource == ModSourceLocalModFolder) {
-            lmods.push_back(mods[i]);
+    for(auto & mod : mods) {
+        if(mod->modsource == ModSourceLocalModFolder) {
+            lmods.push_back(mod);
         }
     }
     return lmods;
@@ -2330,8 +2329,8 @@ std::vector<ModInstance*> ModLoading::GetLocalMods() {
 
 std::vector<ModInstance*> ModLoading::GetAllMods() {
     std::vector<ModInstance*> lmods;
-    for( uint32_t i = 0; i < mods.size(); i++ ) {
-        lmods.push_back(mods[i]);
+    for(auto & mod : mods) {
+        lmods.push_back(mod);
     }
     return lmods;
 }
@@ -2348,12 +2347,12 @@ void ModLoading::AddMod( const std::string& path ) {
 
 
 std::string ModLoading::WhichCampaignLevelBelongsTo(const std::string & level_path) {
-	for (uint32_t i = 0; i < mods.size(); i++) {
-		if (mods[i]->IsActive()) {
-			for (uint32_t j = 0; j < mods[i]->campaigns.size(); j++) {
-				for (const auto& level : mods[i]->campaigns[j].levels) {
+	for (auto & mod : mods) {
+		if (mod->IsActive()) {
+			for (uint32_t j = 0; j < mod->campaigns.size(); j++) {
+				for (const auto& level : mod->campaigns[j].levels) {
 					if (std::string("Data/Levels/") + level.path.str() == level_path) {
-						return mods[i]->campaigns[j].id.str();
+						return mod->campaigns[j].id.str();
 					}
 				}
 			}
@@ -2423,22 +2422,22 @@ void ModLoading::DetectMods() {
 
     std::vector<std::string> verifiedMods;
 
-    for( unsigned i = 0; i < newMods.size(); i++ ) {
+    for(auto & newMod : newMods) {
         bool already_in_list = false;
         bool has_mod_xml = false;
 
-        if( CheckFileAccess(std::string(newMods[i] + "/mod.xml").c_str() ) ) {
+        if( CheckFileAccess(std::string(newMod + "/mod.xml").c_str() ) ) {
             has_mod_xml = true;
         }
 
         if( has_mod_xml ) {
-            for( unsigned k = 0; k < verifiedMods.size(); k++ ) {
-                if( AreSame( std::string(newMods[i] + "/mod.xml").c_str(), std::string(verifiedMods[k] + "/mod.xml").c_str() ) ) {
+            for(auto & verifiedMod : verifiedMods) {
+                if( AreSame( std::string(newMod + "/mod.xml").c_str(), std::string(verifiedMod + "/mod.xml").c_str() ) ) {
                     already_in_list = true; 
                 } 
             }
             if( already_in_list == false ) {
-                verifiedMods.push_back(newMods[i]);
+                verifiedMods.push_back(newMod);
             }
         }
     }
@@ -2479,37 +2478,37 @@ void ModLoading::SetMods( std::vector<std::string> modpaths ) {
         missingPaths = currentPaths;
         stillPaths = std::vector<std::string>(); //Empty as intersection is guaranteed to be zero
     } else {
-        for( unsigned k = 0; k < modpaths.size(); k++ ) {
+        for(auto & modpath : modpaths) {
             bool found = false;
-            for( unsigned i = 0; i < currentPaths.size(); i++ ) {
-                if( modpaths[k] == currentPaths[i] ) {
+            for(auto & currentPath : currentPaths) {
+                if( modpath == currentPath ) {
                     found = true;
                 } 
             }
             if( found == false ) {
-                newPaths.push_back( modpaths[k] );
+                newPaths.push_back( modpath );
             }
         }
-        for( unsigned i = 0; i < currentPaths.size(); i++ ) {
+        for(auto & currentPath : currentPaths) {
             bool found = false;
-            for( unsigned k = 0; k < modpaths.size(); k++ ) {
-                if( modpaths[k] == currentPaths[i] ) {
+            for(auto & modpath : modpaths) {
+                if( modpath == currentPath ) {
                     found = true;
                 } 
             }
             if( found == false ) {
-                missingPaths.push_back( currentPaths[i] );
+                missingPaths.push_back( currentPath );
             }
         }
-        for( unsigned i = 0; i < currentPaths.size(); i++ ) {
+        for(auto & currentPath : currentPaths) {
             bool found = false;
-            for( unsigned k = 0; k < modpaths.size(); k++ ) {
-                if( modpaths[k] == currentPaths[i] ) {
+            for(auto & modpath : modpaths) {
+                if( modpath == currentPath ) {
                     found = true;
                 } 
             }
             if( found ) {
-                stillPaths.push_back( currentPaths[i] );
+                stillPaths.push_back( currentPath );
             }
         }
     }
@@ -2544,8 +2543,8 @@ const std::vector<ModInstance*>& ModLoading::GetMods() {
 
 const std::vector<ModID> ModLoading::GetModsSid() {
     std::vector<ModID> vals;
-    for( unsigned i = 0; i < mods.size(); i++ ) {
-        vals.push_back( mods[i]->GetSid() );
+    for(auto & mod : mods) {
+        vals.push_back( mod->GetSid() );
     } 
     return vals;
 }
@@ -2624,10 +2623,8 @@ std::ostream& operator<<(std::ostream& os, const ModInstance::ModDependency &md 
 
     os << "-Versions-" << std::endl;
     
-    for( std::vector<std::string>::const_iterator sit = md.versions.begin();
-            sit != md.versions.end();
-            sit++) {
-        os << *sit << std::endl;
+    for(const auto & version : md.versions) {
+        os << version << std::endl;
     } 
 
     return os;
@@ -2642,34 +2639,26 @@ std::ostream& operator<<(std::ostream& os, const ModInstance &mi ) {
     os << "Valid:" << mi.GetValidity() << std::endl;
     os << "-Supported Versions-" << std::endl;
     
-    for( std::vector<std::string>::const_iterator sit = mi.supported_versions.begin();
-            sit != mi.supported_versions.end();
-            sit++) {
-        os << *sit << std::endl;
+    for(const auto & supported_version : mi.supported_versions) {
+        os << supported_version << std::endl;
     } 
 
     os << "-Mod Dependencies-" << std::endl;
     
-    for( std::vector<ModInstance::ModDependency>::const_iterator mdit = mi.mod_dependencies.begin();
-            mdit != mi.mod_dependencies.end();
-            mdit++) {
-        os << *mdit << std::endl;
+    for(const auto & mod_dependencie : mi.mod_dependencies) {
+        os << mod_dependencie << std::endl;
     } 
 
     os << "-Manifest -" << std::endl;
     
-    for( std::vector<std::string>::const_iterator sit = mi.manifest.begin();
-            sit != mi.manifest.end();
-            sit++) {
-        os << *sit << std::endl;
+    for(const auto & sit : mi.manifest) {
+        os << sit << std::endl;
     } 
 
     os << "-Overloaded Files-" << std::endl;
     
-    for( std::vector<std::string>::const_iterator sit = mi.overload_files.begin();
-            sit != mi.overload_files.end();
-            sit++) {
-        os << *sit << std::endl;
+    for(const auto & overload_file : mi.overload_files) {
+        os << overload_file << std::endl;
     } 
 
     return os;

--- a/Source/Internal/path_set.cpp
+++ b/Source/Internal/path_set.cpp
@@ -28,8 +28,7 @@
 
 void PathSetUtil::GetCachedFiles( PathSet& path_set ) {
     PathSet new_path_set;
-    for(PathSet::iterator iter = path_set.begin(); iter != path_set.end(); ++iter){
-        const std::string &labeled_path = (*iter);
+    for(const auto & labeled_path : path_set){
         size_t space_pos = labeled_path.find(' ');
         if(space_pos == std::string::npos){
             DisplayError("Error", ("No space found in labeled string: "+labeled_path).c_str());

--- a/Source/Internal/timer.cpp
+++ b/Source/Internal/timer.cpp
@@ -185,7 +185,7 @@ Timer::Timer():
 	last_tick(0),
     wall_time(0)
 {
-    for(unsigned long & i : frame){
-        i=0;
+    for (auto& i : frame) {
+        i = 0;
     }
 }

--- a/Source/Internal/timer.cpp
+++ b/Source/Internal/timer.cpp
@@ -89,8 +89,8 @@ float Timer::GetRenderTime() {
 
 float Timer::GetAverageFrameTime() { 
 	float sum = .0f;
-	for (int i = 0; i < NUM_AVERAGED_FRAMES; i++) {
-		sum += frame[i];
+	for (unsigned long i : frame) {
+		sum += i;
 	}
 
 	return sum / (float)NUM_AVERAGED_FRAMES;
@@ -185,7 +185,7 @@ Timer::Timer():
 	last_tick(0),
     wall_time(0)
 {
-    for(int i=0; i<NUM_AVERAGED_FRAMES; i++){
-        frame[i]=0;
+    for(unsigned long & i : frame){
+        i=0;
     }
 }

--- a/Source/Internal/treestructure.cpp
+++ b/Source/Internal/treestructure.cpp
@@ -48,8 +48,8 @@ int GetTotalNumChildren(int parent, const std::vector<int> &parents){
 
 int GetNumChildren(int parent, const std::vector<int> &parents){
     int num_children = 0;
-    for(unsigned i=0; i<parents.size(); ++i){
-        if(parents[i] == parent){
+    for(int i : parents){
+        if(i == parent){
             ++num_children;
         }
     }
@@ -62,8 +62,8 @@ int GetNumConnections(int parent, const std::vector<int> &parents){
     if(parents[parent] != -1){
         ++num_connections;    
     }
-    for(unsigned i=0; i<parents.size(); ++i){
-        if(parents[i] == parent){
+    for(int i : parents){
+        if(i == parent){
             ++num_connections;
         }
     }
@@ -145,8 +145,8 @@ std::vector<int> GetChildrenRecursive( int parent, const std::vector<int> &paren
         if(parents[i] == parent){
             children.push_back(i);
             std::vector<int> sub_children = GetChildrenRecursive(i, parents);
-            for(unsigned j=0; j<sub_children.size(); ++j){
-                children.push_back(sub_children[j]);
+            for(int & j : sub_children){
+                children.push_back(j);
             }
         }
     }
@@ -179,11 +179,11 @@ std::vector<int> FindTreePath( int a, int b, const std::vector<int> &parents )
         queue.pop();
 
         std::vector<int> connections = GetConnections(path.back(), parents);
-        for(unsigned i=0; i<connections.size(); ++i){
-            if(find(path.begin(), path.end(),connections[i]) == path.end()){
+        for(int & connection : connections){
+            if(find(path.begin(), path.end(),connection) == path.end()){
                 queue.push(path);
-                queue.back().push_back(connections[i]);
-                if(connections[i] == b){
+                queue.back().push_back(connection);
+                if(connection == b){
                     return queue.back();
                 }
             }

--- a/Source/JSON/jsoncpp.cpp
+++ b/Source/JSON/jsoncpp.cpp
@@ -968,10 +968,7 @@ std::string Reader::getFormatedErrorMessages() const {
 
 std::string Reader::getFormattedErrorMessages() const {
   std::string formattedMessage;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end();
-       ++itError) {
-    const ErrorInfo& error = *itError;
+  for (const auto & error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -1894,10 +1891,7 @@ std::string OurReader::getLocationLineAndColumn(Location location) const {
 
 std::string OurReader::getFormattedErrorMessages() const {
   std::string formattedMessage;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end();
-       ++itError) {
-    const ErrorInfo& error = *itError;
+  for (const auto & error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -3695,8 +3689,7 @@ void Path::invalidPath(const std::string& /*path*/, int /*location*/) {
 
 const Value& Path::resolve(const Value& root) const {
   const Value* node = &root;
-  for (Args::const_iterator it = args_.begin(); it != args_.end(); ++it) {
-    const PathArgument& arg = *it;
+  for (const auto & arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray() || !node->isValidIndex(arg.index_)) {
         // Error: unable to resolve path (array value expected at position...
@@ -3718,8 +3711,7 @@ const Value& Path::resolve(const Value& root) const {
 
 Value Path::resolve(const Value& root, const Value& defaultValue) const {
   const Value* node = &root;
-  for (Args::const_iterator it = args_.begin(); it != args_.end(); ++it) {
-    const PathArgument& arg = *it;
+  for (const auto & arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray() || !node->isValidIndex(arg.index_))
         return defaultValue;
@@ -3737,8 +3729,7 @@ Value Path::resolve(const Value& root, const Value& defaultValue) const {
 
 Value& Path::make(Value& root) const {
   Value* node = &root;
-  for (Args::const_iterator it = args_.begin(); it != args_.end(); ++it) {
-    const PathArgument& arg = *it;
+  for (const auto & arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray()) {
         // Error: node is not an array at position ...

--- a/Source/JSON/jsonhelper.cpp
+++ b/Source/JSON/jsonhelper.cpp
@@ -55,9 +55,9 @@ void testJSON() {
     
     Json::Value::Members members = root.getMemberNames();
     
-    for( Json::Value::Members::iterator itr = members.begin(); itr != members.end(); ++itr )
+    for(auto & member : members)
     {
-        std::cout << *itr << std::endl;
+        std::cout << member << std::endl;
     }
     
     

--- a/Source/Logging/logdata.cpp
+++ b/Source/Logging/logdata.cpp
@@ -109,24 +109,24 @@ void LogSystem::RegisterLogHandler( LogTypeMask types, LogHandler* newHandler )
 
     //Disable if enabled first.
     enabledLogTypes = 0;
-    for( int i = 0; i < LOGGER_LIMIT; i++ )
+    for(auto & handler : handlers)
     {
-        if( handlers[i].handler == newHandler )
+        if( handler.handler == newHandler )
         {
-            handlers[i].types = 0U;
-            handlers[i].handler = NULL;
-        } else if (handlers[i].handler != NULL) {
-            enabledLogTypes |= handlers[i].types;
+            handler.types = 0U;
+            handler.handler = NULL;
+        } else if (handler.handler != NULL) {
+            enabledLogTypes |= handler.types;
         }
     }
 
     //Then enable.
-    for( int i = 0; i < LOGGER_LIMIT; i++ )
+    for(auto & handler : handlers)
     {
-        if( handlers[i].handler == NULL )
+        if( handler.handler == NULL )
         {
-            handlers[i].types = types;
-            handlers[i].handler = newHandler;
+            handler.types = types;
+            handler.handler = newHandler;
             worked = true;
             break;
         } 
@@ -144,14 +144,14 @@ void LogSystem::DeregisterLogHandler( LogHandler* newHandler )
 	logMutex.lock();
 
     enabledLogTypes = 0;
-    for( int i = 0; i < LOGGER_LIMIT; i++ )
+    for(auto & handler : handlers)
     {
-        if( handlers[i].handler == newHandler )
+        if( handler.handler == newHandler )
         {
-            handlers[i].types = 0U;
-            handlers[i].handler = NULL;
-        } else if (handlers[i].handler != NULL) {
-            enabledLogTypes |= handlers[i].types;
+            handler.types = 0U;
+            handler.handler = NULL;
+        } else if (handler.handler != NULL) {
+            enabledLogTypes |= handler.types;
         }
     }
 
@@ -160,11 +160,11 @@ void LogSystem::DeregisterLogHandler( LogHandler* newHandler )
 
 void LogSystem::Flush()
 {
-    for( int i = 0; i < LOGGER_LIMIT; i++ )
+    for(auto & handler : handlers)
     {
-        if( handlers[i].handler != NULL)
+        if( handler.handler != NULL)
         {
-            handlers[i].handler->Flush();
+            handler.handler->Flush();
         }
     }
 }
@@ -337,12 +337,12 @@ LogSystem::LogData::~LogData()
 
 	string msg = ss.str();
 
-    for( int i = 0; i < LOGGER_LIMIT; i++ )
+    for(auto & handler : handlers)
     {
-        if( handlers[i].handler != NULL && 
-            (m_type & handlers[i].types) )
+        if( handler.handler != NULL && 
+            (m_type & handler.types) )
         {
-            handlers[i].handler->Log( m_type, m_line, m_filename, m_prefix, msg.c_str(), m_message );
+            handler.handler->Log( m_type, m_line, m_filename, m_prefix, msg.c_str(), m_message );
         }
     }
 

--- a/Source/Main/altmain.cpp
+++ b/Source/Main/altmain.cpp
@@ -57,8 +57,7 @@
 
 void CompressPathSet(PathSet path_set, const std::string &base_folder, const std::string &dst){
     bool first_path = true;
-    for(PathSet::iterator iter = path_set.begin(); iter != path_set.end(); ++iter){
-        const std::string &full_path = (*iter);
+    for(const auto & full_path : path_set){
         const char* truncated_path = &full_path[base_folder.length()];
         Zip(full_path, dst, truncated_path, first_path?_YES_OVERWRITE:_APPEND_OVERWRITE);
         first_path = false;
@@ -141,8 +140,7 @@ int TestMain( int argc, char* argv[], const char* overloaded_write_dir, const ch
     LOGI << "Objects: " << ref->objects.size() << std::endl;
 	const char* key_words[] = {"left", "capsule", "box", "sphere"};
 	const int num_key_words = sizeof(key_words)/sizeof(key_words[0]);
-	for(size_t i=0, len=ref->objects.size(); i<len; ++i){
-        const FZXObject &object = ref->objects[i];
+	for(auto & object : ref->objects){
         // Parse label string
         const std::string &label = object.label;      
         size_t last_space_index = 0;
@@ -160,10 +158,10 @@ int TestMain( int argc, char* argv[], const char* overloaded_write_dir, const ch
                     ++count;
 				}
                 bool match = false;
-                for(int k=0; k<num_key_words; ++k){
-                    bool word_match = (strcmp(key_words[k], sub_str_buf.c_str())==0);
+                for(auto & key_word : key_words){
+                    bool word_match = (strcmp(key_word, sub_str_buf.c_str())==0);
                     if(word_match){
-                        LOGI << "Token found: " << key_words[k] << std::endl;
+                        LOGI << "Token found: " << key_word << std::endl;
                         match = true;
                     }
                 }

--- a/Source/Math/mat4.cpp
+++ b/Source/Math/mat4.cpp
@@ -437,8 +437,8 @@ mat4 mat4::operator-(void) const
 {
     mat4 result(*this);
 
-    for (float & entrie : result.entries)
-        entrie=-entrie;
+    for (float & entry : result.entries)
+        entry=-entry;
 
     return result;
 }

--- a/Source/Math/mat4.cpp
+++ b/Source/Math/mat4.cpp
@@ -437,8 +437,8 @@ mat4 mat4::operator-(void) const
 {
     mat4 result(*this);
 
-    for (int i = 0; i<16; i++)
-        result.entries[i]=-result.entries[i];
+    for (float & entrie : result.entries)
+        entrie=-entrie;
 
     return result;
 }

--- a/Source/Memory/stack_allocator.cpp
+++ b/Source/Memory/stack_allocator.cpp
@@ -101,8 +101,8 @@ uintptr_t StackAllocator::TopBlockSize() {
 }
 
 void StackAllocator::Init(void* p_mem, size_t p_size) {
-    for (int i = 0; i < kMaxBlocks; i++) {
-        stack_block_pts[i] = 0;
+    for (unsigned long & stack_block_pt : stack_block_pts) {
+        stack_block_pt = 0;
     }
     mem = p_mem;
     size = p_size;
@@ -110,8 +110,8 @@ void StackAllocator::Init(void* p_mem, size_t p_size) {
 }
 
 void StackAllocator::Dispose() {
-    for (int i = 0; i < kMaxBlocks; i++) {
-        stack_block_pts[i] = 0;
+    for (unsigned long & stack_block_pt : stack_block_pts) {
+        stack_block_pt = 0;
     }
     mem = 0;
     size = 0;

--- a/Source/Memory/stack_allocator.cpp
+++ b/Source/Memory/stack_allocator.cpp
@@ -101,7 +101,7 @@ uintptr_t StackAllocator::TopBlockSize() {
 }
 
 void StackAllocator::Init(void* p_mem, size_t p_size) {
-    for (unsigned long & stack_block_pt : stack_block_pts) {
+    for (auto & stack_block_pt : stack_block_pts) {
         stack_block_pt = 0;
     }
     mem = p_mem;
@@ -110,7 +110,7 @@ void StackAllocator::Init(void* p_mem, size_t p_size) {
 }
 
 void StackAllocator::Dispose() {
-    for (unsigned long & stack_block_pt : stack_block_pts) {
+    for (auto & stack_block_pt : stack_block_pts) {
         stack_block_pt = 0;
     }
     mem = 0;

--- a/Source/Objects/ambientsoundobject.cpp
+++ b/Source/Objects/ambientsoundobject.cpp
@@ -68,8 +68,7 @@ AmbientSoundObject::~AmbientSoundObject() {
 bool AmbientSoundObject::SetFromDesc( const EntityDescription& desc ){
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_FILE_PATH: {
                     std::string type_file;

--- a/Source/Objects/decalobject.cpp
+++ b/Source/Objects/decalobject.cpp
@@ -143,8 +143,7 @@ void DecalObject::GetDesc(EntityDescription &desc) const {
 bool DecalObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_FILE_PATH: {
                     std::string type_file;

--- a/Source/Objects/dynamiclightobject.cpp
+++ b/Source/Objects/dynamiclightobject.cpp
@@ -116,8 +116,7 @@ bool DynamicLightObject::SetFromDesc( const EntityDescription& desc ) {
     LOG_ASSERT(light_id_ == -1);
     bool ret = Object::SetFromDesc(desc);
     if(ret) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
             case EDF_COLOR: {
                 memread(color.entries, sizeof(float), 3, field.data);

--- a/Source/Objects/envobject.cpp
+++ b/Source/Objects/envobject.cpp
@@ -128,16 +128,14 @@ static void UpdateDetailObjectSurfaces(EnvObject::DOSList *detail_object_surface
                                        int model_id)
 {
     //TODO: Make sure we aren't duplicating code from Terrain.cpp
-    for(int i=0, len=detail_object_surfaces->size(); i<len; ++i){
-        delete detail_object_surfaces->at(i);
+    for(auto & detail_object_surface : *detail_object_surfaces){
+        delete detail_object_surface;
     }
     detail_object_surfaces->clear();
     detail_object_surfaces->resize(ofr->m_detail_object_layers.size());
     int counter = 0;
-    for(EnvObject::DOSList::iterator iter = detail_object_surfaces->begin();
-        iter != detail_object_surfaces->end(); ++iter)
+    for(auto & dos : *detail_object_surfaces)
     {
-        DetailObjectSurface*& dos = (*iter);
         dos = new DetailObjectSurface();
         DetailObjectLayer& dol = ofr->m_detail_object_layers[counter];
         dos->AttachTo(Models::Instance()->GetModel(model_id), transform);
@@ -212,8 +210,8 @@ const MaterialEvent& EnvObject::GetMaterialEvent( const std::string &the_event, 
 
 EnvObject::~EnvObject() {
     RemovePhysicsShape();
-    for(int i=0, len=detail_object_surfaces.size(); i<len; ++i){
-        delete detail_object_surfaces[i];
+    for(auto & detail_object_surface : detail_object_surfaces){
+        delete detail_object_surface;
     }
 }
 
@@ -658,8 +656,7 @@ void EnvObject::DrawInstances(EnvObject** instance_array, int num_instances, con
         } else {
             std::vector<mat4> light_volume_matrix;
             std::vector<mat4> light_volume_matrix_inverse;
-            for(int i=0, len=scenegraph_->light_volume_objects_.size(); i<len; ++i){
-                Object* obj = scenegraph_->light_volume_objects_[i];
+            for(auto obj : scenegraph_->light_volume_objects_){
                 const mat4 &mat = obj->GetTransform();
                 light_volume_matrix.push_back(mat);
                 light_volume_matrix_inverse.push_back(invert(mat));
@@ -900,10 +897,9 @@ void EnvObject::PreDrawCamera(float curr_game_time) {
         return;
     }
 
-    for(DOSList::iterator iter = detail_object_surfaces.begin();
-        iter != detail_object_surfaces.end(); ++iter)
+    for(auto & detail_object_surface : detail_object_surfaces)
     {
-        (*iter)->PreDrawCamera(transform_);
+        detail_object_surface->PreDrawCamera(transform_);
     }
 }
 
@@ -1019,15 +1015,15 @@ void CreatePointCloud(std::vector<vec3> &points, const Model &model, const Image
         vec3 verts[3];
         int face_index = 0;
         int vert_index;
-        for(unsigned i=0; i<triangle_area.size(); ++i){
+        for(float & i : triangle_area){
             for(unsigned j=0; j<3; ++j){
                 vert_index = model.faces[face_index+j]*3;
                 verts[j] = vec3(model.vertices[vert_index+0],
                                 model.vertices[vert_index+1],
                                 model.vertices[vert_index+2]);
             }
-            triangle_area[i] = length(cross(verts[2]-verts[0], verts[1]-verts[0]))*0.5f;
-            total_triangle_area += triangle_area[i];
+            i = length(cross(verts[2]-verts[0], verts[1]-verts[0]))*0.5f;
+            total_triangle_area += i;
             face_index += 3;
         }
     }
@@ -1070,8 +1066,8 @@ void CreatePointCloud(std::vector<vec3> &points, const Model &model, const Image
     }
 
     vec3 center;
-    for(unsigned i=0; i<temp_points.size(); ++i){
-        center += temp_points[i];
+    for(auto & temp_point : temp_points){
+        center += temp_point;
     }
     center /= (float)temp_points.size();
 
@@ -1816,8 +1812,7 @@ void EnvObject::CreateLeaf(vec3 pos, vec3 vel, int iterations) {
 bool EnvObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_FILE_PATH: {
                     std::string type_file;
@@ -1855,15 +1850,15 @@ void EnvObject::ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args 
     case OBJECT_MSG::SET_COLOR: {
         //vec3 old_color = color_tint_component_.temp_tint();
         color_tint_component_.ReceiveObjectMessageVAList(type, args);
-        for(int i=0, len=detail_object_surfaces.size(); i<len; ++i){
-            detail_object_surfaces[i]->SetColorTint(GetDisplayTint());
+        for(auto & detail_object_surface : detail_object_surfaces){
+            detail_object_surface->SetColorTint(GetDisplayTint());
         }
         CalculateDisplayTint_();
         break;}
     case OBJECT_MSG::SET_OVERBRIGHT: {
         color_tint_component_.ReceiveObjectMessageVAList(type, args);
-        for(int i=0, len=detail_object_surfaces.size(); i<len; ++i){
-            detail_object_surfaces[i]->SetOverbright(GetOverbright());
+        for(auto & detail_object_surface : detail_object_surfaces){
+            detail_object_surface->SetOverbright(GetOverbright());
         }
         CalculateDisplayTint_();
         break;}

--- a/Source/Objects/envobjectattach.cpp
+++ b/Source/Objects/envobjectattach.cpp
@@ -31,8 +31,7 @@ void Serialize(const std::vector<AttachedEnvObject>& aeo, std::vector<char> &dat
         const AttachedEnvObject &attached_env_object = aeo[i];
         memwrite(&attached_env_object.direct_ptr, sizeof(attached_env_object.direct_ptr), 1, data);
         memwrite(&attached_env_object.legacy_obj_id, sizeof(attached_env_object.legacy_obj_id), 1, data);
-        for(unsigned j=0; j<kMaxBoneConnects; ++j){
-            const BoneConnect& bone_connect = attached_env_object.bone_connects[j];
+        for(const auto & bone_connect : attached_env_object.bone_connects){
             memwrite(&bone_connect.bone_id, sizeof(bone_connect.bone_id), 1, data);
             memwrite(&bone_connect.num_connections, sizeof(bone_connect.num_connections), 1, data);
             memwrite(&bone_connect.rel_mat, sizeof(bone_connect.rel_mat), 1, data);
@@ -50,8 +49,7 @@ void Deserialize(const std::vector<char> &data, std::vector<AttachedEnvObject>& 
         attached_env_object.bone_connection_dirty = false;
         memread(&attached_env_object.direct_ptr, sizeof(attached_env_object.direct_ptr), 1, data, index);
         memread(&attached_env_object.legacy_obj_id, sizeof(attached_env_object.legacy_obj_id), 1, data, index);
-        for(unsigned j=0; j<kMaxBoneConnects; ++j){
-            const BoneConnect& bone_connect = attached_env_object.bone_connects[j];
+        for(const auto & bone_connect : attached_env_object.bone_connects){
             memread((void*)&bone_connect.bone_id, sizeof(bone_connect.bone_id), 1, data, index);
             memread((void*)&bone_connect.num_connections, sizeof(bone_connect.num_connections), 1, data, index);
             memread((void*)&bone_connect.rel_mat, sizeof(bone_connect.rel_mat), 1, data, index);

--- a/Source/Objects/group.cpp
+++ b/Source/Objects/group.cpp
@@ -67,21 +67,21 @@ void Group::GetChildren(std::vector<Object*>* ret_children) {
 }
 
 void Group::GetBottomUpCompleteChildren(std::vector<Object*>* ret_children) {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object *obj = children[i].direct_ptr;
+    for(auto & i : children){
+        Object *obj = i.direct_ptr;
         obj->GetBottomUpCompleteChildren(ret_children);
         ret_children->push_back(obj); 
     }
 }
 
 void Group::GetTopDownCompleteChildren(std::vector<Object*>* ret_children) {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object *obj = children[i].direct_ptr;
+    for(auto & i : children){
+        Object *obj = i.direct_ptr;
         ret_children->push_back(obj); 
     }
 
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object *obj = children[i].direct_ptr;
+    for(auto & i : children){
+        Object *obj = i.direct_ptr;
         obj->GetTopDownCompleteChildren(ret_children);
     }
 }
@@ -99,19 +99,16 @@ void Group::ChildLost(Object *obj){
 
 void Group::FinalizeLoadedConnections() {
     Object::FinalizeLoadedConnections();
-	for(int i=0, len=children.size(); i<len; ++i ){
-		children[i].direct_ptr->ReceiveObjectMessage(OBJECT_MSG::FINALIZE_LOADED_CONNECTIONS);
+	for(auto & i : children){
+		i.direct_ptr->ReceiveObjectMessage(OBJECT_MSG::FINALIZE_LOADED_CONNECTIONS);
 	}
 }
 
 bool Group::SetFromDesc( const EntityDescription &desc ) {
 	bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for (int i=0, len=desc.children.size(); 
-             i<len; 
-             ++i) 
+        for (auto new_desc : desc.children) 
         {
-            EntityDescription new_desc = desc.children[i];
             Object* obj = CreateObjectFromDesc(new_desc); 
             if(obj){
                 obj->SetParent(this);
@@ -134,8 +131,8 @@ bool Group::SetFromDesc( const EntityDescription &desc ) {
 void Group::GetDesc(EntityDescription &desc) const {
     Object::GetDesc(desc);
 	desc.AddInt(EDF_VERSION, 1);
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object* obj = children[i].direct_ptr;
+    for(const auto & i : children){
+        Object* obj = i.direct_ptr;
         if(obj){
             if(obj == this){
                 FatalError("Error", "Group %d: GetDesc() including copy of itself", GetID());
@@ -147,8 +144,8 @@ void Group::GetDesc(EntityDescription &desc) const {
 }
 
 void Group::InitRelMats() {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object* obj = children[i].direct_ptr;
+    for(auto & i : children){
+        Object* obj = i.direct_ptr;
         if(obj && (obj->GetType() == _group || obj->GetType() == _prefab) && !obj->Selected()){
             Group* child_group = (Group*)obj;
             child_group->InitRelMats();
@@ -156,9 +153,9 @@ void Group::InitRelMats() {
     }
 
 	// Get child transforms relative to group transform
-	for(int i=0, len=children.size(); i<len; ++i){
-		Child& child = children[i];
-		Object* obj = children[i].direct_ptr;
+	for(auto & i : children){
+		Child& child = i;
+		Object* obj = i.direct_ptr;
 		if(obj){
 			child.rel_rotation    = invert(GetRotation()) * obj->GetRotation();
 			child.rel_translation = (invert(GetRotation()) * ((obj->GetTranslation() - translation_))/scale_);
@@ -172,8 +169,8 @@ void Group::InitShape() {
         return;
     }
 
-    for(int i=0, len=children.size(); i<len; ++i){
-        Object* obj = children[i].direct_ptr;
+    for(auto & i : children){
+        Object* obj = i.direct_ptr;
         if(obj && (obj->GetType() == _group || obj->GetType() == _prefab) && !obj->Selected()){
             Group* child_group = (Group*)obj;
             child_group->InitShape();
@@ -184,9 +181,9 @@ void Group::InitShape() {
     static const int MAX_POINTS = 800;
     int num_points = 0;
     vec3 points[MAX_POINTS];
-    for(int i=0, len=children.size(); i<len; ++i){
+    for(auto & i : children){
         if(num_points <= MAX_POINTS-8){
-            Object* obj = children[i].direct_ptr;
+            Object* obj = i.direct_ptr;
             if(obj){
                 //int index = 0;
                 for(int j=0; j<8; ++j){
@@ -235,8 +232,7 @@ void Group::PreDrawFrame(float curr_game_time) {
         PropagateTransformsDown(false);
     }
 
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
             obj->PreDrawFrame(curr_game_time);
@@ -251,8 +247,7 @@ void Group::SetTranslationRotationFast(const vec3& trans, const quaternion& rota
 }
 
 void Group::PropagateTransformsDownFast(bool deep) {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
 			obj->SetTranslationRotationFast(translation_ + (GetRotation() * (scale_ * child.rel_translation)), GetRotation() * child.rel_rotation);
@@ -265,8 +260,7 @@ void Group::PropagateTransformsDownFast(bool deep) {
 }
 
 void Group::PropagateTransformsDown(bool deep) {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
             obj->SetScale((invert(child.rel_rotation) * child.rel_scale) * scale_);
@@ -288,8 +282,7 @@ void Group::PreDrawCamera(float curr_game_time) {
         return;
     }
 
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
             obj->PreDrawCamera(curr_game_time);
@@ -307,8 +300,8 @@ void Group::ChildMoved(Object::MoveType type) {
 }
 
 void Group::UpdateParentHierarchy() {
-	for(int i=0, len=children.size(); i<len; ++i){
-		children[i].direct_ptr->UpdateParentHierarchy();
+	for(auto & i : children){
+		i.direct_ptr->UpdateParentHierarchy();
 	}
 }
 
@@ -322,8 +315,7 @@ void Group::GetDisplayName(char* buf, int buf_size) {
 
 void Group::SetEnabled(bool val) {
     enabled_ = val;
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
             obj->SetEnabled(val);
@@ -333,8 +325,7 @@ void Group::SetEnabled(bool val) {
 }
 
 void Group::HandleTransformationOccured() {
-    for(int i=0, len=children.size(); i<len; ++i){
-        Child& child = children[i];
+    for(auto & child : children){
         Object* obj = child.direct_ptr;
         if(obj){
             obj->HandleTransformationOccurred();
@@ -361,8 +352,8 @@ void Group::ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) {
 }
 
 void Group::RemapReferences(std::map<int,int> id_map) {
-    for(int i=0, len=children.size(); i<len; ++i){
-       children[i].direct_ptr->RemapReferences(id_map);  
+    for(auto & i : children){
+       i.direct_ptr->RemapReferences(id_map);  
     }
 }
 
@@ -373,8 +364,8 @@ ObjectSanityState Group::GetSanity() {
         sanity_flags |= kObjectSanity_G_Empty;
     }
 
-    for( uint32_t i = 0; i < children.size(); i++ ) {
-        if( children[i].direct_ptr ) {
+    for(auto & i : children) {
+        if( i.direct_ptr ) {
         } else {
             sanity_flags |= kObjectSanity_G_NullChild;
         }
@@ -393,10 +384,10 @@ ObjectSanityState Group::GetSanity() {
             std::vector<int> connections;
             obj->GetConnectionIDs(&connections);
 
-            for( uint32_t k = 0; k < connections.size(); k++ ) {
+            for(int connection : connections) {
                 bool internally_connected = false;
                 for( uint32_t t = 0; t < all_children.size(); t++ ) {
-                    if(all_children[i] && all_children[t]->GetID() == connections[k] ) {
+                    if(all_children[i] && all_children[t]->GetID() == connection ) {
                         internally_connected = true;
                     }
                 }

--- a/Source/Objects/hotspot.cpp
+++ b/Source/Objects/hotspot.cpp
@@ -394,8 +394,7 @@ void Hotspot::ASSetBoolVar( const std::string &name, bool value ) {
 bool Hotspot::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
             case EDF_FILE_PATH: {
                 std::string type_file;
@@ -643,8 +642,8 @@ CScriptArray* Hotspot::ASGetConnectedObjects() {
     CScriptArray* array = CScriptArray::Create(arrayType);
 
     array->Reserve(connected_to.size());
-    for(size_t i = 0; i < connected_to.size(); ++i) {
-        array->InsertLast(&connected_to[i]);
+    for(int & i : connected_to) {
+        array->InsertLast(&i);
     }
     return array;
 }

--- a/Source/Objects/itemobject.cpp
+++ b/Source/Objects/itemobject.cpp
@@ -753,17 +753,15 @@ void ItemObject::AddReader( ItemObjectScriptReader* reader )
 {
     if(reader->holding){
         std::list<ItemObjectScriptReader*> to_invalidate;
-        for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin();
-            iter != readers_.end(); ++iter)
+        for(auto & reader : readers_)
         {
-            if((*iter)->stuck || (*iter)->holding){
-                to_invalidate.push_back(*iter);
+            if(reader->stuck || reader->holding){
+                to_invalidate.push_back(reader);
             }
         }
-        for(std::list<ItemObjectScriptReader*>::iterator iter = to_invalidate.begin();
-            iter != to_invalidate.end(); ++iter)
+        for(auto & iter : to_invalidate)
         {
-            (*iter)->Invalidate();
+            iter->Invalidate();
         }
     }
     readers_.push_back(reader);
@@ -982,10 +980,9 @@ void ItemObject::GetPhysicsVel( vec3 & linear_vel, vec3 & angular_vel )
 
 bool ItemObject::IsHeld() {
     bool held = false;
-    for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin(); 
-        iter != readers_.end(); ++iter)
+    for(auto & reader : readers_)
     {
-        if((*iter)->holding){
+        if(reader->holding){
             held = true;
         }
     }
@@ -994,10 +991,9 @@ bool ItemObject::IsHeld() {
 
 bool ItemObject::IsConstrained() {
     bool constrained = false;
-    for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin(); 
-        iter != readers_.end(); ++iter)
+    for(auto & reader : readers_)
     {
-        if((*iter)->constraint){
+        if(reader->constraint){
             constrained = true;
         }
     }
@@ -1006,10 +1002,9 @@ bool ItemObject::IsConstrained() {
 
 bool ItemObject::IsStuckInCharacter() {
     bool stuck = false;
-    for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin(); 
-        iter != readers_.end(); ++iter)
+    for(auto & reader : readers_)
     {
-        if((*iter)->stuck){
+        if(reader->stuck){
             stuck = true;
         }
     }
@@ -1018,11 +1013,10 @@ bool ItemObject::IsStuckInCharacter() {
 
 int ItemObject::StuckInWhom() {
     int stuck_id = -1;
-    for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin(); 
-        iter != readers_.end(); ++iter)
+    for(auto & reader : readers_)
     {
-        if((*iter)->stuck && (*iter)->char_id != -1){
-            stuck_id = (*iter)->char_id;
+        if(reader->stuck && reader->char_id != -1){
+            stuck_id = reader->char_id;
         }
     }
     return stuck_id;
@@ -1030,11 +1024,10 @@ int ItemObject::StuckInWhom() {
 
 int ItemObject::HeldByWhom() {
     int held_id = -1;
-    for(std::list<ItemObjectScriptReader*>::iterator iter = readers_.begin(); 
-        iter != readers_.end(); ++iter)
+    for(auto & reader : readers_)
     {
-        if((*iter)->holding && (*iter)->char_id != -1){
-            held_id = (*iter)->char_id;
+        if(reader->holding && reader->char_id != -1){
+            held_id = reader->char_id;
         }
     }
     return held_id;
@@ -1329,8 +1322,7 @@ void ItemObject::DrawItem(const mat4& proj_view_matrix, Object::DrawType type) {
 
         std::vector<mat4> light_volume_matrix;
         std::vector<mat4> light_volume_matrix_inverse;
-        for(int i=0, len=scenegraph_->light_volume_objects_.size(); i<len; ++i){
-            Object* obj = scenegraph_->light_volume_objects_[i];
+        for(auto obj : scenegraph_->light_volume_objects_){
             const mat4 &mat = obj->GetTransform();
             light_volume_matrix.push_back(mat);
             light_volume_matrix_inverse.push_back(invert(mat));
@@ -1413,8 +1405,7 @@ void ItemObject::InvalidateHeldReaders() {
 bool ItemObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) { 
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_FILE_PATH: {
                     std::string type_file;

--- a/Source/Objects/lightprobeobject.cpp
+++ b/Source/Objects/lightprobeobject.cpp
@@ -93,8 +93,7 @@ bool LightProbeObject::SetFromDesc( const EntityDescription& desc ) {
     LOG_ASSERT(!stored_coefficients);
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
             case EDF_NEGATIVE_LIGHT_PROBE: {
                 int negative_int;

--- a/Source/Objects/navmeshconnectionobject.cpp
+++ b/Source/Objects/navmeshconnectionobject.cpp
@@ -57,8 +57,8 @@ bool NavmeshConnectionObject::ConnectTo( Object& other, bool checking_other /*= 
             return false;
         } else {
             int other_id = ppo->GetID();
-            for(unsigned i=0; i<connections.size(); ++i) {
-                if(connections[i].other_object_id == other_id) {
+            for(auto & connection : connections) {
+                if(connection.other_object_id == other_id) {
                    return false;
                 }       
             }    
@@ -111,8 +111,8 @@ bool NavmeshConnectionObject::Disconnect( Object& other, bool checking_other ) {
 }
 
 void NavmeshConnectionObject::GetConnectionIDs(std::vector<int>* cons) {
-    for( uint32_t i = 0; i < connections.size(); i++ ) { 
-        cons->push_back(connections[i].other_object_id);
+    for(auto & connection : connections) { 
+        cons->push_back(connection.other_object_id);
     }
 }
 
@@ -190,8 +190,7 @@ bool NavmeshConnectionObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
         //Keeping this to maintain compatability for now. There shouldn't be any alphas running this though.
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_NAV_MESH_CONNECTIONS:
                     field.ReadNavMeshConnectionDataVec(&connections);
@@ -328,8 +327,8 @@ void NavmeshConnectionObject::FinalizeLoadedConnections() {
     }
 
     // Make sure all connections are symmetric
-    for(int i=0, len=connections.size(); i<len; ++i){
-        Object* obj = scenegraph_->GetObjectFromID(connections[i].other_object_id);
+    for(auto & connection : connections){
+        Object* obj = scenegraph_->GetObjectFromID(connection.other_object_id);
         if(obj){
             obj->ConnectTo(*this, true);
         }
@@ -337,20 +336,20 @@ void NavmeshConnectionObject::FinalizeLoadedConnections() {
 }
 
 void NavmeshConnectionObject::RemapReferences(std::map<int,int> id_map) {
-    for(int i=0, len=connections.size(); i<len; ++i){
-        if( id_map.find(connections[i].other_object_id) != id_map.end() ) {
-            connections[i].other_object_id = id_map[connections[i].other_object_id];
+    for(auto & connection : connections){
+        if( id_map.find(connection.other_object_id) != id_map.end() ) {
+            connection.other_object_id = id_map[connection.other_object_id];
         } else {
             //The remapped id could belong to this, in which case it is valid
             bool is_this = false;
-            for(std::map<int,int>::iterator iter = id_map.begin(); iter != id_map.end(); ++iter) {
-                if(iter->second == this->GetID()) {
+            for(auto & iter : id_map) {
+                if(iter.second == this->GetID()) {
                     is_this = true;
                     break;
                 }
             }
             if(!is_this)
-                connections[i].other_object_id = -1;
+                connection.other_object_id = -1;
         }
     }
 }

--- a/Source/Objects/object.cpp
+++ b/Source/Objects/object.cpp
@@ -192,8 +192,7 @@ void Object::SaveToXML( TiXmlElement* parent ) {
 }
 
 bool Object::SetFromDesc( const EntityDescription& desc ) {
-    for(unsigned i=0; i<desc.fields.size(); ++i){
-        const EntityDescriptionField& field = desc.fields[i];
+    for(const auto & field : desc.fields){
         switch(field.type){
             case EDF_ID: {
                 int id;
@@ -374,25 +373,25 @@ void Object::Moved(Object::MoveType type) {
 }
 
 void Object::FinalizeLoadedConnections() {
-    for(size_t i = 0; i < unfinalized_connected_to.size(); ++i) {
-        Object* object = scenegraph_->GetObjectFromID(unfinalized_connected_to[i]);
+    for(int & i : unfinalized_connected_to) {
+        Object* object = scenegraph_->GetObjectFromID(i);
         if(object) {
             if(!ConnectTo(*object, false)) {
-                LOGW << "Failed to connect to the object with id " << unfinalized_connected_to[i] << " after loading" << std::endl;
+                LOGW << "Failed to connect to the object with id " << i << " after loading" << std::endl;
             }
         } else {
-            LOGW << "Connected to an invalid id " << unfinalized_connected_to[i] << " after loading" << std::endl;
+            LOGW << "Connected to an invalid id " << i << " after loading" << std::endl;
         }
     }
 
-    for(size_t i = 0; i < unfinalized_connected_from.size(); ++i) {
-        Object* object = scenegraph_->GetObjectFromID(unfinalized_connected_from[i]);
+    for(int & i : unfinalized_connected_from) {
+        Object* object = scenegraph_->GetObjectFromID(i);
         if(object) {
             if(!object->ConnectTo(*this, false)) {
-                LOGW << "Failed to connect to the object with id " << unfinalized_connected_from[i] << " after loading" << std::endl;
+                LOGW << "Failed to connect to the object with id " << i << " after loading" << std::endl;
             }
         } else {
-            LOGW << "Connected to an invalid id " << unfinalized_connected_from[i] << " after loading" << std::endl;
+            LOGW << "Connected to an invalid id " << i << " after loading" << std::endl;
         }
     }
 

--- a/Source/Objects/pathpointobject.cpp
+++ b/Source/Objects/pathpointobject.cpp
@@ -57,8 +57,8 @@ bool PathPointObject::ConnectTo( Object& other, bool checking_other /*= false*/ 
             return false;
         } else {
             int other_id = ppo->GetID();
-            for(unsigned i=0; i<connection_ids.size(); ++i){ // Disconnect if we're already connected
-                if(connection_ids[i] == other_id){
+            for(int connection_id : connection_ids){ // Disconnect if we're already connected
+                if(connection_id == other_id){
                    Disconnect(other, checking_other);
                 }       
             }    
@@ -103,8 +103,8 @@ bool PathPointObject::Disconnect( Object& other, bool checking_other ) {
 }
 
 void PathPointObject::GetConnectionIDs(std::vector<int>* cons) {
-    for( uint32_t i = 0; i < connection_ids.size(); i++ ) {
-        cons->push_back(connection_ids[i]);
+    for(int & connection_id : connection_ids) {
+        cons->push_back(connection_id);
     } 
 }
 
@@ -126,8 +126,7 @@ void PathPointObject::GetDesc(EntityDescription &desc) const {
 bool PathPointObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
                 case EDF_CONNECTIONS:
                     field.ReadIntVec(&connection_ids);
@@ -174,28 +173,28 @@ void PathPointObject::Draw() {
        scenegraph_->map_editor->state_ != MapEditor::kInGame)
     {
         DebugDraw::Instance()->AddWireSphere(GetTranslation(), 0.5f, vec4(0.0f,0.5f,0.5f,0.5f), _delete_on_draw);
-        for(unsigned i=0; i<connection_ids.size(); ++i){
-            Object* obj = scenegraph_->GetObjectFromID(connection_ids[i]);
+        for(int connection_id : connection_ids){
+            Object* obj = scenegraph_->GetObjectFromID(connection_id);
             DebugDraw::Instance()->AddLine(GetTranslation(), obj->GetTranslation(), vec4(0.0f,0.5f,0.5f,0.5f), _delete_on_draw);
         }
     }
 }
 
 void PathPointObject::RemapReferences(std::map<int,int> id_map) {
-    for( unsigned i = 0; i < connection_ids.size(); i++ ) {
-        if( id_map.find(connection_ids[i]) != id_map.end() ) {
-            connection_ids[i] = id_map[connection_ids[i]];
+    for(int & connection_id : connection_ids) {
+        if( id_map.find(connection_id) != id_map.end() ) {
+            connection_id = id_map[connection_id];
         } else {
             //The remapped id could belong to this, in which case it is valid
             bool is_this = false;
-            for(std::map<int,int>::iterator iter = id_map.begin(); iter != id_map.end(); ++iter) {
-                if(iter->second == this->GetID()) {
+            for(auto & iter : id_map) {
+                if(iter.second == this->GetID()) {
                     is_this = true;
                     break;
                 }
             }
             if(!is_this)
-                connection_ids[i] = -1;
+                connection_id = -1;
         }
     }
 }

--- a/Source/Objects/placeholderobject.cpp
+++ b/Source/Objects/placeholderobject.cpp
@@ -61,8 +61,8 @@ PlaceholderObject::PlaceholderObject():
 }
 
 void PlaceholderObject::DisposePreviewObjects() {
-    for(unsigned i=0, len=preview_objects_.size(); i < len; ++i){
-        delete preview_objects_[i];
+    for(auto & preview_object : preview_objects_){
+        delete preview_object;
     }
     preview_objects_.clear();
 }
@@ -78,8 +78,8 @@ void PlaceholderObject::SetPreview( const std::string& path ) {
     Path source;
     ActorsEditor_LoadEntitiesFromFile(path, desc_list,&file_type, &source);
     preview_objects_.reserve(desc_list.size());
-    for(unsigned i=0, len=desc_list.size(); i < len; ++i){
-        Object* obj = CreateObjectFromDesc(desc_list[i]);
+    for(auto & i : desc_list){
+        Object* obj = CreateObjectFromDesc(i);
         if(obj) {
             if(obj->GetType() == _env_object){
                 EnvObject* eo = (EnvObject*)obj;
@@ -124,9 +124,9 @@ void PlaceholderObject::Draw() {
         }
 
         bool old_shadow_cache_dirty = shadow_cache_dirty;
-        for(unsigned i=0, len=preview_objects_.size(); i < len; ++i){
-            preview_objects_[i]->SetTransformationMatrix(GetTransform());
-            preview_objects_[i]->ReceiveObjectMessage(OBJECT_MSG::DRAW);
+        for(auto & preview_object : preview_objects_){
+            preview_object->SetTransformationMatrix(GetTransform());
+            preview_object->ReceiveObjectMessage(OBJECT_MSG::DRAW);
         }
         shadow_cache_dirty = old_shadow_cache_dirty; // We don't want to update static shadow maps just because we moved this preview object
 
@@ -187,8 +187,7 @@ bool PlaceholderObject::SetFromDesc( const EntityDescription& desc ) {
             SetBillboard("Data/UI/spawner/thumbs/Utility/placeholder_arena_battle.png");
         }
         
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
             case EDF_FILE_PATH: {
                 std::string path;
@@ -230,8 +229,7 @@ void PlaceholderObject::SetSpecialType(PlaceholderObject::PlaceholderObjectType 
 }
 
 bool PlaceholderObject::Initialize() {
-    for(int i=0, len=preview_objects_.size(); i<len; ++i){
-        Object* obj = preview_objects_[i];
+    for(auto obj : preview_objects_){
         obj->scenegraph_ = scenegraph_;
         obj->Initialize();
     }

--- a/Source/Objects/reflectioncaptureobject.cpp
+++ b/Source/Objects/reflectioncaptureobject.cpp
@@ -133,8 +133,7 @@ void ReflectionCaptureObject::GetDesc(EntityDescription &desc) const {
 bool ReflectionCaptureObject::SetFromDesc( const EntityDescription& desc ) {
     bool ret = Object::SetFromDesc(desc);
     if( ret ) {
-        for(unsigned i=0; i<desc.fields.size(); ++i){
-            const EntityDescriptionField& field = desc.fields[i];
+        for(const auto & field : desc.fields){
             switch(field.type){
             case EDF_GI_COEFFICIENTS: {
                 memcpy(avg_color, &field.data[0], kLightProbeNumCoeffs * sizeof(float));

--- a/Source/Objects/riggedobject.cpp
+++ b/Source/Objects/riggedobject.cpp
@@ -2794,8 +2794,8 @@ void MorphTarget::Load(const std::string &base_model_name,
     } else {
         model_id[0] = Models::Instance()->CopyModel(base_model_id);
         Model& model = Models::Instance()->GetModel(model_id[0]);
-        for(float & vertice : model.vertices){
-            vertice = 0.0f;
+        for(float & vertex : model.vertices){
+            vertex = 0.0f;
         }
         for(float & tex_coord : model.tex_coords){
             tex_coord = 0.0f;

--- a/Source/Objects/riggedobject.cpp
+++ b/Source/Objects/riggedobject.cpp
@@ -179,8 +179,8 @@ RiggedObject::RiggedObject() :
 
     palette_colors.resize(max_palette_elements, vec3(1.0f));
     palette_colors_srgb.resize(max_palette_elements, vec3(1.0f));
-    for(int i=0; i<4; ++i){
-        model_id[i] = -1;
+    for(int & i : model_id){
+        i = -1;
     }
 
     anim_update_period = 2;
@@ -205,11 +205,11 @@ RiggedObject::~RiggedObject() {
             free(simd_bone_mats);
         #endif
     #endif
-    for(int i=0; i<4; ++i){
-        Models::Instance()->DeleteModel(model_id[i]);
+    for(int i : model_id){
+        Models::Instance()->DeleteModel(i);
     }
-    for(unsigned i=0; i<morph_targets.size(); ++i){
-        morph_targets[i].Dispose();
+    for(auto & morph_target : morph_targets){
+        morph_target.Dispose();
     }
     
     // TODO: why do we get a black screen when returning to the main menu on Mac
@@ -446,14 +446,13 @@ void RiggedObject::PreDrawFrame(float curr_game_time) {
 				}
 				else {
 					int total_connections = 0;
-					for (unsigned j = 0; j < kMaxBoneConnects; ++j) {
-						total_connections += attached_env_object.bone_connects[j].num_connections;
+					for (auto & bone_connect : attached_env_object.bone_connects) {
+						total_connections += bone_connect.num_connections;
 					}
 
 					mat4 total_mat(0.0f);
-					for (unsigned j = 0; j < kMaxBoneConnects; ++j) {
-						const BoneConnect &bone_connect = attached_env_object.bone_connects[j];
-						if (bone_connect.num_connections) {
+					for (const auto & bone_connect : attached_env_object.bone_connects) {
+							if (bone_connect.num_connections) {
 							mat4 mat = display_bone_transforms[bone_connect.bone_id].GetMat4() * bone_connect.rel_mat;
 							total_mat += mat * ((float)bone_connect.num_connections / (float)total_connections);
 						}
@@ -496,11 +495,11 @@ void RiggedObject::StoreNetworkBones() {
 void RiggedObject::StoreNetworkMorphTargets() { 
 	// first check if not present 
 	if (morph_targets.size() != network_morphs.size()) {
-		for (uint32_t i = 0; i < morph_targets.size(); i++) {
+		for (auto & morph_target : morph_targets) {
 			bool present = false;
 
-			for (uint32_t j = 0; j < network_morphs.size(); j++) {
-				if (morph_targets[i].name == network_morphs[j].name) {
+			for (auto & network_morph : network_morphs) {
+				if (morph_target.name == network_morph.name) {
 					present = true;
 					break;
 				}
@@ -509,31 +508,31 @@ void RiggedObject::StoreNetworkMorphTargets() {
 
 			if (present == false) {
 				MorphTargetStateStorage missing_morph;
-				missing_morph.disp_weight = morph_targets[i].disp_weight;
-				missing_morph.name = morph_targets[i].name;
+				missing_morph.disp_weight = morph_target.disp_weight;
+				missing_morph.name = morph_target.name;
 				missing_morph.dirty = true;
-				missing_morph.mod_weight = morph_targets[i].mod_weight;
+				missing_morph.mod_weight = morph_target.mod_weight;
 				network_morphs.push_back(missing_morph);
 			}
 		}
 	}
 
-	for (uint32_t i = 0; i < morph_targets.size(); i++) {
-		for (uint32_t j = 0; j < network_morphs.size(); j++) {
-			if (morph_targets[i].name == network_morphs[j].name) {
-				float a = morph_targets[i].disp_weight;
-				float b = network_morphs[j].disp_weight;
+	for (auto & morph_target : morph_targets) {
+		for (auto & network_morph : network_morphs) {
+			if (morph_target.name == network_morph.name) {
+				float a = morph_target.disp_weight;
+				float b = network_morph.disp_weight;
 
 
-				float c = network_morphs[j].mod_weight;
-				float d = morph_targets[i].mod_weight;
+				float c = network_morph.mod_weight;
+				float d = morph_target.mod_weight;
 
 				if (std::abs(a - b) > 1e-4 ||
 					std::abs(c - d) > 1e-4) {
 
-					network_morphs[j].mod_weight = morph_targets[i].mod_weight;
-					network_morphs[j].disp_weight = morph_targets[i].disp_weight;
-					network_morphs[j].dirty = true;
+					network_morph.mod_weight = morph_target.mod_weight;
+					network_morph.disp_weight = morph_target.disp_weight;
+					network_morph.dirty = true;
 				} 
 			}
 
@@ -550,8 +549,8 @@ void RiggedObject::PreDrawCamera(float curr_game_time) {
     }
 
     PROFILER_ZONE(g_profiler_ctx, "RiggedObject::PreDraw");
-    for(int i=0; i<4; ++i){
-        need_vbo_update[i] = true;
+    for(bool & i : need_vbo_update){
+        i = true;
     }
     Graphics::Instance()->setGLState(rigged_object_gl_state.gl_state);
 
@@ -768,8 +767,8 @@ void RiggedObject::Draw(const mat4& proj_view_matrix, Object::DrawType type) {
             shaders->SetUniformVec3("blood_tint", vec3(-1,-1,-1)); // Presumably this is here to force refreshing this uniform?
             shaders->SetUniformVec3("blood_tint", Graphics::Instance()->config_.blood_color());
             std::vector<vec3> ambient_cube_color_vec;
-            for(int i=0; i<6; ++i){
-                ambient_cube_color_vec.push_back(ambient_cube_color[i]);
+            for(auto & i : ambient_cube_color){
+                ambient_cube_color_vec.push_back(i);
             }
             shaders->SetUniformVec3Array("ambient_cube_color", ambient_cube_color_vec);        
             shaders->SetUniformVec3Array("tint_palette", palette_colors_srgb);
@@ -795,8 +794,7 @@ void RiggedObject::Draw(const mat4& proj_view_matrix, Object::DrawType type) {
 
             std::vector<mat4> light_volume_matrix;
             std::vector<mat4> light_volume_matrix_inverse;
-            for(int i=0, len=scenegraph_->light_volume_objects_.size(); i<len; ++i){
-                Object* obj = scenegraph_->light_volume_objects_[i];
+            for(auto obj : scenegraph_->light_volume_objects_){
                 const mat4 &mat = obj->GetTransform();
                 light_volume_matrix.push_back(mat);
                 light_volume_matrix_inverse.push_back(invert(mat));
@@ -925,8 +923,8 @@ void RiggedObject::Draw(const mat4& proj_view_matrix, Object::DrawType type) {
                 vel_vbo.Fill(model_num_verts*3*sizeof(GLfloat), &vel[0]);
             } else {
                 PROFILER_ZONE(g_profiler_ctx, "Calculate null vertex velocities");
-                for(int i=0, len=vel.size(); i<len; ++i){
-                    vel[i] = 0.0f;
+                for(float & i : vel){
+                    i = 0.0f;
                 }
                 vel_vbo.SetHint(model_num_verts*3*sizeof(GLfloat),kVBODynamic);
                 vel_vbo.Fill(model_num_verts*3*sizeof(GLfloat), &vel[0]);
@@ -1048,15 +1046,13 @@ bool RiggedObject::DrawBoneConnectUI(Object* objects[], int num_obj_ids, IMUICon
                     Object* obj = objects[obj_id_iter];
                     // Check if we already have a connection between this object and this character
                     bool already_attached = false;
-                    for(unsigned j=0; j<children.size(); ++j){
-                        AttachedEnvObject& attached_env_object = children[j];
+                    for(auto & attached_env_object : children){
                         if(attached_env_object.direct_ptr == obj){
                             // If this object is already attached to the selected bone, increment the number of connections
                             attached_env_object.bone_connection_dirty = true;
                             already_attached = true;
                             bool already_attached_to_bone = false;
-                            for(unsigned k=0; k<kMaxBoneConnects; ++k){
-                                BoneConnect& bone_connect = attached_env_object.bone_connects[k];
+                            for(auto & bone_connect : attached_env_object.bone_connects){
                                 if(bone_connect.bone_id == (int)i){
                                     ++bone_connect.num_connections;
                                     already_attached_to_bone = true;
@@ -1065,8 +1061,7 @@ bool RiggedObject::DrawBoneConnectUI(Object* objects[], int num_obj_ids, IMUICon
                             }
                             // If this object is not already attached to the bone, try to attach it with a spare slot
                             if(!already_attached_to_bone){
-                                for(unsigned k=0; k<kMaxBoneConnects; ++k){
-                                    BoneConnect& bone_connect = attached_env_object.bone_connects[k];
+                                for(auto & bone_connect : attached_env_object.bone_connects){
                                     if(bone_connect.num_connections == 0){
                                         bone_connect.bone_id = i;
                                         bone_connect.num_connections = 1;
@@ -1107,8 +1102,7 @@ bool RiggedObject::DrawBoneConnectUI(Object* objects[], int num_obj_ids, IMUICon
                         AttachedEnvObject& attached_obj = children[j];
                         if(attached_obj.direct_ptr == obj){
                             int total_connections = 0; //NOTE(David): Number of connections remaining between object and character
-                            for(unsigned k=0; k<kMaxBoneConnects; ++k){
-                                BoneConnect& bone_connect = attached_obj.bone_connects[k];
+                            for(auto & bone_connect : attached_obj.bone_connects){
                                 if(bone_connect.bone_id == (int)i && bone_connect.num_connections > 0){
                                     --bone_connect.num_connections;
                                 }
@@ -1138,12 +1132,11 @@ bool RiggedObject::DrawBoneConnectUI(Object* objects[], int num_obj_ids, IMUICon
         DebugDraw::Instance()->AddLine(start, end, bone_color, _delete_on_draw, _DD_XRAY);
     }
 
-    for(unsigned i=0; i<children.size(); ++i){
-        const AttachedEnvObject& attached_env_object = children[i];
-        Object* obj = children[i].direct_ptr;
+    for(auto & i : children){
+        const AttachedEnvObject& attached_env_object = i;
+        Object* obj = i.direct_ptr;
         if(obj && obj->Selected()){
-            for(unsigned j=0; j<kMaxBoneConnects; ++j){
-                const BoneConnect& bone_connect = attached_env_object.bone_connects[j];
+            for(const auto & bone_connect : attached_env_object.bone_connects){
                 if(bone_connect.num_connections > 0){
                     int bone_id = bone_connect.bone_id;
                     const Bone& bone = skeleton_.bones[skeleton_.physics_bones[bone_id].bone];
@@ -1268,13 +1261,13 @@ void RiggedObject::Update(float timestep) {
         }
         first_ragdoll_frame = false;
         // Updated attached items
-        for(AttachedItemList::iterator iter = attached_items.items.begin(); iter != attached_items.items.end(); ++iter) {
-            UpdateAttachedItemRagdoll(*iter, skeleton_, weapon_offset);
+        for(auto & item : attached_items.items) {
+            UpdateAttachedItemRagdoll(item, skeleton_, weapon_offset);
         }
         // Make sure attached items are not asleep if skeleton is awake
-        for(AttachedItemList::iterator iter = stuck_items.items.begin(); iter != stuck_items.items.end(); ++iter) {
+        for(auto & item : stuck_items.items) {
             if(skeleton_.physics_bones[0].bullet_object->IsActive()){
-                iter->item->WakeUpPhysics();
+                item.item->WakeUpPhysics();
             }
         }
     }
@@ -1284,8 +1277,8 @@ void RiggedObject::Update(float timestep) {
     --prev_anim_update_time;
 
     if(time_until_next_anim_update <= 0) {
-        for(unsigned i=0; i<morph_targets.size(); ++i){
-            morph_targets[i].UpdateForInterpolation();
+        for(auto & morph_target : morph_targets){
+            morph_target.UpdateForInterpolation();
         }
         if(!animated){
             PROFILER_ZONE(g_profiler_ctx, "Update ragdoll animation");
@@ -1322,11 +1315,10 @@ void RiggedObject::Update(float timestep) {
                 skeleton_.RefreshFixedJoints(animation_frame_bone_matrices);
                 // Apply morph weights from animation output
                 std::map<std::string, MorphTarget*> morph_target_names;
-                for(unsigned i=0; i<morph_targets.size(); ++i){
-                    morph_target_names[morph_targets[i].name] = &morph_targets[i];
+                for(auto & morph_target : morph_targets){
+                    morph_target_names[morph_target.name] = &morph_target;
                 }
-                for(unsigned i=0; i<anim_output.shape_keys.size(); ++i){
-                    const ShapeKeyBlend& skb = anim_output.shape_keys[i];
+                for(auto & skb : anim_output.shape_keys){
                     const std::string &label = skb.label;
                     if(morph_target_names.find(label) != morph_target_names.end()) {
                         morph_target_names[label]->anim_weight = 
@@ -1345,11 +1337,11 @@ void RiggedObject::Update(float timestep) {
                 PROFILER_ZONE(g_profiler_ctx, "anim_client.GetMatrices()");
                 anim_client.GetMatrices(anim_output, &skeleton_.parents);
             }
-            for(int i=0, len=anim_output.matrices.size(); i<len; ++i){
-                anim_output.matrices[i].origin *= model_char_scale;
+            for(auto & matrice : anim_output.matrices){
+                matrice.origin *= model_char_scale;
             }
-            for(int i=0, len=anim_output.ik_bones.size(); i<len; ++i){
-                anim_output.ik_bones[i].transform.origin *= model_char_scale;
+            for(auto & ik_bone : anim_output.ik_bones){
+                ik_bone.transform.origin *= model_char_scale;
             }
             weap_anim_info_map = anim_output.weap_anim_info_map;
             // Copy bone transforms for further manipulation
@@ -1366,14 +1358,14 @@ void RiggedObject::Update(float timestep) {
             vec4 angle_axis(0.0f,1.0f,0.0f,total_rotation);
             quaternion rot(angle_axis);
             mat4 rotmat4 = Mat4FromQuaternion(rot);
-            for(unsigned i=0; i<transforms.size(); i++){
-                transforms[i] = rotmat4 * transforms[i];
+            for(auto & transform : transforms){
+                transform = rotmat4 * transform;
             }
-            for(int i=0, len=anim_output.ik_bones.size(); i<len; ++i){
-                anim_output.ik_bones[i].transform = rotmat4 * anim_output.ik_bones[i].transform;
+            for(auto & ik_bone : anim_output.ik_bones){
+                ik_bone.transform = rotmat4 * ik_bone.transform;
             }
-            for(WeapAnimInfoMap::iterator iter = weap_anim_info_map.begin(); iter != weap_anim_info_map.end(); ++iter) {
-                WeapAnimInfo &weap_anim_info = iter->second;
+            for(auto & iter : weap_anim_info_map) {
+                WeapAnimInfo &weap_anim_info = iter.second;
                 if(weap_anim_info.relative_id == -1){
                     weap_anim_info.bone_transform = rotmat4 * weap_anim_info.bone_transform;
                 }
@@ -1384,11 +1376,11 @@ void RiggedObject::Update(float timestep) {
                 transforms[i].origin += total_center_offset;
                 animation_frame_bone_matrices[i] = transforms[i];
             }
-            for(int i=0, len=anim_output.ik_bones.size(); i<len; ++i){
-                anim_output.ik_bones[i].transform.origin += total_center_offset;
+            for(auto & ik_bone : anim_output.ik_bones){
+                ik_bone.transform.origin += total_center_offset;
             }
-            for(std::map<int, WeapAnimInfo>::iterator iter = weap_anim_info_map.begin(); iter != weap_anim_info_map.end(); ++iter) {
-                WeapAnimInfo &weap_anim_info = iter->second;
+            for(auto & iter : weap_anim_info_map) {
+                WeapAnimInfo &weap_anim_info = iter.second;
                 if(weap_anim_info.relative_id == -1){
                     weap_anim_info.bone_transform.origin += total_center_offset;
                 } else {
@@ -1398,11 +1390,10 @@ void RiggedObject::Update(float timestep) {
             
             // Apply animation morphs
             std::map<std::string, MorphTarget*> morph_target_names;
-            for(unsigned i=0; i<morph_targets.size(); ++i){
-                morph_target_names[morph_targets[i].name] = &morph_targets[i];
+            for(auto & morph_target : morph_targets){
+                morph_target_names[morph_target.name] = &morph_target;
             }
-            for(unsigned i=0; i<anim_output.shape_keys.size(); ++i){
-                const ShapeKeyBlend& skb = anim_output.shape_keys[i];
+            for(auto & skb : anim_output.shape_keys){
                 const std::string &label = skb.label;
                 if(morph_target_names.find(label) != morph_target_names.end()) {
                     morph_target_names[label]->anim_weight = skb.weight*skb.weight_weight;
@@ -1411,8 +1402,7 @@ void RiggedObject::Update(float timestep) {
 
             // Apply status keys
             status_keys.clear();
-            for(unsigned i=0; i<anim_output.status_keys.size(); ++i){
-                const StatusKeyBlend key = anim_output.status_keys[i];
+            for(auto key : anim_output.status_keys){
                 status_keys[key.label] = key.weight*key.weight_weight;
             }
 
@@ -1468,12 +1458,12 @@ void RiggedObject::Update(float timestep) {
     }
 
     if(animated){
-        for(AttachedItemList::iterator iter = attached_items.items.begin(); iter != attached_items.items.end(); ++iter) {
-            ItemObjectScriptReader& item = iter->item;
+        for(auto & iter : attached_items.items) {
+            ItemObjectScriptReader& item = iter.item;
             item.SetInterpInfo(GetTimeSinceLastAnimUpdate(), GetTimeBetweenLastTwoAnimUpdates());
         }
-        for(AttachedItemList::iterator iter=stuck_items.items.begin(); iter != stuck_items.items.end(); ++iter) {
-            iter->item.SetInterpInfo(GetTimeSinceLastAnimUpdate(), GetTimeBetweenLastTwoAnimUpdates());
+        for(auto & item : stuck_items.items) {
+            item.item.SetInterpInfo(GetTimeSinceLastAnimUpdate(), GetTimeBetweenLastTwoAnimUpdates());
         }
     }
 }
@@ -1498,14 +1488,13 @@ namespace {
     {
         std::vector<float> sm_vertices(sm.vertices.size());
         std::vector<float> sm_tex_coords(sm.tex_coords.size());
-        for(int i=0, len=vert_parent.size(); i<len; ++i){
-            WOLFIRE_SIMPLIFY::ParentRecordList parents = vert_parent[i];
+        for(auto parents : vert_parent){
             float total[3];
-            for(int j=0; j<3; ++j){
-                total[j] = 0.0f;
+            for(float & j : total){
+                j = 0.0f;
             }
-            for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+            for(auto & parent : parents){
+                WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                 if(pr.weight > 0.0f){
                     int parent_vert = sm.old_vert_id[pr.id];
                     int parent_vert_index = parent_vert*3;
@@ -1514,29 +1503,28 @@ namespace {
                     }
                 }
             }
-            for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+            for(auto & parent : parents){
+                WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                 int parent_vert_index = pr.id*3;
                 for(int j=0; j<3; ++j){
                     sm_vertices[parent_vert_index+j] = total[j];
                 }
             }
         }
-        for(int i=0, len=tex_parent.size(); i<len; ++i){
-            WOLFIRE_SIMPLIFY::ParentRecordList parents = tex_parent[i];
+        for(auto parents : tex_parent){
             float total[2];
-            for(int j=0; j<2; ++j){
-                total[j] = 0.0f;
+            for(float & j : total){
+                j = 0.0f;
             }
-            for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+            for(auto & parent : parents){
+                WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                 int parent_tex_index = sm.old_tex_id[pr.id]*2;
                 for(int j=0; j<2; ++j){
                     total[j] += base_model.tex_coords[parent_tex_index+j] * pr.weight;
                 }
             }
-            for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+            for(auto & parent : parents){
+                WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                 int parent_tex_index = pr.id*2;
                 for(int j=0; j<2; ++j){
                     sm_tex_coords[parent_tex_index+j] = total[j];
@@ -1629,11 +1617,11 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
     anim_client.SetRetargeting(skeleton_path);
 
     const mat4 &transform = GetTransform();
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        if(!skeleton_.physics_bones[i].bullet_object){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object){
             continue;
         }
-        skeleton_.physics_bones[i].bullet_object->ApplyTransform(transform);
+        physics_bone.bullet_object->ApplyTransform(transform);
     }
 
     ik_offset.resize(skeleton_.physics_bones.size());
@@ -1656,9 +1644,9 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
     }
 
     const std::vector<MorphInfo> &morphs = char_ref->GetMorphs();
-    for(unsigned i=0; i<morphs.size(); ++i){
+    for(const auto & morph : morphs){
         MorphTarget mt;
-        mt.Load(ofc->model_name, the_model_id, morphs[i].label, morphs[i].num_steps);
+        mt.Load(ofc->model_name, the_model_id, morph.label, morph.num_steps);
         morph_targets.push_back(mt);
     }
     
@@ -1708,15 +1696,14 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
                 bone_weight.clear();
                 bone_id.resize(sm.vertices.size()/3, 0.0f);
                 bone_weight.resize(sm.vertices.size()/3, 0.0f);
-                for(int i=0, len=vert_parent.size(); i<len; ++i){
-                    WOLFIRE_SIMPLIFY::ParentRecordList parents = vert_parent[i];
+                for(auto parents : vert_parent){
                     float total[3];
                     bone_info_accumulate.clear();
-                    for(int j=0; j<3; ++j){
-                        total[j] = 0.0f;
+                    for(float & j : total){
+                        j = 0.0f;
                     }
-                    for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                        WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+                    for(auto & parent : parents){
+                        WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                         if(pr.weight > 0.0f){
                             int parent_vert = sm.old_vert_id[pr.id];
                             int parent_vert_index = parent_vert*3;
@@ -1756,18 +1743,16 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
                     }
                     // Normalize weights to add up to 1.0
                     float total_weight = 0.0f;
-                    for(int i=0,len=bone_info_accumulate.size(); i<len; ++i){
-                        BoneInfo &bi = bone_info_accumulate[i];
+                    for(auto & bi : bone_info_accumulate){
                         total_weight += bi.weight; 
                     }
                     if(total_weight != 0.0f){
-                        for(int i=0,len=bone_info_accumulate.size(); i<len; ++i){
-                            BoneInfo &bi = bone_info_accumulate[i];
+                        for(auto & bi : bone_info_accumulate){
                             bi.weight /= total_weight; 
                         }
                     }
-                    for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                        WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+                    for(auto & parent : parents){
+                        WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                         int parent_vert_index = pr.id*3;
                         for(int j=0; j<3; ++j){
                             sm.vertices[parent_vert_index+j] = total[j];
@@ -1778,21 +1763,20 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
                         }
                     }
                 }
-                for(int i=0, len=tex_parent.size(); i<len; ++i){
-                    WOLFIRE_SIMPLIFY::ParentRecordList parents = tex_parent[i];
+                for(auto parents : tex_parent){
                     float total[2];
-                    for(int j=0; j<2; ++j){
-                        total[j] = 0.0f;
+                    for(float & j : total){
+                        j = 0.0f;
                     }
-                    for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                        WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+                    for(auto & parent : parents){
+                        WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                         int parent_tex_index = sm.old_tex_id[pr.id]*2;
                         for(int j=0; j<2; ++j){
                             total[j] += base_model.tex_coords[parent_tex_index+j] * pr.weight;
                         }
                     }
-                    for(WOLFIRE_SIMPLIFY::ParentRecordList::iterator iter = parents.begin(); iter != parents.end(); ++iter){
-                        WOLFIRE_SIMPLIFY::ParentRecord pr = (*iter);
+                    for(auto & parent : parents){
+                        WOLFIRE_SIMPLIFY::ParentRecord pr = parent;
                         int parent_tex_index = pr.id*2;
                         for(int j=0; j<2; ++j){
                             sm.tex_coords[parent_tex_index+j] = total[j];
@@ -1828,14 +1812,14 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
                 model.morph_transform_vec.resize(model_num_verts);
                 
                 std::queue<MorphTarget*> queue;
-                for(unsigned i=0; i<morph_targets.size(); ++i){
-                    queue.push(&morph_targets[i]);
+                for(auto & morph_target : morph_targets){
+                    queue.push(&morph_target);
                 }
                 while(!queue.empty()){
                     MorphTarget& morph = (*queue.front());
                     queue.pop();
-                    for(unsigned i=0; i<morph.morph_targets.size(); ++i){
-                        queue.push(&morph.morph_targets[i]);
+                    for(auto & morph_target : morph.morph_targets){
+                        queue.push(&morph_target);
                     }
                     if(morph.model_id[0] != -1) {
                         morph.model_id[lod_index] = Models::Instance()->AddModel();
@@ -1846,8 +1830,8 @@ void RiggedObject::Load(const std::string& character_path, vec3 pos, SceneGraph*
                         morph_model.CopyVertCollapse(model);
                     }
                 }
-                for(unsigned i=0; i<morph_targets.size(); ++i){
-                    morph_targets[i].CalcVertsModified(model_id[lod_index],lod_index);
+                for(auto & morph_target : morph_targets){
+                    morph_target.CalcVertsModified(model_id[lod_index],lod_index);
                 }
             }
             SaveSimplificationCache(char_ref->path_);
@@ -1913,9 +1897,9 @@ bool RiggedObject::InHeadChain(BulletObject* obj) {
 
 void RiggedObject::InvalidatedItem(ItemObjectScriptReader *invalidated) {
     int weap_id = -1;
-    for(AttachedItemList::iterator iter = attached_items.items.begin(); iter != attached_items.items.end(); ++iter) {
-        if(&(iter->item) == invalidated){
-            weap_id = (iter->item)->GetID();
+    for(auto & item : attached_items.items) {
+        if(&(item.item) == invalidated){
+            weap_id = (item.item)->GetID();
             break;
         } 
     }
@@ -2058,12 +2042,11 @@ void RiggedObject::SetItemAttachment(AttachedItem &stuck_item, AttachmentRef att
 
 void RiggedObject::SheatheItem(int id, bool on_right){
     AttachedItem *item_ptr = NULL;
-    for(std::list<AttachedItem>::iterator iter = attached_items.items.begin(); 
-        iter != attached_items.items.end(); ++iter)
+    for(auto & iter : attached_items.items)
     {
-        ItemObjectScriptReader& item = iter->item;
+        ItemObjectScriptReader& item = iter.item;
         if(item->GetID() == id){
-            item_ptr = &(*iter);
+            item_ptr = &iter;
         }
     }
     if(!item_ptr){
@@ -2079,12 +2062,11 @@ void RiggedObject::SheatheItem(int id, bool on_right){
 
 void RiggedObject::UnSheatheItem(int id, bool right_hand){
     AttachedItem *item_ptr = NULL;
-    for(std::list<AttachedItem>::iterator iter = attached_items.items.begin(); 
-        iter != attached_items.items.end(); ++iter)
+    for(auto & iter : attached_items.items)
     {
-        ItemObjectScriptReader& item = iter->item;
+        ItemObjectScriptReader& item = iter.item;
         if(item->GetID() == id){
-            item_ptr = &(*iter);
+            item_ptr = &iter;
         }
     }
     if(!item_ptr){
@@ -2108,10 +2090,9 @@ void RiggedObject::DetachAllItems(){
     attached_items.RemoveAll();
     char_anim.clear();
 
-    for(std::list<AttachedItem>::iterator iter = stuck_items.items.begin(); 
-        iter != stuck_items.items.end(); ++iter)
+    for(auto & item : stuck_items.items)
     {
-        iter->item->ActivatePhysics();
+        item.item->ActivatePhysics();
     }
     stuck_items.items.clear();
 }
@@ -2162,8 +2143,7 @@ void RiggedObject::ApplyBoneMatricesToModel(bool old, int lod_level) {
     const bool kMorphTargetsEnabled = true;
     if(kMorphTargetsEnabled){
         // Determine which morphs are active (have effective weight > 0)
-        for(unsigned k=0; k<morph_targets.size(); ++k){
-            MorphTarget& m_t = morph_targets[k];
+        for(auto & m_t : morph_targets){
             if(online->IsClient() || m_t.weight > 0.0f ||
               (m_t.anim_weight > 0.0f && m_t.script_weight_weight < 1.0f) || 
               (m_t.script_weight > 0.0f && m_t.script_weight_weight > 0.0f))
@@ -2184,13 +2164,11 @@ void RiggedObject::ApplyBoneMatricesToModel(bool old, int lod_level) {
         // Accumulate the effect of all active morphs
         Models *mi = Models::Instance();
         int vert_id, vert_id_index;
-        for(unsigned k=0, len=active_morph_targets.size(); k<len; ++k){
-            MorphTarget* morph = active_morph_targets[k];
-
+        for(auto morph : active_morph_targets){
             const Model *morph_model = &mi->GetModel(morph->model_id[lod_level]);
             const std::vector<int> &modified_tc = morph->modified_tc[lod_level];
-            for(unsigned j=0, len2=modified_tc.size(); j<len2; ++j){
-                vert_id = modified_tc[j];
+            for(int j : modified_tc){
+                vert_id = j;
                 vert_id_index = vert_id*2;
                 model->tex_transform_vec[vert_id] += 
                     vec2(morph_model->tex_coords[vert_id_index+0],
@@ -2199,8 +2177,8 @@ void RiggedObject::ApplyBoneMatricesToModel(bool old, int lod_level) {
             }
             const std::vector<int> &modified_vert = morph->modified_verts[lod_level];
 
-            for(unsigned j=0,len2=modified_vert.size(); j<len2; ++j){
-                vert_id = modified_vert[j];
+            for(int j : modified_vert){
+                vert_id = j;
                 vert_id_index = vert_id*3;
 
 				if (online->IsClient()) {
@@ -2290,9 +2268,9 @@ void MorphTarget::SetScriptWeight(float weight, float weight_weight) {
 }
 
 void RiggedObject::SetMTTargetWeight( const std::string &target_name, float weight, float weight_weight ) {
-    for(unsigned i=0; i<morph_targets.size(); ++i){
-        if(morph_targets[i].name == target_name){
-            morph_targets[i].SetScriptWeight(weight, weight_weight);
+    for(auto & morph_target : morph_targets){
+        if(morph_target.name == target_name){
+            morph_target.SetScriptWeight(weight, weight_weight);
             return;
         }
     }    
@@ -2500,9 +2478,9 @@ void RiggedObject::FixDiscontinuity() {
 	Update(game_timer.timestep);
 	time_until_next_anim_update = 0;
 	Update(game_timer.timestep);
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-		if(skeleton_.physics_bones[i].bullet_object){
-	        skeleton_.physics_bones[i].bullet_object->FixDiscontinuity();
+    for(auto & physics_bone : skeleton_.physics_bones){
+		if(physics_bone.bullet_object){
+	        physics_bone.bullet_object->FixDiscontinuity();
 		}
     }    
 }
@@ -2510,8 +2488,8 @@ void RiggedObject::FixDiscontinuity() {
 void RiggedObject::RefreshRagdoll()
 {
     if(!animated){
-        for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-            BulletObject* b_object = skeleton_.physics_bones[i].bullet_object;
+        for(auto & physics_bone : skeleton_.physics_bones){
+            BulletObject* b_object = physics_bone.bullet_object;
             if(!b_object){
                 continue;
             }
@@ -2526,8 +2504,8 @@ void RiggedObject::Ragdoll(const vec3 &velocity) {
         animated = false;
         first_ragdoll_frame = true;
     
-        for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-            BulletObject* b_object = skeleton_.physics_bones[i].bullet_object;
+        for(auto & physics_bone : skeleton_.physics_bones){
+            BulletObject* b_object = physics_bone.bullet_object;
             if(!b_object){
                 continue;
             }
@@ -2541,18 +2519,17 @@ void RiggedObject::Ragdoll(const vec3 &velocity) {
             skeleton_.SetGFStrength(skeleton_.physics_joints[i], 0.0f);
         }
 
-        for(std::list<AttachedItem>::iterator iter = stuck_items.items.begin(); 
-            iter != stuck_items.items.end(); ++iter)
+        for(auto & item : stuck_items.items)
         {
-            iter->item.ActivatePhysics();
-            iter->item.AddConstraint(skeleton_.physics_bones[iter->bone_id].bullet_object);
+            item.item.ActivatePhysics();
+            item.item.AddConstraint(skeleton_.physics_bones[item.bone_id].bullet_object);
         }
     }
 }
 
 void RiggedObject::SetDamping(float amount){
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        BulletObject* b_object = skeleton_.physics_bones[i].bullet_object;
+    for(auto & physics_bone : skeleton_.physics_bones){
+        BulletObject* b_object = physics_bone.bullet_object;
         if(!b_object){
             continue;
         }
@@ -2562,10 +2539,9 @@ void RiggedObject::SetDamping(float amount){
         }
     }   
     if(amount >= 1.0f){
-        for(std::list<AttachedItem>::iterator iter = stuck_items.items.begin(); 
-            iter != stuck_items.items.end(); ++iter)
+        for(auto & item : stuck_items.items)
         {
-            iter->item->SleepPhysics();
+            item.item->SleepPhysics();
         }
     }
 }
@@ -2573,10 +2549,9 @@ void RiggedObject::SetDamping(float amount){
 void RiggedObject::UnRagdoll() {
     //mat4 inv_transform = invert(GetTransformationMatrix());
     if(!animated){
-        for(std::list<AttachedItem>::iterator iter = stuck_items.items.begin(); 
-            iter != stuck_items.items.end(); ++iter)
+        for(auto & item : stuck_items.items)
         {
-            iter->item.RemoveConstraint();
+            item.item.RemoveConstraint();
         }
 
         anim_client.Reset();
@@ -2594,12 +2569,12 @@ vec3 RiggedObject::GetAvgPosition()
 {
     vec3 total(0.0f);
     int num_total = 0;
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        if(!skeleton_.physics_bones[i].bullet_object){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object){
             continue;
         }
         num_total++;
-        total += skeleton_.physics_bones[i].bullet_object->GetPosition();
+        total += physics_bone.bullet_object->GetPosition();
     }    
 
     total /= (float)num_total;
@@ -2611,14 +2586,14 @@ vec3 RiggedObject::GetAvgVelocity()
 {
     vec3 total(0.0f);
     float divisor = 0.0f;
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        if(!skeleton_.physics_bones[i].bullet_object ||
-           !skeleton_.physics_bones[i].bullet_object->linked){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object ||
+           !physics_bone.bullet_object->linked){
             continue;
         }
-        const float mass = skeleton_.physics_bones[i].bullet_object->GetMass();
+        const float mass = physics_bone.bullet_object->GetMass();
         divisor += mass;
-        total += skeleton_.physics_bones[i].bullet_object->GetLinearVelocity() * mass;
+        total += physics_bone.bullet_object->GetLinearVelocity() * mass;
     }    
 
     total /= divisor;
@@ -2629,14 +2604,14 @@ vec3 RiggedObject::GetAvgVelocity()
 vec3 RiggedObject::GetAvgAngularVelocity() {
     vec3 total(0.0f);
     float divisor = 0.0f;
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        if(!skeleton_.physics_bones[i].bullet_object ||
-           !skeleton_.physics_bones[i].bullet_object->linked){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object ||
+           !physics_bone.bullet_object->linked){
                 continue;
         }
-        total += skeleton_.physics_bones[i].bullet_object->GetAngularVelocity() *
-                 skeleton_.physics_bones[i].bullet_object->GetMass();
-        divisor += skeleton_.physics_bones[i].bullet_object->GetMass();
+        total += physics_bone.bullet_object->GetAngularVelocity() *
+                 physics_bone.bullet_object->GetMass();
+        divisor += physics_bone.bullet_object->GetMass();
     }    
 
     total /= divisor;
@@ -2648,11 +2623,11 @@ vec3 RiggedObject::GetAvgAngularVelocity() {
 quaternion RiggedObject::GetAvgRotation()
 {
     quaternion total;
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); i++){
-        if(!skeleton_.physics_bones[i].bullet_object){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object){
             continue;
         }
-        const PhysicsBone& bone = skeleton_.physics_bones[i];
+        const PhysicsBone& bone = physics_bone;
         mat4 rotation = bone.bullet_object->GetRotation() * 
                         invert(bone.initial_rotation);
         total += QuaternionFromMat4(rotation) * bone.bullet_object->GetMass();
@@ -2677,18 +2652,18 @@ vec3 RiggedObject::GetIKTargetPosition( const std::string &target_name )
 }
 
 float RiggedObject::GetIKWeight( const std::string &target_name ) {
-    for(unsigned i=0; i<blended_bone_paths.size(); ++i){
-        if(blended_bone_paths[i].ik_bone.label == target_name){
-            return blended_bone_paths[i].weight;
+    for(auto & blended_bone_path : blended_bone_paths){
+        if(blended_bone_path.ik_bone.label == target_name){
+            return blended_bone_path.weight;
         }
     }
     return 0.0f;
 }
 
 BoneTransform GetIKTransform( RiggedObject* rigged_object, const std::string &target_name ) {
-    for(unsigned i=0; i<rigged_object->blended_bone_paths.size(); ++i){
-        if(rigged_object->blended_bone_paths[i].ik_bone.label == target_name){
-            return rigged_object->blended_bone_paths[i].transform;
+    for(auto & blended_bone_path : rigged_object->blended_bone_paths){
+        if(blended_bone_path.ik_bone.label == target_name){
+            return blended_bone_path.transform;
         }
     }
     BoneTransform identity;
@@ -2696,9 +2671,9 @@ BoneTransform GetIKTransform( RiggedObject* rigged_object, const std::string &ta
 }
 
 mat4 GetUnmodifiedIKTransform( RiggedObject* rigged_object, const std::string &target_name ) {
-    for(unsigned i=0; i<rigged_object->blended_bone_paths.size(); ++i){
-        if(rigged_object->blended_bone_paths[i].ik_bone.label == target_name){
-            return rigged_object->blended_bone_paths[i].unmodified_transform.GetMat4();
+    for(auto & blended_bone_path : rigged_object->blended_bone_paths){
+        if(blended_bone_path.ik_bone.label == target_name){
+            return blended_bone_path.unmodified_transform.GetMat4();
         }
     }
     mat4 identity;
@@ -2706,9 +2681,9 @@ mat4 GetUnmodifiedIKTransform( RiggedObject* rigged_object, const std::string &t
 }
 
 vec3 RiggedObject::GetIKTargetAnimPosition( const std::string &target_name ) {
-    for(unsigned i=0; i<blended_bone_paths.size(); ++i){
-        if(blended_bone_paths[i].ik_bone.label == target_name){
-            int target_bone = blended_bone_paths[i].ik_bone.bone_path.back();
+    for(auto & blended_bone_path : blended_bone_paths){
+        if(blended_bone_path.ik_bone.label == target_name){
+            int target_bone = blended_bone_path.ik_bone.bone_path.back();
             return unmodified_transforms[target_bone].origin;
         }
     }
@@ -2753,8 +2728,7 @@ void MorphTarget::CalcVertsModified(int base_model_id, int lod_level) {
     } else {
         verts_modified[lod_level].resize(model_num_verts, false);
         tc_modified[lod_level].resize(model_num_verts, false);
-        for(unsigned i=0; i<morph_targets.size(); ++i){
-            MorphTarget &mt = morph_targets[i];
+        for(auto & mt : morph_targets){
             mt.CalcVertsModified(base_model_id, lod_level);
             for(int j=0; j<model_num_verts; ++j){
                 if(mt.verts_modified[lod_level][j]){
@@ -2795,8 +2769,8 @@ void MorphTarget::Load(const std::string &base_model_name,
     script_weight_weight = 0.0f;
     checksum = 0;
 
-    for(int i=0; i<4; ++i){
-        model_id[i] = -1;
+    for(int & i : model_id){
+        i = -1;
     }
 
     if(parts == 1){       
@@ -2820,11 +2794,11 @@ void MorphTarget::Load(const std::string &base_model_name,
     } else {
         model_id[0] = Models::Instance()->CopyModel(base_model_id);
         Model& model = Models::Instance()->GetModel(model_id[0]);
-        for(int i=0, len=(int)model.vertices.size(); i<len; ++i){
-            model.vertices[i] = 0.0f;
+        for(float & vertice : model.vertices){
+            vertice = 0.0f;
         }
-        for(int i=0, len=(int)model.tex_coords.size(); i<len; ++i){
-            model.tex_coords[i] = 0.0f;
+        for(float & tex_coord : model.tex_coords){
+            tex_coord = 0.0f;
         }
         model_copy[0] = true;
         for(int i=0; i<parts; ++i){
@@ -2877,20 +2851,20 @@ void MorphTarget::PreDrawCamera(int num, int progress, int lod_level, uint32_t c
         
         if(new_weight == 0.0f || new_weight == 1.0f){
             Model *the_model = (new_weight == 0.0f)?&morph_model_start:&morph_model_end;
-            for(unsigned j=0; j<modified_verts[lod_level].size(); ++j){
-                const int index = modified_verts[lod_level][j]*3;
+            for(int j : modified_verts[lod_level]){
+                const int index = j*3;
                 model.vertices[index+0] = the_model->vertices[index+0]; 
                 model.vertices[index+1] = the_model->vertices[index+1]; 
                 model.vertices[index+2] = the_model->vertices[index+2];
             }
-            for(unsigned j=0; j<modified_tc[lod_level].size(); ++j){
-                const int tc_index = modified_tc[lod_level][j]*2;
+            for(int j : modified_tc[lod_level]){
+                const int tc_index = j*2;
                 model.tex_coords[tc_index+0] = the_model->tex_coords[tc_index+0]; 
                 model.tex_coords[tc_index+1] = the_model->tex_coords[tc_index+1];
             }
         } else {
-            for(unsigned j=0; j<modified_verts[lod_level].size(); ++j){
-                const int index = modified_verts[lod_level][j]*3;
+            for(int j : modified_verts[lod_level]){
+                const int index = j*3;
                 model.vertices[index+0] = morph_model_start.vertices[index+0]*(1.0f-new_weight); 
                 model.vertices[index+1] = morph_model_start.vertices[index+1]*(1.0f-new_weight); 
                 model.vertices[index+2] = morph_model_start.vertices[index+2]*(1.0f-new_weight); 
@@ -2898,8 +2872,8 @@ void MorphTarget::PreDrawCamera(int num, int progress, int lod_level, uint32_t c
                 model.vertices[index+1] += morph_model_end.vertices[index+1]*new_weight; 
                 model.vertices[index+2] += morph_model_end.vertices[index+2]*new_weight; 
             }
-            for(unsigned j=0; j<modified_tc[lod_level].size(); ++j){
-                const int tc_index = modified_tc[lod_level][j]*2;
+            for(int j : modified_tc[lod_level]){
+                const int tc_index = j*2;
                 model.tex_coords[tc_index+0] = morph_model_start.tex_coords[tc_index+0]*(1.0f-new_weight); 
                 model.tex_coords[tc_index+1] = morph_model_start.tex_coords[tc_index+1]*(1.0f-new_weight);
                 model.tex_coords[tc_index+0] += morph_model_end.tex_coords[tc_index+0]*new_weight; 
@@ -2934,8 +2908,8 @@ void MorphTarget::Dispose() {
             Models::Instance()->DeleteModel(model_id[i]);
         }
     }
-    for(unsigned i=0; i<morph_targets.size(); ++i){
-        morph_targets[i].Dispose();
+    for(auto & morph_target : morph_targets){
+        morph_target.Dispose();
     }
 }
 
@@ -3013,11 +2987,11 @@ mat4 RiggedObject::GetBoneRotation( int bone ) {
 }
 
 void RiggedObject::SetSkeletonOwner( Object* owner ) {
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); ++i){
-        if(!skeleton_.physics_bones[i].bullet_object){
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(!physics_bone.bullet_object){
             continue;
         }
-        skeleton_.physics_bones[i].bullet_object->owner_object = owner;
+        physics_bone.bullet_object->owner_object = owner;
     }
 }
 
@@ -3109,18 +3083,18 @@ vec3 RiggedObject::GetIKChainPos( const std::string &target_name, int which )
 
 void RiggedObject::EnableSleep()
 {
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); ++i){
-        if(skeleton_.physics_bones[i].bullet_object){
-            skeleton_.physics_bones[i].bullet_object->CanSleep();
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(physics_bone.bullet_object){
+            physics_bone.bullet_object->CanSleep();
         }
     }
 }
 
 void RiggedObject::DisableSleep()
 {
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); ++i){
-        if(skeleton_.physics_bones[i].bullet_object){
-            skeleton_.physics_bones[i].bullet_object->NoSleep();
+    for(auto & physics_bone : skeleton_.physics_bones){
+        if(physics_bone.bullet_object){
+            physics_bone.bullet_object->NoSleep();
         }
     }
 }
@@ -3136,11 +3110,11 @@ void RiggedObject::HandleLipSyncMorphTargets(float timestep) {
         const std::map<std::string, float> &mw = lipsync_reader.GetMorphWeights();
         std::map<std::string, float>::const_iterator iter;
         for(iter = mw.begin(); iter != mw.end(); ++iter){
-            for(unsigned i=0; i<morph_targets.size(); ++i){
-                if(morph_targets[i].name == iter->first){
-                    morph_targets[i].script_weight = 
-                        mix(morph_targets[i].script_weight, iter->second, 0.5f);
-                    morph_targets[i].script_weight_weight = 1.0f;
+            for(auto & morph_target : morph_targets){
+                if(morph_target.name == iter->first){
+                    morph_target.script_weight = 
+                        mix(morph_target.script_weight, iter->second, 0.5f);
+                    morph_target.script_weight_weight = 1.0f;
                     break;
                 }
             }    
@@ -3148,9 +3122,9 @@ void RiggedObject::HandleLipSyncMorphTargets(float timestep) {
         lipsync_reader.Update(timestep);
         if(!lipsync_reader.valid()){
             for(iter = mw.begin(); iter != mw.end(); ++iter){
-                for(unsigned i=0; i<morph_targets.size(); ++i){
-                    if(morph_targets[i].name == iter->first){
-                        morph_targets[i].script_weight_weight = 0.0f;
+                for(auto & morph_target : morph_targets){
+                    if(morph_target.name == iter->first){
+                        morph_target.script_weight_weight = 0.0f;
                         break;
                     }
                 }    
@@ -3210,10 +3184,9 @@ void RiggedObject::SetCharAnim( const std::string &path, char flags, const std::
 const float _item_blend_fade_speed = 5.0f;
 void RiggedObject::CheckItemAnimBlends(const std::string &path, char flags) {
     anim_client.ClearBlendAnimation();
-    for(std::list<AttachedItem>::iterator iter = attached_items.items.begin(); 
-        iter != attached_items.items.end(); ++iter)
+    for(auto & iter : attached_items.items)
     {
-        ItemObjectScriptReader& item = iter->item;
+        ItemObjectScriptReader& item = iter.item;
         if(item->item_ref()->HasAnimBlend(path) && item->state() == ItemObject::kWielded){
             const std::string &a_path = item->item_ref()->GetAnimBlend(path); 
             anim_client.SetBlendAnimation(a_path);
@@ -3255,8 +3228,8 @@ void RiggedObject::MPCutPlane(const vec3 & normal, const vec3 & pos, const vec3 
 	}
 	else {
 		//blood_surface.AddBloodToTriangles(hit_list);
-		for (unsigned i = 0; i < hit_list.size(); ++i) { 
-			GetTransformedTri(hit_list[i], mp_points);
+		for (int i : hit_list) { 
+			GetTransformedTri(i, mp_points);
 			if (dot(cross(mp_points[1] - mp_points[0], mp_points[2] - mp_points[0]), dir) > 0.0f) {
 				continue;
 			}
@@ -3270,8 +3243,8 @@ void RiggedObject::MPCutPlane(const vec3 & normal, const vec3 & pos, const vec3 
 			}
 			vec2 tex_points[3];
 			for (unsigned j = 0; j < 3; ++j) {
-				tex_points[j][0] = model->tex_coords[model->faces[hit_list[i] * 3 + j] * 2 + 0];
-				tex_points[j][1] = model->tex_coords[model->faces[hit_list[i] * 3 + j] * 2 + 1];
+				tex_points[j][0] = model->tex_coords[model->faces[i * 3 + j] * 2 + 0];
+				tex_points[j][1] = model->tex_coords[model->faces[i * 3 + j] * 2 + 1];
 
 				 
 			}
@@ -3297,13 +3270,13 @@ void RiggedObject::MPCutPlane(const vec3 & normal, const vec3 & pos, const vec3 
 			if (type == _light || RangedRandomFloat(0.0f, 1.0f) < 0.6f) {
 				vec2 bleed_point = mix(tex_intersect_points[0], tex_intersect_points[1], 0.5f);
 				vec3 coords = bary_coords(bleed_point, tex_points[0], tex_points[1], tex_points[2]); 
-				blood_surface.CreateDripInTri(hit_list[i], coords, RangedRandomFloat(0.1f, 1.0f), RangedRandomFloat(0.0f, 1.0f), true, SurfaceWalker::BLOOD);
+				blood_surface.CreateDripInTri(i, coords, RangedRandomFloat(0.1f, 1.0f), RangedRandomFloat(0.0f, 1.0f), true, SurfaceWalker::BLOOD);
 			}
 
 			if (type == _heavy || RangedRandomFloat(0.0f, 1.0f) < 0.2f) {
 				vec2 bleed_point = mix(tex_intersect_points[0], tex_intersect_points[1], 0.5f);
 				vec3 coords = bary_coords(bleed_point, tex_points[0], tex_points[1], tex_points[2]); 
-				blood_surface.CreateDripInTri(hit_list[i], coords, RangedRandomFloat(0.1f, 0.5f), RangedRandomFloat(0.0f, 10.0f), true, SurfaceWalker::BLOOD);
+				blood_surface.CreateDripInTri(i, coords, RangedRandomFloat(0.1f, 0.5f), RangedRandomFloat(0.0f, 10.0f), true, SurfaceWalker::BLOOD);
 			}
 
 			//dot(offset+dir*time, normal) = 0.0f              
@@ -3382,11 +3355,11 @@ void UpdateStuckItem(AttachedItem& stuck_item, const Skeleton &skeleton, bool an
 }
 
 void RiggedObject::UpdateAttachedItems() {
-    for(AttachedItemList::iterator iter = attached_items.items.begin(); iter != attached_items.items.end(); ++iter){
-        UpdateAttachedItem(*iter, skeleton_, model_char_scale, weapon_offset, weap_anim_info_map, weapon_offset_retarget);
+    for(auto & item : attached_items.items){
+        UpdateAttachedItem(item, skeleton_, model_char_scale, weapon_offset, weap_anim_info_map, weapon_offset_retarget);
     }
-    for(AttachedItemList::iterator iter = stuck_items.items.begin(); iter != stuck_items.items.end(); ++iter) {
-        UpdateStuckItem(*iter, skeleton_, animated);
+    for(auto & item : stuck_items.items) {
+        UpdateStuckItem(item, skeleton_, animated);
     }
 }
 
@@ -3410,8 +3383,8 @@ void RiggedObject::CutPlane( const vec3 &normal, const vec3 &pos, const vec3 &di
             GetTransformedTri(i, points);
             pos_side = false;
             neg_side = false;
-            for (unsigned j = 0; j < 3; ++j) {
-                if (dot(points[j] - pos, normal) < 0.0f) {
+            for (const auto & point : points) {
+                if (dot(point - pos, normal) < 0.0f) {
                     neg_side = true;
                 }
                 else {
@@ -3439,8 +3412,8 @@ void RiggedObject::CutPlane( const vec3 &normal, const vec3 &pos, const vec3 &di
         }
     } else {
         //blood_surface.AddBloodToTriangles(hit_list);
-        for(unsigned i=0; i<hit_list.size(); ++i){ 
-            GetTransformedTri(hit_list[i], points);
+        for(int i : hit_list){ 
+            GetTransformedTri(i, points);
             if(dot(cross(points[1] - points[0], points[2] - points[0]), dir) > 0.0f){
                 continue;
             }
@@ -3454,8 +3427,8 @@ void RiggedObject::CutPlane( const vec3 &normal, const vec3 &pos, const vec3 &di
             }
             vec2 tex_points[3];
             for(unsigned j=0; j<3; ++j){
-                tex_points[j][0] = model->tex_coords[model->faces[hit_list[i]*3+j]*2+0];
-                tex_points[j][1] = model->tex_coords[model->faces[hit_list[i]*3+j]*2+1]; 
+                tex_points[j][0] = model->tex_coords[model->faces[i*3+j]*2+0];
+                tex_points[j][1] = model->tex_coords[model->faces[i*3+j]*2+1]; 
             }
             vec2 tex_intersect_points[2];
             vec3 intersect_points[2];
@@ -3480,7 +3453,7 @@ void RiggedObject::CutPlane( const vec3 &normal, const vec3 &pos, const vec3 &di
                 vec3 coords = bary_coords(bleed_point, tex_points[0], tex_points[1], tex_points[2]); 
 
 				//LOGI << "BLEED POINT " << bleed_point << " coords " << coords << std::endl;
-                blood_surface.CreateDripInTri(hit_list[i], coords, RangedRandomFloat(0.1f,1.0f), RangedRandomFloat(0.0f,1.0f), true, SurfaceWalker::BLOOD);
+                blood_surface.CreateDripInTri(i, coords, RangedRandomFloat(0.1f,1.0f), RangedRandomFloat(0.0f,1.0f), true, SurfaceWalker::BLOOD);
             }
 
             if(type == _heavy || RangedRandomFloat(0.0f,1.0f)<0.2f){
@@ -3488,7 +3461,7 @@ void RiggedObject::CutPlane( const vec3 &normal, const vec3 &pos, const vec3 &di
                 vec3 coords = bary_coords(bleed_point, tex_points[0], tex_points[1], tex_points[2]); 
 
 				//LOGI << "BLEED POINT " << bleed_point << " coords " << coords << std::endl;
-                blood_surface.CreateDripInTri(hit_list[i], coords, RangedRandomFloat(0.1f,0.5f), RangedRandomFloat(0.0f,10.0f), true, SurfaceWalker::BLOOD);
+                blood_surface.CreateDripInTri(i, coords, RangedRandomFloat(0.1f,0.5f), RangedRandomFloat(0.0f,10.0f), true, SurfaceWalker::BLOOD);
             }
 
             //dot(offset+dir*time, normal) = 0.0f              
@@ -3540,9 +3513,9 @@ void RiggedObject::Stab( const vec3 &pos, const vec3 &dir, int type, int depth )
     for(int i=0, len=model->faces.size()/3; i<len; ++i){
         close_enough = false;
         GetTransformedTri(i, points);
-        for(unsigned j=0; j<3; ++j){
-            points[j] -= dir * dot(dir, points[j] - pos);
-            if(distance_squared(points[j], pos) < _stab_threshold){
+        for(auto & point : points){
+            point -= dir * dot(dir, point - pos);
+            if(distance_squared(point, pos) < _stab_threshold){
                 close_enough = true;
             }
         }
@@ -3563,11 +3536,11 @@ void RiggedObject::Stab( const vec3 &pos, const vec3 &dir, int type, int depth )
     vec3 start = pos - dir * 1000.0f;
     vec3 end = pos + dir * 1000.0f;
     vec3 intersect;
-    for(unsigned i=0; i<hit_list.size(); ++i){
-        GetTransformedTri(hit_list[i], points);
+    for(int i : hit_list){
+        GetTransformedTri(i, points);
         if(LineFacet(start, end, points[0], points[1], points[2], &intersect)){
             for(unsigned j=0; j<10; ++j){
-                blood_surface.CreateDripInTri(hit_list[i], vec3(0.333f,0.333f,0.333f), RangedRandomFloat(0.1f,1.0f), RangedRandomFloat(0.0f,10.0f), true, SurfaceWalker::BLOOD);
+                blood_surface.CreateDripInTri(i, vec3(0.333f,0.333f,0.333f), RangedRandomFloat(0.1f,1.0f), RangedRandomFloat(0.0f,10.0f), true, SurfaceWalker::BLOOD);
             }
         }
     }
@@ -3614,8 +3587,8 @@ void RiggedObject::AddWaterCube( const mat4 &transform ) {
 
             std::vector<mat4> fire_decal_matrix;
             std::vector<mat4> water_decal_matrix;
-            for(int i=0, len=scenegraph_->decal_objects_.size(); i<len; ++i){
-                DecalObject* obj = (DecalObject*)scenegraph_->decal_objects_[i];
+            for(auto & decal_object : scenegraph_->decal_objects_){
+                DecalObject* obj = (DecalObject*)decal_object;
                 if(obj->decal_file_ref->special_type == 3){
                     fire_decal_matrix.push_back(obj->GetTransform());
                 }
@@ -3676,12 +3649,12 @@ void RiggedObject::AddWaterCube( const mat4 &transform ) {
 }
 
 void RiggedObject::UpdateCollisionObjects() {
-    for(unsigned i=0; i<skeleton_.physics_bones.size(); ++i){
-        BulletObject* cbo = skeleton_.physics_bones[i].col_bullet_object;
+    for(auto & physics_bone : skeleton_.physics_bones){
+        BulletObject* cbo = physics_bone.col_bullet_object;
         if(!cbo){
             continue;
         }
-        cbo->SetTransform(skeleton_.physics_bones[i].bullet_object->GetTransform());
+        cbo->SetTransform(physics_bone.bullet_object->GetTransform());
         cbo->UpdateTransform();
     }
     skeleton_.UpdateCollisionWorldAABB();
@@ -3753,8 +3726,8 @@ static int ASGetBonePoint(Skeleton* skeleton, int which_bone, int which_point){
 }
 
 static void ASAddVelocity(Skeleton* skeleton, const vec3& vel){
-    for(int bone_index=0, num_bones=skeleton->physics_bones.size(); bone_index<num_bones; ++bone_index){
-        BulletObject* bullet_object = skeleton->physics_bones[bone_index].bullet_object;
+    for(auto & physics_bone : skeleton->physics_bones){
+        BulletObject* bullet_object = physics_bone.bullet_object;
         if(bullet_object){
             bullet_object->AddLinearVelocity(vel);
         }
@@ -3787,8 +3760,8 @@ void RotateBonesToMatchVec(RiggedObject* rigged_object, const vec3& a, const vec
 
 static void TransformAllFrameMats(RiggedObject* rigged_object, const BoneTransform &transform) {
     std::vector<BoneTransform> &mats = rigged_object->animation_frame_bone_matrices;
-    for(int i=0, len=mats.size(); i<len; ++i){
-        mats[i] = transform * mats[i];
+    for(auto & mat : mats){
+        mat = transform * mat;
     }
 }
 
@@ -3863,8 +3836,8 @@ static CScriptArray *ASGetConvexHullPoints(Skeleton* skeleton, int bone){
     CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
     array->Reserve(points.size());
 
-    for(int i=0, len=points.size(); i<len; ++i) {
-        array->InsertLast(&points[i]);
+    for(float & point : points) {
+        array->InsertLast(&point);
     }        
     return array;
 }
@@ -4026,8 +3999,8 @@ void RiggedObject::SaveSimplificationCache(const std::string &path) {
     }
     unsigned short checksum = skeleton_.skeleton_asset_ref->checksum()+
         Models::Instance()->GetModel(model_id[0]).checksum;
-    for(int i=0, len=morph_targets.size(); i<len; ++i){
-        checksum += morph_targets[i].checksum;
+    for(auto & morph_target : morph_targets){
+        checksum += morph_target.checksum;
     }
     fwrite(&simp_cache_vers, sizeof(int), 1, file);
     fwrite(&checksum, sizeof(unsigned short), 1, file);
@@ -4050,14 +4023,14 @@ void RiggedObject::SaveSimplificationCache(const std::string &path) {
     }
 
     std::queue<MorphTarget*> queue;
-    for(unsigned i=0; i<morph_targets.size(); ++i){
-        queue.push(&morph_targets[i]);
+    for(auto & morph_target : morph_targets){
+        queue.push(&morph_target);
     }
     while(!queue.empty()){
         MorphTarget& morph = (*queue.front());
         queue.pop();
-        for(unsigned i=0; i<morph.morph_targets.size(); ++i){
-            queue.push(&morph.morph_targets[i]);
+        for(auto & morph_target : morph.morph_targets){
+            queue.push(&morph_target);
         }
         for(unsigned i=1; i<4; ++i){
             const Model& model = Models::Instance()->GetModel(morph.model_id[i]);
@@ -4102,8 +4075,8 @@ bool RiggedObject::LoadSimplificationCache(const std::string& path) {
     }
     unsigned short checksum = skeleton_.skeleton_asset_ref->checksum()+
         Models::Instance()->GetModel(model_id[0]).checksum;
-    for(int i=0, len=morph_targets.size(); i<len; ++i){
-        checksum += morph_targets[i].checksum;
+    for(auto & morph_target : morph_targets){
+        checksum += morph_target.checksum;
     }
     unsigned short file_checksum;
     fread(&file_checksum, sizeof(unsigned short), 1, file);
@@ -4145,14 +4118,14 @@ bool RiggedObject::LoadSimplificationCache(const std::string& path) {
     }
 
     std::queue<MorphTarget*> queue;
-    for(unsigned i=0; i<morph_targets.size(); ++i){
-        queue.push(&morph_targets[i]);
+    for(auto & morph_target : morph_targets){
+        queue.push(&morph_target);
     }
     while(!queue.empty()){
         MorphTarget& morph = (*queue.front());
         queue.pop();
-        for(unsigned i=0; i<morph.morph_targets.size(); ++i){
-            queue.push(&morph.morph_targets[i]);
+        for(auto & morph_target : morph.morph_targets){
+            queue.push(&morph_target);
         }
         for(unsigned i=1; i<4; ++i){
             morph.model_id[i] = Models::Instance()->AddModel();
@@ -4237,8 +4210,8 @@ void RiggedObject::CreateFurModel( int model_id, int fur_model_id ) {
     // verts
     {
         std::vector<bool> included(fur_ref_model.vertices.size()/3, false);
-        for(unsigned i=0; i<fur_model.faces.size(); ++i){
-            included[fur_model.faces[i]] = true;
+        for(unsigned int face : fur_model.faces){
+            included[face] = true;
         }
 
         int remap_index = 0;
@@ -4253,8 +4226,8 @@ void RiggedObject::CreateFurModel( int model_id, int fur_model_id ) {
                 fur_model.vertices.push_back(fur_ref_model.vertices[vert_index+2] - base_model.old_center[2]);
             }
         }
-        for(unsigned i=0; i<fur_model.faces.size(); ++i){
-            fur_model.faces[i] = remapped[fur_model.faces[i]];
+        for(unsigned int & face : fur_model.faces){
+            face = remapped[face];
         }
     }
    
@@ -4279,8 +4252,8 @@ void RiggedObject::CreateFurModel( int model_id, int fur_model_id ) {
         for(int i=0, len=fur_model.vertices.size()/3; i<len; ++i){
             vert_dup[i] = fur_model_points[fur_verts[i]].front();
         }
-        for(unsigned i=0; i<fur_model.faces.size(); ++i){
-            fur_model.faces[i] = vert_dup[fur_model.faces[i]];
+        for(unsigned int & face : fur_model.faces){
+            face = vert_dup[face];
         } 
     }
 
@@ -4713,20 +4686,18 @@ void RiggedObject::UnStickItem( int id ) {
 
 std::vector<ItemRef> RiggedObject::GetWieldedItemRefs() const {
     int num_wielded = 0;
-    for(std::list<AttachedItem>::const_iterator iter = attached_items.items.begin(); 
-        iter != attached_items.items.end(); ++iter)
+    for(const auto & iter : attached_items.items)
     {
-        const ItemObjectScriptReader& item = iter->item;
+        const ItemObjectScriptReader& item = iter.item;
         if(item->GetID() == primary_weapon_id){
             ++num_wielded;
         }
     }
     std::vector<ItemRef> wielded_item_refs(num_wielded);
     num_wielded = 0;
-    for(std::list<AttachedItem>::const_iterator iter = attached_items.items.begin(); 
-        iter != attached_items.items.end(); ++iter)
+    for(const auto & iter : attached_items.items)
     {
-        const ItemObjectScriptReader& item = iter->item;
+        const ItemObjectScriptReader& item = iter.item;
         if(item->GetID() == primary_weapon_id){
             wielded_item_refs[num_wielded++] = item->item_ref();
         }
@@ -4783,11 +4754,10 @@ void RiggedObject::AvailableItemSlots( const ItemRef& item_ref, AttachmentSlotLi
         DrawAvailableAttachmentSlots(item_ref, _at_sheathe, skeleton_, list);
     }
     const std::list<std::string> &attachment_list = item_ref->GetAttachmentList();
-    for(std::list<std::string>::const_iterator iter = attachment_list.begin();
-        iter != attachment_list.end(); ++iter)
+    for(const auto & iter : attachment_list)
     {
         //AttachmentRef attachment_ref = Attachments::Instance()->ReturnRef((*iter));
-        AttachmentRef attachment_ref = Engine::Instance()->GetAssetManager()->LoadSync<Attachment>((*iter));
+        AttachmentRef attachment_ref = Engine::Instance()->GetAssetManager()->LoadSync<Attachment>(iter);
         DrawAvailableAttachment(attachment_ref, skeleton_, false, list);
         if(attachment_ref->mirror_allowed){
             DrawAvailableAttachment(attachment_ref, skeleton_, true, list);
@@ -4911,8 +4881,8 @@ void AttachedItems::Remove( int id ) {
 }
 
 void AttachedItems::RemoveAll() {
-    for(std::list<AttachedItem>::iterator iter = items.begin(); iter != items.end(); ++iter) {
-        iter->item->ActivatePhysics();
+    for(auto & item : items) {
+        item.item->ActivatePhysics();
     }
     items.clear();
 }

--- a/Source/Objects/terrainobject.cpp
+++ b/Source/Objects/terrainobject.cpp
@@ -164,10 +164,9 @@ void TerrainObject::PreDrawCamera(float curr_game_time) {
     }
 
     static const mat4 identity;
-    for(std::list<DetailObjectSurface*>::iterator iter = terrain_.detail_object_surfaces.begin();
-        iter != terrain_.detail_object_surfaces.end(); ++iter)
+    for(auto & detail_object_surface : terrain_.detail_object_surfaces)
     {
-        (*iter)->PreDrawCamera(identity);
+        detail_object_surface->PreDrawCamera(identity);
     }
 }
 
@@ -180,10 +179,9 @@ void TerrainObject::Draw() {
 
     if(!terrain_info_.minimal) {
         static const mat4 identity;
-        for(std::list<DetailObjectSurface*>::iterator iter = terrain_.detail_object_surfaces.begin();
-            iter != terrain_.detail_object_surfaces.end(); ++iter)
+        for(auto & detail_object_surface : terrain_.detail_object_surfaces)
         {
-            (*iter)->Draw(identity, DetailObjectSurface::TERRAIN, vec3(1.0f), scenegraph_->sky->GetSpecularCubeMapTexture(), &scenegraph_->light_probe_collection, scenegraph_);
+            detail_object_surface->Draw(identity, DetailObjectSurface::TERRAIN, vec3(1.0f), scenegraph_->sky->GetSpecularCubeMapTexture(), &scenegraph_->light_probe_collection, scenegraph_);
         }
     }
 }
@@ -269,8 +267,7 @@ void TerrainObject::DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_
 
     int vert_attrib_id = shaders->returnShaderAttrib("vertex_attrib", shader);
     graphics->EnableVertexAttribArray(vert_attrib_id);
-    for(std::list<Model>::iterator iter = terrain_.terrain_patches.begin(); iter != terrain_.terrain_patches.end(); ++iter) {
-        Model& patch = (*iter);
+    for(auto & patch : terrain_.terrain_patches) {
         const vec3 adjusted_min = patch.min_coords + translation;
         const vec3 adjusted_max = patch.max_coords + translation;
         if(CheckBoxAgainstPlanes(adjusted_min, adjusted_max, cull_planes, num_cull_planes)) {
@@ -283,8 +280,7 @@ void TerrainObject::DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_
             graphics->DrawElements(use_tesselation?GL_PATCHES:GL_TRIANGLES, (unsigned int) patch.faces.size(), GL_UNSIGNED_INT, 0);
         }
     }
-    for(std::list<Model>::iterator iter = terrain_.edge_terrain_patches.begin(); iter != terrain_.edge_terrain_patches.end(); ++iter) {
-        Model& patch = (*iter);
+    for(auto & patch : terrain_.edge_terrain_patches) {
         const vec3 adjusted_min = patch.min_coords + translation;
         const vec3 adjusted_max = patch.max_coords + translation;
         if(CheckBoxAgainstPlanes(adjusted_min, adjusted_max, cull_planes, num_cull_planes)) {
@@ -542,8 +538,7 @@ void TerrainObject::DrawTerrain() {
 
     std::vector<mat4> light_volume_matrix;
     std::vector<mat4> light_volume_matrix_inverse;
-    for(size_t i=0, len=scenegraph_->light_volume_objects_.size(); i<len; ++i){
-        Object* obj = scenegraph_->light_volume_objects_[i];
+    for(auto obj : scenegraph_->light_volume_objects_){
         const mat4 &mat = obj->GetTransform();
         light_volume_matrix.push_back(mat);
         light_volume_matrix_inverse.push_back(invert(mat));
@@ -579,8 +574,7 @@ void TerrainObject::DrawTerrain() {
     const vec3 translation = GetTranslation();
     {
         PROFILER_GPU_ZONE(g_profiler_ctx, "Draw opaque terrain patches");
-        for(std::list<Model>::iterator iter = terrain_.terrain_patches.begin(); iter != terrain_.terrain_patches.end(); ++iter) {
-            Model& patch = (*iter);
+        for(auto & patch : terrain_.terrain_patches) {
             const vec3 adjusted_min = patch.min_coords + translation;
             const vec3 adjusted_max = patch.max_coords + translation;
             if(ActiveCameras::Get()->checkBoxInFrustum(adjusted_min,
@@ -593,8 +587,7 @@ void TerrainObject::DrawTerrain() {
     {
         PROFILER_GPU_ZONE(g_profiler_ctx, "Draw edge terrain patches");
         graphics->setGLState(edge_gl_state_);
-        for(std::list<Model>::iterator iter = terrain_.edge_terrain_patches.begin(); iter != terrain_.edge_terrain_patches.end(); ++iter) {
-            Model& patch = (*iter);
+        for(auto & patch : terrain_.edge_terrain_patches) {
             const vec3 adjusted_min = patch.min_coords + translation;
             const vec3 adjusted_max = patch.max_coords + translation;
             if(ActiveCameras::Get()->checkBoxInFrustum(adjusted_min,

--- a/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.cpp
+++ b/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.cpp
@@ -121,9 +121,9 @@ public:
                 while( el )
                 {
                     bool found = false;
-                    for( int i = 0; i < parameters.size(); i++ )
+                    for(auto & parameter : parameters)
                     {
-                        found |= parameters[i].Search(
+                        found |= parameter.Search(
                             items, 
                             item, 
                             el);
@@ -523,9 +523,9 @@ void ActorObjectLevelSeeker::SearchGroup( std::vector<Item>& items, const Item& 
 
         bool found = false;
 
-        for( int i = 0; i < aos.size(); i++ )
+        for(auto & ao : aos)
         {
-            found |= aos[i].Search( items, item, el );
+            found |= ao.Search( items, item, el );
         } 
 
         if( !found )
@@ -551,9 +551,9 @@ std::vector<Item> ActorObjectLevelSeeker::SearchLevelRoot( const Item& source, T
         "Hotspots"
     };
 
-    for( int i = 0; i < ARRLEN(entity_roots); i++ )
+    for(auto & entity_root : entity_roots)
     {
-        TiXmlElement* elem = hRoot.FirstChildElement(entity_roots[i]).ToElement();
+        TiXmlElement* elem = hRoot.FirstChildElement(entity_root).ToElement();
 
         if( elem )
         {
@@ -561,7 +561,7 @@ std::vector<Item> ActorObjectLevelSeeker::SearchLevelRoot( const Item& source, T
         }
         else
         {
-            LOGD << source << " Is missing " << entity_roots[i] << std::endl;
+            LOGD << source << " Is missing " << entity_root << std::endl;
         }
     }
     return items;

--- a/Source/Ogda/manifestresult.cpp
+++ b/Source/Ogda/manifestresult.cpp
@@ -76,8 +76,8 @@ const std::string& ManifestResult::GetCurrentDestHash(const std::string& base_pa
 std::ostream& operator<<(std::ostream& out, const ManifestResult& mr) {
         
     out << "ManifestResult( items { ";
-        for( int i = 0; i < mr.items.size(); i++ ) {    
-            out << mr.items[i] << ",";
+        for(const auto & item : mr.items) {    
+            out << item << ",";
         }
     out << "}," << mr.dest << "," << mr.dest_hash << "," << mr.name << "," << mr.version << "," << mr.type << ")";
     return out;

--- a/Source/Online/Message/attach_to_message.cpp
+++ b/Source/Online/Message/attach_to_message.cpp
@@ -82,8 +82,7 @@ namespace OnlineMessages {
                     MovementObject* movement_object = (MovementObject*)parent;
                     AttachmentSlotList attachment_slots;
                     movement_object->rigged_object()->AvailableItemSlots(item_object->item_ref(), &attachment_slots);
-                    for (AttachmentSlotList::iterator iterator = attachment_slots.begin(); iterator != attachment_slots.end(); ++iterator) {
-                        AttachmentSlot& slot = (*iterator);
+                    for (auto & slot : attachment_slots) {
                         if (slot.type == (AttachmentType)t->bone_id && slot.mirrored == t->mirrored) {
                             movement_object->AttachItemToSlotEditor(item_object->GetID(), slot.type, slot.mirrored, slot.attachment_ref, true);
                             break;

--- a/Source/Online/Message/movement_object_update.cpp
+++ b/Source/Online/Message/movement_object_update.cpp
@@ -94,8 +94,8 @@ namespace OnlineMessages {
                 MovementObject* mo = static_cast<MovementObject*>(object);
 
                 // Check if we already have an update for the specified time
-                for (auto it = mo->incoming_movement_object_frames.begin(); it != mo->incoming_movement_object_frames.end(); it++) {
-                    MovementObjectUpdate* update = static_cast<MovementObjectUpdate*>(it->GetData());
+                for (auto & incoming_movement_object_frame : mo->incoming_movement_object_frames) {
+                    MovementObjectUpdate* update = static_cast<MovementObjectUpdate*>(incoming_movement_object_frame.GetData());
                     if (update->timestamp == mou->timestamp) {
                         LOGW << "Received MovementObjectUpdate with an identical timestamp of an existing update for object: \"" << object_id << " (" << mou->identifier << ")\"" << std::endl;
                         return;

--- a/Source/Online/online.cpp
+++ b/Source/Online/online.cpp
@@ -579,18 +579,18 @@ const vector<Peer> Online::GetPeers()  {
 }
 
 Peer* Online::GetPeerFromConnection(NetConnectionID conn_id) {
-    for(int i = 0; i < online_session->connected_peers.size(); i++) {
-        if(online_session->connected_peers[i].conn_id == conn_id) {
-            return &online_session->connected_peers[i];
+    for(auto & connected_peer : online_session->connected_peers) {
+        if(connected_peer.conn_id == conn_id) {
+            return &connected_peer;
         }
     }
     return nullptr;
 }
 
 Peer* Online::GetPeerFromID(PeerID peer_id) {
-    for(int i = 0; i < online_session->connected_peers.size(); i++) {
-        if(online_session->connected_peers[i].peer_id == peer_id) {
-            return &online_session->connected_peers[i];
+    for(auto & connected_peer : online_session->connected_peers) {
+        if(connected_peer.peer_id == peer_id) {
+            return &connected_peer;
         }
     }
     return nullptr;
@@ -1407,18 +1407,16 @@ void Online::SendMessageObjects() {
 
     //First, send persistent packages, if we see there's a new client who isn't up to date.
     if(host_started_level && IsHosting()) {
-        for(int k = 0; k < online_session->connected_peers.size(); k++) {
-            Peer& peer = online_session->connected_peers[k];
-
+        for(auto & peer : online_session->connected_peers) {
             if(online_session->client_connection_manager.IsClientLoaded(peer.peer_id) && online_session->client_connection_manager.HasClientGottenPersistentQueue(peer.peer_id) == false) {
-                for(int i = 0; i < online_session->persistent_outgoing_messages.size(); i++)  {
-                    OnlineMessageBase* omb = static_cast<OnlineMessageBase*>(message_handler.GetMessageData(online_session->persistent_outgoing_messages[i]));
+                for(auto & persistent_outgoing_message : online_session->persistent_outgoing_messages)  {
+                    OnlineMessageBase* omb = static_cast<OnlineMessageBase*>(message_handler.GetMessageData(persistent_outgoing_message));
 
                     if(omb != nullptr) {
                         PackageHeader package_header;
 
                         package_header.package_type = PackageHeader::Type::MESSAGE_OBJECT;
-                        package_header.message_ref = online_session->persistent_outgoing_messages[i];
+                        package_header.message_ref = persistent_outgoing_message;
 
                         binn* l = package_header.Serialize();
 
@@ -1453,8 +1451,7 @@ void Online::SendMessageObjects() {
 
             binn_free(l);
 
-            for(int k = 0; k < online_session->connected_peers.size(); k++) {
-                Peer& peer = online_session->connected_peers[k];
+            for(auto & peer : online_session->connected_peers) {
                 bool send_message = true;
 
                 if(outgoing_message.broadcast == false && outgoing_message.target != peer.conn_id) {

--- a/Source/Online/online_utility.cpp
+++ b/Source/Online/online_utility.cpp
@@ -70,17 +70,17 @@ std::string OnlineUtility::GetActiveModsString() {
     bool active_mods = false;
     stringstream modlist;
     vector<ModInstance*> mods = ModLoading::Instance().GetAllMods();
-    for(size_t i = 0; i < mods.size(); i++) {
-        if(mods[i]->IsActive() && !mods[i]->IsCore()) {
+    for(auto & mod : mods) {
+        if(mod->IsActive() && !mod->IsCore()) {
             if(active_mods) {
                 modlist << ", ";
             }
             active_mods = true;
 
-            if(mods[i]->SupportsOnline()) {
-                modlist << mods[i]->id;
+            if(mod->SupportsOnline()) {
+                modlist << mod->id;
             } else {
-                modlist << "[" << mods[i]->id << "]";
+                modlist << "[" << mod->id << "]";
             }
         }
     }
@@ -101,13 +101,13 @@ std::string OnlineUtility::GetActiveIncompatibleModsString() {
     bool active_mods = false;
     stringstream modlist;
     vector<ModInstance*> mods = ModLoading::Instance().GetAllMods();
-    for(size_t i = 0; i < mods.size(); i++) {
-        if(mods[i]->IsActive() && !mods[i]->IsCore() && !mods[i]->SupportsOnline()) {
+    for(auto & mod : mods) {
+        if(mod->IsActive() && !mod->IsCore() && !mod->SupportsOnline()) {
             if(active_mods) {
                 modlist << ", ";
             }
             active_mods = true;
-            modlist << "\"" << mods[i]->id << "\"";
+            modlist << "\"" << mod->id << "\"";
         }
     }
 

--- a/Source/Physics/bulletobject.cpp
+++ b/Source/Physics/bulletobject.cpp
@@ -524,8 +524,8 @@ void BulletObject::CheckForNAN() {
     btTransform bt_transform;
     GetDisplayTransform(&bt_transform);
     mat4 test_mat = SafeGetOpenGLMatrix(body->getWorldTransform());
-    for(float entrie : test_mat.entries){
-        if(entrie != entrie){
+    for(float entry : test_mat.entries){
+        if(entry != entry){
             LOGE << "NAN found in BulletObject" << std::endl;
             break;
         }

--- a/Source/Physics/bulletobject.cpp
+++ b/Source/Physics/bulletobject.cpp
@@ -524,8 +524,8 @@ void BulletObject::CheckForNAN() {
     btTransform bt_transform;
     GetDisplayTransform(&bt_transform);
     mat4 test_mat = SafeGetOpenGLMatrix(body->getWorldTransform());
-    for(unsigned i=0; i<16; ++i){
-        if(test_mat.entries[i] != test_mat.entries[i]){
+    for(float entrie : test_mat.entries){
+        if(entrie != entrie){
             LOGE << "NAN found in BulletObject" << std::endl;
             break;
         }

--- a/Source/Physics/bulletworld.cpp
+++ b/Source/Physics/bulletworld.cpp
@@ -187,20 +187,18 @@ void BulletWorld::Dispose() {
     delete broadphase_interface_; broadphase_interface_ = NULL;
     delete collision_dispatcher_; collision_dispatcher_ = NULL;
     delete collision_configuration_; collision_configuration_ = NULL;
-    for (BulletObjectList::iterator it = dynamic_objects_.begin(); it != dynamic_objects_.end(); ++it) {
-        BulletObject* object = (*it);
+    for (auto object : dynamic_objects_) {
         object->Dispose();
         delete object;
     }
     dynamic_objects_.clear();
-    for (BulletObjectList::iterator it = static_objects_.begin(); it != static_objects_.end(); ++it) {
-        BulletObject* object = (*it);
+    for (auto object : static_objects_) {
         object->Dispose();
         delete object;
     }
     static_objects_.clear();
-    for(HullShapeCacheMap::iterator it = hull_shape_cache_.begin(); it != hull_shape_cache_.end(); ++it){
-        delete it->second;
+    for(auto & it : hull_shape_cache_){
+        delete it.second;
     }
     hull_shape_cache_.clear();
 }
@@ -1553,10 +1551,10 @@ void BulletWorld::UpdateBulletObjectTransforms()
 
 void BulletWorld::RemoveTempConstraints()
 {
-    for(size_t i=0; i<temp_constraints_.size(); i++){
-        if(temp_constraints_[i].second){
-            dynamics_world_->removeConstraint(temp_constraints_[i].second);
-            delete temp_constraints_[i].second;
+    for(auto & temp_constraint : temp_constraints_){
+        if(temp_constraint.second){
+            dynamics_world_->removeConstraint(temp_constraint.second);
+            delete temp_constraint.second;
         }
     }
     temp_constraints_.clear();
@@ -1571,11 +1569,11 @@ void CenterAtCOMTri(Model &mesh){
     }
     vec3 avg_pos;
     int num_avg = 0;
-    for(unsigned i=0; i<vertex_faces.size(); ++i){
-        if(vertex_faces[i] == 1){
-            avg_pos += vec3(mesh.vertices[vertex_faces[i]*3+0],
-                            mesh.vertices[vertex_faces[i]*3+1],
-                            mesh.vertices[vertex_faces[i]*3+2]);
+    for(int vertex_face : vertex_faces){
+        if(vertex_face == 1){
+            avg_pos += vec3(mesh.vertices[vertex_face*3+0],
+                            mesh.vertices[vertex_face*3+1],
+                            mesh.vertices[vertex_face*3+2]);
             ++num_avg;
         }
     }
@@ -1703,8 +1701,8 @@ void GetSimplifiedHull(const std::vector<vec3> &input, std::vector<vec3> &output
 
 btConvexHullShape* CreateConvexHullShape(const std::vector<vec3> &verts) {
     btConvexHullShape* convex_hull_shape = new btConvexHullShape();
-    for (unsigned i=0 ; i<verts.size() ; ++i) {
-        convex_hull_shape->addPoint(btVector3(verts[i][0],verts[i][1],verts[i][2]));
+    for (const auto & vert : verts) {
+        convex_hull_shape->addPoint(btVector3(vert[0],vert[1],vert[2]));
     }
     convex_hull_shape->setMargin(0.00f);
     return convex_hull_shape;
@@ -1854,8 +1852,8 @@ void BulletWorld::CreateCustomHullShape( const std::string& key, const std::vect
         delete hsc_iter->second;
     }
     btConvexHullShape *shape = new btConvexHullShape();
-    for (int i=0, len=points.size(); i<len; ++i) {
-        shape->addPoint(btVector3(points[i][0], points[i][1], points[i][2]));
+    for (const auto & point : points) {
+        shape->addPoint(btVector3(point[0], point[1], point[2]));
     }
     shape->setMargin(0.00f);
     hull_shape_cache_[key] = shape;
@@ -2059,10 +2057,10 @@ void BulletWorld::CreateSpikeConstraint( BulletObject* obj, const vec3 &from, co
 }
 
 void BulletWorld::ClearBoneConstraints(){
-	for(size_t i=0; i<fixed_constraints_.size(); i++){
-        if( fixed_constraints_[i].second ) {
-            dynamics_world_->removeConstraint(fixed_constraints_[i].second);
-            delete fixed_constraints_[i].second;
+	for(auto & fixed_constraint : fixed_constraints_){
+        if( fixed_constraint.second ) {
+            dynamics_world_->removeConstraint(fixed_constraint.second);
+            delete fixed_constraint.second;
         }
     }
     fixed_constraints_.clear();
@@ -2076,9 +2074,9 @@ void BulletWorld::FinalizeStaticEntries() {
     // Create meta model of all models combined
     vert_indices.clear();
     vertices.clear();
-    for(int i=0, len=static_entries.size(); i<len; ++i){
-        Model& model = Models::Instance()->GetModel(static_entries[i].model_id);
-        mat4 &transform = static_entries[i].transform;
+    for(auto & static_entrie : static_entries){
+        Model& model = Models::Instance()->GetModel(static_entrie.model_id);
+        mat4 &transform = static_entrie.transform;
         //int start_vert_indices = vert_indices.size();
         int start_vertices = vertices.size()/3;
         for(int j=0, len=model.vertices.size(); j<len; j+=3){
@@ -2088,8 +2086,8 @@ void BulletWorld::FinalizeStaticEntries() {
             vertices.push_back(vec[1]);
             vertices.push_back(vec[2]);
         }
-        for(int j=0, len=model.faces.size(); j<len; ++j){
-            vert_indices.push_back(model.faces[j]+start_vertices);
+        for(unsigned int face : model.faces){
+            vert_indices.push_back(face+start_vertices);
         }
     }
     // Create physics object

--- a/Source/Scripting/angelscript/add_on/scripthelper/scripthelper.cpp
+++ b/Source/Scripting/angelscript/add_on/scripthelper/scripthelper.cpp
@@ -464,10 +464,9 @@ int WriteConfigToStream(asIScriptEngine *engine, ostream &strm)
 	// Write the members of the template types, so they can be fully registered before any other type uses them
 	// TODO: Order the template types based on dependency to avoid failure if one type uses instances of another 
 	strm << "\n// Template type members\n";
-	for( set<asITypeInfo*>::iterator it = templateTypes.begin(); it != templateTypes.end(); ++it )
+	for(auto type : templateTypes)
 	{
-		asITypeInfo *type = *it;
-		TypeWriter::Write(engine, strm, type, currNamespace, currAccessMask);
+			TypeWriter::Write(engine, strm, type, currNamespace, currAccessMask);
 	}
 
 	// Write the object types members

--- a/Source/Scripting/angelscript/ascontext.cpp
+++ b/Source/Scripting/angelscript/ascontext.cpp
@@ -806,8 +806,8 @@ bool ASContext::CallMPCallBack(uint32_t state, const std::vector<char>& data) {
 			asITypeInfo *arrayType = engine->GetTypeInfoById(engine->GetTypeIdByDecl("array<uint8>"));
 			CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
 			array->Reserve(data.size());
-			for (int i = 0, len = data.size(); i < len; ++i) {
-				array->InsertLast(const_cast<char*>(&data[i]));
+			for (const char & i : data) {
+				array->InsertLast(const_cast<char*>(&i));
 			}
 
 			args.AddAddress((void*)array);
@@ -836,8 +836,8 @@ bool ASContext::CallMPCallBack(uint32_t state, const std::vector<unsigned int>& 
 			asITypeInfo *arrayType = engine->GetTypeInfoById(engine->GetTypeIdByDecl("array<uint>"));
 			CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
 			array->Reserve(data.size());
-			for (int i = 0, len = data.size(); i < len; ++i) {
-				array->InsertLast((void*)&data[i]);
+			for (const unsigned int & i : data) {
+				array->InsertLast((void*)&i);
 			}
 
 			args.AddAddress((void*)array);

--- a/Source/Scripting/angelscript/ascrashdump.cpp
+++ b/Source/Scripting/angelscript/ascrashdump.cpp
@@ -45,14 +45,14 @@ static AngelScriptContext contexts[CONTEXT_COUNT];
 
 void RegisterAngelscriptContext( const char* name, ASContext* ascontext )
 {
-    for( int i = 0; i < CONTEXT_COUNT; i++ )
+    for(auto & context : contexts)
     {
-        if( contexts[i].allocated == false )
+        if( context.allocated == false )
         {
-            strncpy( contexts[i].name, name, 64 );
-            contexts[i].name[63] = '\0';
-            contexts[i].allocated = true;
-            contexts[i].context = ascontext;
+            strncpy( context.name, name, 64 );
+            context.name[63] = '\0';
+            context.allocated = true;
+            context.context = ascontext;
             return;
         }
     }    
@@ -60,11 +60,11 @@ void RegisterAngelscriptContext( const char* name, ASContext* ascontext )
 
 void DeregisterAngelscriptContext( ASContext* ascontext )
 {
-    for( int i = 0; i < CONTEXT_COUNT; i++ )
+    for(auto & context : contexts)
     {
-        if( contexts[i].context == ascontext )
+        if( context.context == ascontext )
         {
-            contexts[i].allocated = false;
+            context.allocated = false;
         }
     }
 }
@@ -79,13 +79,13 @@ void DumpAngelscriptStates()
 
     if( output.is_open() ) {
         LOGI << "Dumping angelscript states to: " << dump_path << std::endl;
-        for( int i = 0; i < CONTEXT_COUNT; i++ )
+        for(auto & context : contexts)
         {
-            if( contexts[i].allocated )
+            if( context.allocated )
             {
-                LOGI << "Dumping angelscript state for: " << contexts[i].name << std::endl;
+                LOGI << "Dumping angelscript state for: " << context.name << std::endl;
                 if( output.good() ) {
-                    contexts[i].context->DumpCallstack(output);
+                    context.context->DumpCallstack(output);
                 }
             }
         }

--- a/Source/Scripting/angelscript/asdebugger.cpp
+++ b/Source/Scripting/angelscript/asdebugger.cpp
@@ -50,8 +50,8 @@ ASDebugger::ASDebugger()
     , show_global_variables(false)
     , show_stack_trace(false)
 {
-    for(size_t i = 0; i < global_breakpoints.size(); ++i) {
-        ToggleBreakpoint(global_breakpoints[i].first.c_str(), global_breakpoints[i].second);
+    for(auto & global_breakpoint : global_breakpoints) {
+        ToggleBreakpoint(global_breakpoint.first.c_str(), global_breakpoint.second);
     }
 }
 
@@ -60,8 +60,8 @@ ASDebugger::~ASDebugger() {
 
 void ASDebugger::AddContext(ASContext* context) {
     bool add = true;
-    for(size_t i = 0; i < active_contexts.size(); ++i) {
-        if(active_contexts[i] == context) {
+    for(auto & active_context : active_contexts) {
+        if(active_context == context) {
             add = false;
             break;
         }
@@ -86,8 +86,8 @@ const std::vector<ASContext*>& ASDebugger::GetActiveContexts() {
 
 void ASDebugger::AddGlobalBreakpoint(const char* file, int line) {
     bool found = false;
-    for(size_t i = 0; i < global_breakpoints.size(); ++i) {
-        if(strcmp(global_breakpoints[i].first.c_str(), file) == 0 && global_breakpoints[i].second == line) {
+    for(auto & global_breakpoint : global_breakpoints) {
+        if(strcmp(global_breakpoint.first.c_str(), file) == 0 && global_breakpoint.second == line) {
             found = true;
             break;
         }
@@ -95,8 +95,8 @@ void ASDebugger::AddGlobalBreakpoint(const char* file, int line) {
 
     if(!found) {
         global_breakpoints.push_back(std::pair<std::string, int>(file, line));
-        for(size_t i = 0; i < active_contexts.size(); ++i) {
-            active_contexts[i]->dbg.AddBreakpoint(file, line);
+        for(auto & active_context : active_contexts) {
+            active_context->dbg.AddBreakpoint(file, line);
         }
     }
 }
@@ -105,8 +105,8 @@ void ASDebugger::RemoveGlobalBreakpoint(const char* file, int line) {
     for(size_t i = 0; i < global_breakpoints.size(); ++i) {
         if(strcmp(global_breakpoints[i].first.c_str(), file) == 0 && global_breakpoints[i].second == line) {
             global_breakpoints.erase(global_breakpoints.begin() + i);
-            for(size_t i = 0; i < active_contexts.size(); ++i) {
-                active_contexts[i]->dbg.RemoveBreakpoint(file, line);
+            for(auto & active_context : active_contexts) {
+                active_context->dbg.RemoveBreakpoint(file, line);
             }
             break;
         }
@@ -312,8 +312,8 @@ void ASDebugger::AddBreakpoint(const char* file_name, int line) {
     {
         std::vector<int>& lines = breakpoint_iter->second;
 
-        for(size_t i = 0; i < lines.size(); ++i) {
-            if(lines[i] == line) {
+        for(int i : lines) {
+            if(i == line) {
                 return;
             }
         }
@@ -379,8 +379,8 @@ void ASDebugger::LineCallback(asIScriptContext* ctx) {
     if(breakpoints == NULL)
         return;
     else {
-        for(size_t i = 0; i < breakpoints->size(); ++i) {
-            if(breakpoints->at(i) == current_line) {
+        for(int breakpoint : *breakpoints) {
+            if(breakpoint == current_line) {
                 paused = true;
                 auto_scroll = true;
                 ctx->Suspend();
@@ -443,8 +443,8 @@ void ASDebugger::Continue(asIScriptContext* ctx) {
         if(breakpoints == NULL)
             return;
         else {
-            for(size_t i = 0; i < breakpoints->size(); ++i) {
-                if(breakpoints->at(i) == (int)lf.line_number) {
+            for(int breakpoint : *breakpoints) {
+                if(breakpoint == (int)lf.line_number) {
                     current_file = lf.file;
                     current_line = lf.line_number;
                     ctx->Suspend();
@@ -726,8 +726,8 @@ ASDebugger::BreakAction ASDebugger::UpdateGUI() {
 
         bool is_breakpoint = false;
         if(breakpoints != NULL) {
-            for(size_t i = 0; i < breakpoints->size(); ++i) {
-                if(breakpoints->at(i) == line_nr) {
+            for(int breakpoint : *breakpoints) {
+                if(breakpoint == line_nr) {
                     is_breakpoint = true;
                     break;
                 }

--- a/Source/Scripting/angelscript/asfuncs.cpp
+++ b/Source/Scripting/angelscript/asfuncs.cpp
@@ -170,8 +170,8 @@ static CScriptArray* AS_GetPlayerStates() {
 
     array->Reserve(vals.size());
 
-    for(unsigned i = 0; i < vals.size(); i++) {
-        array->InsertLast((void*)&vals[i]);
+    for(auto & val : vals) {
+        array->InsertLast((void*)&val);
     }
 
     return array;
@@ -444,8 +444,8 @@ static CScriptArray* AS_GetRawKeyboardInputs() {
 
     array->Reserve(vals.size());
 
-    for( unsigned i = 0; i < vals.size(); i++ ) {
-        array->InsertLast((void*)&vals[i]);
+    for(auto & val : vals) {
+        array->InsertLast((void*)&val);
     }
 
     return array;
@@ -461,8 +461,8 @@ static CScriptArray* AS_GetRawMouseInputs() {
 
     array->Reserve(vals.size());
 
-    for( unsigned i = 0; i < vals.size(); i++ ) {
-        array->InsertLast((void*)&vals[i]);
+    for(auto & val : vals) {
+        array->InsertLast((void*)&val);
     }
 
     return array;
@@ -478,8 +478,8 @@ static CScriptArray* AS_GetRawJoystickInputs(int which) {
 
     array->Reserve(vals.size());
 
-    for( unsigned i = 0; i < vals.size(); i++ ) {
-        array->InsertLast((void*)&vals[i]);
+    for(auto & val : vals) {
+        array->InsertLast((void*)&val);
     }
 
     return array;
@@ -2452,10 +2452,8 @@ CScriptArray* ASGetSelected() {
     array->Reserve(the_scenegraph->objects_.size());
 
     const SceneGraph::object_list &objects = the_scenegraph->objects_;
-    for(SceneGraph::object_list::const_iterator iter = objects.begin();
-        iter != objects.end(); ++iter)
+    for(auto obj : objects)
     {
-        Object* obj = (*iter);
         if(obj->Selected()) {
             int val = obj->GetID();
             array->InsertLast(&val);
@@ -2545,10 +2543,8 @@ CScriptArray *ASGetObjectIDArrayType(int type) {
     array->Reserve(the_scenegraph->objects_.size());
 
     const SceneGraph::object_list &objects = the_scenegraph->objects_;
-    for(SceneGraph::object_list::const_iterator iter = objects.begin();
-        iter != objects.end(); ++iter)
+    for(auto obj : objects)
     {
-        Object* obj = (*iter);
         if(obj->GetType() == type){
             int val = obj->GetID();
             if(val != -1){
@@ -2567,10 +2563,9 @@ CScriptArray *ASGetObjectIDArray() {
     array->Reserve(the_scenegraph->objects_.size());
 
     const SceneGraph::object_list &objects = the_scenegraph->objects_;
-    for(SceneGraph::object_list::const_iterator iter = objects.begin();
-        iter != objects.end(); ++iter)
+    for(auto object : objects)
     {
-        int val = (*iter)->GetID();
+        int val = object->GetID();
         if(val != -1){
             array->InsertLast(&val);
         }
@@ -2593,8 +2588,8 @@ int ASCreateObject(const std::string& path, bool exclude_from_save) {
     std::string file_type;
     Path source;
     ActorsEditor_LoadEntitiesFromFile(path, desc_list, &file_type, &source);
-    for(unsigned i=0; i<desc_list.size(); ++i){
-        Object* obj = MapEditor::AddEntityFromDesc(the_scenegraph, desc_list[i], false);
+    for(auto & i : desc_list){
+        Object* obj = MapEditor::AddEntityFromDesc(the_scenegraph, i, false);
         if( obj ) {
             obj->exclude_from_undo = exclude_from_save;
             obj->exclude_from_save = exclude_from_save;
@@ -2690,8 +2685,7 @@ void AttachItem(Object* movement_object_base, Object* item_object_base, int type
     MovementObject* movement_object = (MovementObject*)movement_object_base;
     AttachmentSlotList attachment_slots;
     movement_object->rigged_object()->AvailableItemSlots(item_object->item_ref(), &attachment_slots);
-    for(AttachmentSlotList::iterator it = attachment_slots.begin(); it != attachment_slots.end(); ++it) {
-        AttachmentSlot& slot = (*it);
+    for(auto & slot : attachment_slots) {
         if(slot.mirrored == mirrored && slot.type == type){
             movement_object->AttachItemToSlotEditor(item_object->GetID(), slot.type, slot.mirrored, slot.attachment_ref);
             break;
@@ -2827,10 +2821,9 @@ CScriptArray* ASGetChildren(Object* obj) {
     CScriptArray *array = CScriptArray::Create(arrayType, (asUINT)0);
     array->Reserve(group->children.size());
 
-    for(std::vector<Group::Child>::const_iterator iter = group->children.begin();
-        iter != group->children.end(); ++iter)
+    for(const auto & iter : group->children)
     {
-        int val = (*iter).direct_ptr->GetID();
+        int val = iter.direct_ptr->GetID();
         if(val != -1){
             array->InsertLast(&val);
         }
@@ -3201,8 +3194,8 @@ void GetCharactersInSphere( vec3 origin, float radius, CScriptArray *array ) {
 }
 
 void GetCharacters( CScriptArray *array ) {
-    for(int i=0, len=the_scenegraph->movement_objects_.size(); i<len; ++i){
-        int val = the_scenegraph->movement_objects_[i]->GetID();
+    for(auto & movement_object : the_scenegraph->movement_objects_){
+        int val = movement_object->GetID();
         array->InsertLast(&val);
     }
 }
@@ -3276,9 +3269,9 @@ int ASFindFirstCharacterInGroup(int id) {
         Group* group = static_cast<Group*>(obj);
         std::vector<Object*> children;
         group->GetTopDownCompleteChildren(&children);
-        for( unsigned i = 0; i < children.size(); i++ ) {
-            if( children[i]->GetType() == _movement_object ) {
-                return children[i]->GetID();
+        for(auto & i : children) {
+            if( i->GetType() == _movement_object ) {
+                return i->GetID();
             }
         }
     }
@@ -6143,10 +6136,9 @@ static CScriptArray* JSONValueGetMembers(Json::Value *self) {
 
     array->Reserve(members.size());
 
-    for(std::vector<std::string>::const_iterator iter = members.begin();
-        iter != members.end(); ++iter)
+    for(const auto & member : members)
     {
-        array->InsertLast((void*)(&(*iter)));
+        array->InsertLast((void*)(&member));
     }
     return array;
 }
@@ -6447,8 +6439,8 @@ static CScriptArray* AS_GetPossibleResolutions() {
 
     array->Reserve(resolutions.size());
 
-    for( unsigned i = 0; i < resolutions.size(); i++ ) {
-        vec2 cur_res = vec2(resolutions[i].w, resolutions[i].h);
+    for(auto & resolution : resolutions) {
+        vec2 cur_res = vec2(resolution.w, resolution.h);
         array->InsertLast((void*)&(cur_res));
     }
     return array;
@@ -6684,9 +6676,9 @@ static ModInstance::Parameter& ASParameterOpAssign( ModInstance::Parameter* self
 
 static ModInstance::Parameter ParameterConstStringIndex(ModInstance::Parameter *self, const std::string &key) {
     if(strmtch(self->type,"table")) {
-        for(uint32_t i = 0; i < self->parameters.size(); i++) {
-            if(strmtch(self->parameters[i].name,key.c_str())) {
-                return self->parameters[i];
+        for(auto & parameter : self->parameters) {
+            if(strmtch(parameter.name,key.c_str())) {
+                return parameter;
             }
         }
     }
@@ -6729,8 +6721,8 @@ static std::string ASParameterGetName(ModInstance::Parameter *self) {
 }
 
 static bool ASParameterContains(ModInstance::Parameter *self, const std::string& val) {
-    for(uint32_t i = 0; i < self->parameters.size(); i++ ) {
-        if(strmtch(self->parameters[i].value, val.c_str())) {
+    for(auto & parameter : self->parameters) {
+        if(strmtch(parameter.value, val.c_str())) {
             return true;
         }
     }
@@ -6738,8 +6730,8 @@ static bool ASParameterContains(ModInstance::Parameter *self, const std::string&
 }
 
 static bool ASParameterContainsName(ModInstance::Parameter *self, const std::string& val) {
-    for(uint32_t i = 0; i < self->parameters.size(); i++ ) {
-        if(strmtch(self->parameters[i].name, val.c_str())) {
+    for(auto & parameter : self->parameters) {
+        if(strmtch(parameter.name, val.c_str())) {
             return true;
         }
     }
@@ -7024,8 +7016,8 @@ static CScriptArray* ASGetModSids() {
 
     array->Reserve(sids.size());
 
-    for( unsigned i = 0; i < sids.size(); i++ ) {
-        array->InsertLast((void*)&(sids[i]));
+    for(auto & sid : sids) {
+        array->InsertLast((void*)&sid);
     }
     return array;
 }
@@ -7040,9 +7032,9 @@ static CScriptArray* ASGetActiveModSids() {
 
     array->Reserve(sids.size());
 
-    for( unsigned i = 0; i < sids.size(); i++ ) {
-        if( ModLoading::Instance().IsActive(sids[i]) ) {
-            array->InsertLast((void*)&(sids[i]));
+    for(auto & sid : sids) {
+        if( ModLoading::Instance().IsActive(sid) ) {
+            array->InsertLast((void*)&sid);
         }
     }
     return array;
@@ -7061,8 +7053,8 @@ static CScriptArray* ASModGetMenuItems(ModID& sid) {
 
         array->Reserve(mmi.size());
 
-        for( unsigned i = 0; i < mmi.size(); i++ ) {
-            array->InsertLast((void*)&(mmi[i]));
+        for(auto & i : mmi) {
+            array->InsertLast((void*)&i);
         }
     }
     return array;
@@ -7081,8 +7073,8 @@ static CScriptArray* ASModGetSpawnerItems(ModID& sid) {
 
         array->Reserve(msi.size());
 
-        for(unsigned i = 0; i < msi.size(); i++) {
-            array->InsertLast((void*)&(msi[i]));
+        for(auto & i : msi) {
+            array->InsertLast((void*)&i);
         }
     }
 
@@ -7099,20 +7091,20 @@ static CScriptArray* ASModGetAllSpawnerItems(bool only_include_active) {
 
     unsigned item_count = 0;
 
-    for(unsigned i = 0; i < mods.size(); i++) {
-        if(!only_include_active || mods[i]->IsActive() ) {
-            item_count += mods[i]->items.size();
+    for(auto mod : mods) {
+        if(!only_include_active || mod->IsActive() ) {
+            item_count += mod->items.size();
         }
     }
 
     array->Reserve(item_count);
 
-    for(unsigned i = 0; i < mods.size(); i++) {
-        if(!only_include_active || mods[i]->IsActive() ) {
-            const std::vector<ModInstance::Item>& msi = mods[i]->items;
+    for(auto mod : mods) {
+        if(!only_include_active || mod->IsActive() ) {
+            const std::vector<ModInstance::Item>& msi = mod->items;
 
-            for(unsigned i = 0; i < msi.size(); i++) {
-                array->InsertLast((void*)&(msi[i]));
+            for(const auto & i : msi) {
+                array->InsertLast((void*)&i);
             }
         }
     }
@@ -7143,8 +7135,8 @@ static CScriptArray* ASModGetCampaigns( ModID& sid ) {
 
         array->Reserve(campaigns.size());
 
-        for(unsigned i = 0; i < campaigns.size(); i++) {
-            array->InsertLast((void*)&(campaigns[i]));
+        for(auto & campaign : campaigns) {
+            array->InsertLast((void*)&campaign);
         }
     }
     return array;
@@ -7164,8 +7156,8 @@ static CScriptArray* ASGetCampaigns() {
 
     array->Reserve(campaigns.size());
 
-    for( unsigned i = 0; i < campaigns.size(); i++ ) {
-        array->InsertLast((void*)&(campaigns[i]));
+    for(auto & campaign : campaigns) {
+        array->InsertLast((void*)&campaign);
     }
 
     return array;
@@ -7293,9 +7285,9 @@ static std::string ASCampaignGetMenuScript( void *m ) {
 
 static std::string ASCampaignGetAttribute( void *m, std::string& id ) {
     std::vector<ModInstance::Attribute>& attributes = ((ModInstance::Campaign*)m)->attributes;
-    for( unsigned int i = 0; i < attributes.size(); i++ ) {
-        if( strmtch( attributes[i].id, id.c_str()) ){
-            return attributes[i].value.str();
+    for(auto & attribute : attributes) {
+        if( strmtch( attribute.id, id.c_str()) ){
+            return attribute.value.str();
         }
     }
     return "";
@@ -7311,17 +7303,17 @@ static CScriptArray* ASCampaignGetLevels(void *m) {
 
     array->Reserve(mmi.size());
 
-    for( unsigned i = 0; i < mmi.size(); i++ ) {
-        array->InsertLast((void*)&(mmi[i]));
+    for(auto & i : mmi) {
+        array->InsertLast((void*)&i);
     }
 
     return array;
 }
 
 static ModInstance::Level ASCampaignGetLevel(ModInstance::Campaign *m, const std::string& id) {
-    for( unsigned i = 0; i < m->levels.size(); i++ ) {
-        if( strmtch(id, m->levels[i].id) ) {
-            return m->levels[i];
+    for(auto & level : m->levels) {
+        if( strmtch(id, level.id) ) {
+            return level;
         }
     }
     return ModInstance::Level();
@@ -7340,8 +7332,8 @@ static CScriptArray* ASModGetModCampaignLevels(ModID& sid) {
 
         array->Reserve(mmi.size());
 
-        for( unsigned i = 0; i < mmi.size(); i++ ) {
-            array->InsertLast((void*)&(mmi[i]));
+        for(auto & i : mmi) {
+            array->InsertLast((void*)&i);
         }
     }
     return array;
@@ -7360,8 +7352,8 @@ static CScriptArray* ASModGetModSingleLevels(ModID& sid) {
 
         array->Reserve(mmi.size());
 
-        for( unsigned i = 0; i < mmi.size(); i++ ) {
-            array->InsertLast((void*)&(mmi[i]));
+        for(auto & i : mmi) {
+            array->InsertLast((void*)&i);
         }
     }
     return array;
@@ -7450,8 +7442,8 @@ static void ASOpenWorkshop() {
 
 static void ASDeactivateAllMods() {
     std::vector<ModInstance*> mods = ModLoading::Instance().GetAllMods();
-    for( unsigned i = 0; i < mods.size(); i++ ) {
-        mods[i]->Activate(false);
+    for(auto & mod : mods) {
+        mod->Activate(false);
     }
 }
 

--- a/Source/Scripting/angelscript/asprofiler.cpp
+++ b/Source/Scripting/angelscript/asprofiler.cpp
@@ -39,17 +39,17 @@ ASProfiler::ASProfiler()
 {}
 
 ASProfiler::~ASProfiler() {
-    for(size_t i = 0; i < zone_times.size(); ++i)
-        DeleteZone(zone_times[i]);
+    for(auto & zone_time : zone_times)
+        DeleteZone(zone_time);
 }
 
 void ASProfiler::Update() {
     if(window_counter == kMaxWindowSize) {
-        for(size_t i = 0; i < zone_times.size(); ++i) { 
-            MoveForward(zone_times[i]);
+        for(auto & zone_time : zone_times) { 
+            MoveForward(zone_time);
         }
-        for(size_t i = 0; i < script_function_times.size(); ++i) { 
-            MoveForward(&script_function_times[i]);
+        for(auto & script_function_time : script_function_times) { 
+            MoveForward(&script_function_time);
         }
         window_counter = 0;
     } else {
@@ -70,20 +70,20 @@ void ASProfiler::Draw() {
     }
 
     uint64_t zone_time = 0;
-    for(size_t i = 0; i < zone_times.size(); ++i) { 
-        zone_time += zone_times[i]->times.back();
+    for(auto & i : zone_times) { 
+        zone_time += i->times.back();
     }
 
     sprintf(buffer, "%s: %f###%p", context->current_script.GetOriginalPath(), zone_time * 0.001f, (void*)context);
     if(ImGui::TreeNode(buffer)) {
-        for(size_t i = 0; i < script_function_times.size(); ++i) {
-            ZoneTime* zone = &script_function_times[i];
+        for(auto & script_function_time : script_function_times) {
+            ZoneTime* zone = &script_function_time;
             ImGui::Text("%s", zone->name.c_str());
             ImGui::PlotHistogram("", &TimeGetter, zone->times.data(), kTimeHistorySize, 0, NULL, 0.0f, 5000.0f, ImVec2(0,40));
         }
             
-        for(size_t i = 0; i < zone_times.size(); ++i) {
-            DrawZone(zone_times[i]);
+        for(auto & zone_time : zone_times) {
+            DrawZone(zone_time);
         }
         ImGui::TreePop();
     }
@@ -91,8 +91,8 @@ void ASProfiler::Draw() {
 
 void ASProfiler::AddContext(ASContext* context) {
     bool add = true;
-    for(size_t i = 0; i < active_contexts.size(); ++i) {
-        if(active_contexts[i] == context) {
+    for(auto & active_context : active_contexts) {
+        if(active_context == context) {
             add = false;
             break;
         }
@@ -125,9 +125,9 @@ void ASProfiler::ASEnterTelemetryZone( const std::string& str ) {
 
     bool found = false;
     if(active_zone == NULL) {
-        for(size_t i = 0; i < zone_times.size(); ++i) {
-            if(zone_times[i]->name == str) {
-                active_zone = zone_times[i];
+        for(auto & zone_time : zone_times) {
+            if(zone_time->name == str) {
+                active_zone = zone_time;
                 found = true;
                 break;
             }
@@ -143,9 +143,9 @@ void ASProfiler::ASEnterTelemetryZone( const std::string& str ) {
             active_zone = zone_times.back();
         }
     } else {
-        for(size_t i = 0; i < active_zone->children.size(); ++i) {
-            if(active_zone->children[i]->name == str) {
-                active_zone = active_zone->children[i];
+        for(auto & i : active_zone->children) {
+            if(i->name == str) {
+                active_zone = i;
                 found = true;
                 break;
             }
@@ -190,9 +190,9 @@ void ASProfiler::CallScriptFunction(const char* str) {
         return;
 
     ZoneTime* zone = NULL;
-    for(size_t i = 0; i < script_function_times.size(); ++i) {
-        if(strcmp(script_function_times[i].name.c_str(), str) == 0) {
-            zone = &script_function_times[i];
+    for(auto & script_function_time : script_function_times) {
+        if(strcmp(script_function_time.name.c_str(), str) == 0) {
+            zone = &script_function_time;
             break;
         }
     }
@@ -225,8 +225,8 @@ void ASProfiler::LeaveScriptFunction() {
 }
 
 void ASProfiler::DeleteZone(ZoneTime* zone) {
-    for(size_t i = 0; i < zone->children.size(); ++i) {
-        DeleteZone(zone->children[i]);
+    for(auto & i : zone->children) {
+        DeleteZone(i);
     }
 
     delete zone;
@@ -236,8 +236,8 @@ void ASProfiler::MoveForward(ZoneTime* zone) {
     memmove(zone->times.data(), zone->times.data() + 1, sizeof(uint64_t) * (kTimeHistorySize - 1));
     zone->times[kTimeHistorySize - 1] = 0;
 
-    for(size_t i = 0; i < zone->children.size(); ++i) {
-        MoveForward(zone->children[i]);
+    for(auto & i : zone->children) {
+        MoveForward(i);
     }
 }
 
@@ -247,8 +247,8 @@ void ASProfiler::DrawZone(ZoneTime* zone) {
     sprintf(buffer, "%s: %f###%d", zone->name.c_str(), zone_time * 0.001f, zone->id);
     if(ImGui::TreeNode(buffer)) {
         ImGui::PlotHistogram("", &TimeGetter, zone->times.data(), kTimeHistorySize, 0, NULL, 0.0f, 5000.0f, ImVec2(0,40));
-        for(size_t i = 0; i < zone->children.size(); ++i) { 
-            DrawZone(zone->children[i]);
+        for(auto & i : zone->children) { 
+            DrawZone(i);
         }
         ImGui::TreePop();
     }

--- a/Source/Scripting/scriptfile.cpp
+++ b/Source/Scripting/scriptfile.cpp
@@ -46,9 +46,9 @@ const int _num_script_open_tries = 10;
 
 std::string ScriptFile::GetModPollutionInformation() const {
     std::stringstream ss;
-    for( unsigned i = 0; i < dependencies.size(); i++ ) {
-        if( dependencies[i].path.GetModsource() != CoreGameModID ) {
-            ss << "Includes " << dependencies[i].path << " from mod " << ModLoading::Instance().GetModName(dependencies[i].path.GetModsource()) << "." << std::endl;
+    for(const auto & dependencie : dependencies) {
+        if( dependencie.path.GetModsource() != CoreGameModID ) {
+            ss << "Includes " << dependencie.path << " from mod " << ModLoading::Instance().GetModName(dependencie.path.GetModsource()) << "." << std::endl;
         }
     }
     return ss.str();
@@ -68,8 +68,8 @@ static bool AlreadyAddedIncludeFileInParentHierarchy(const ScriptFile* parent_sc
 
 bool ScriptFile::AlreadyAddedIncludeFile(const Path &path) {
     bool already_loaded = false;
-    for(unsigned i=0; i<dependencies.size(); ++i){
-        if(path == dependencies[i].path){
+    for(auto & dependencie : dependencies){
+        if(path == dependencie.path){
             already_loaded = true;
             break;
         }
@@ -89,8 +89,8 @@ unsigned GetLineNumber(std::string &script, unsigned char_pos){
 
 unsigned GetNumLines(std::string &script){
     unsigned line_number = 1;
-    for(unsigned i=0; i<script.size(); i++){
-        if(script[i] == '\n'){
+    for(char i : script){
+        if(i == '\n'){
             line_number++;
         }
     }

--- a/Source/Scripting/scriptparams.cpp
+++ b/Source/Scripting/scriptparams.cpp
@@ -386,10 +386,10 @@ void ReadScriptParametersFromXML( ScriptParamMap &spm, const TiXmlElement* param
 
 void WriteScriptParamsToXML( const ScriptParamMap & pm, TiXmlElement* params )
 {
-    for(ScriptParamMap::const_iterator iter = pm.begin(); iter != pm.end(); ++iter){
+    for(const auto & iter : pm){
         TiXmlElement* param = new TiXmlElement("parameter");
-        param->SetAttribute("name",iter->first.c_str());
-        const ScriptParam &sp = iter->second;
+        param->SetAttribute("name",iter.first.c_str());
+        const ScriptParam &sp = iter.second;
         sp.WriteToXML(param);
         params->LinkEndChild(param);
     }

--- a/Source/Sound/al_audio.cpp
+++ b/Source/Sound/al_audio.cpp
@@ -1112,9 +1112,9 @@ void alAudio::streamerLink::update(float timestep, unsigned int current_tick)
 
     std::vector<rc_alAudioBuffer> buffers = m_source->DequeueBuffers();
 
-    for( unsigned i = 0; i < buffers.size(); i++ )
+    for(auto & buffer : buffers)
     {
-        m_streamer->update(buffers[i]);
+        m_streamer->update(buffer);
     }
 
     m_source->QueueBuffers(buffers);
@@ -1155,9 +1155,9 @@ void alAudio::streamerLink::stop()
 
     std::vector<rc_alAudioBuffer> buffers = m_source->DequeueBuffers();
 
-    for( unsigned i = 0; i < buffers.size(); i++ )
+    for(auto & buffer : buffers)
     {
-        m_streamer->update(buffers[i]);
+        m_streamer->update(buffer);
     }
 
     m_source->QueueBuffers(buffers);

--- a/Source/Sound/sound.cpp
+++ b/Source/Sound/sound.cpp
@@ -81,8 +81,7 @@ void Sound::Dispose() {
 }
 
 void Sound::Update() {
-    for(unsigned i=0; i<ambient_triangles.size(); ++i){
-        AmbientTriangle& a_t = ambient_triangles[i];
+    for(auto & a_t : ambient_triangles){
         for(unsigned j=0; j<3; ++j){
             a_t.vol[j] = min(1.0f, a_t.vol[j] + m_accum_game_timestep);
             SetVolume(a_t.handles[j], a_t.vol[j]);
@@ -127,8 +126,7 @@ void Sound::updateListener(vec3 pos, vec3 vel, vec3 facing, vec3 up) {
     //oss << "Ambient triangles: " << ambient_triangles.size();
     //GUI::Instance()->AddDebugText("ambient_triangles", oss.str(), 0.5f);
 
-    for(unsigned i=0; i<ambient_triangles.size(); ++i){
-        AmbientTriangle& a_t = ambient_triangles[i];
+    for(auto & a_t : ambient_triangles){
         for(unsigned j=0; j<3; ++j){
             //vec3 new_dir(dot(a_t.rel_dir[j], cross(facing, up)),
             //             dot(a_t.rel_dir[j], up),

--- a/Source/Sound/soundtrack.cpp
+++ b/Source/Sound/soundtrack.cpp
@@ -512,9 +512,9 @@ pcm_count(0),
 sample_rate(0),
 channels(0) {
     bool first_creation = true;
-    for( unsigned i = 0; i < song.songrefs.size(); i++ ) {
+    for(auto & songref : song.songrefs) {
         PlayedSongInterface *ps = NULL;
-        MusicXMLParser::Song ns = owner->GetSong(song.songrefs[i].name);
+        MusicXMLParser::Song ns = owner->GetSong(songref.name);
     
         LOGI << "Creating a PlayedLayeredSong layer: " << ns.name << std::endl;
         
@@ -645,16 +645,16 @@ void Soundtrack::PlayedLayeredSong::update( HighResBufferSegment* buffer ) {
 
 bool Soundtrack::PlayedLayeredSong::IsAtEnd() {
     bool is_at_end = true;
-    for( unsigned  i = 0; i < subsongs.size(); i++ ) {
-        is_at_end = is_at_end && subsongs[i]->IsAtEnd();
+    for(auto & subsong : subsongs) {
+        is_at_end = is_at_end && subsong->IsAtEnd();
     }
     return is_at_end;
 }
 
 void Soundtrack::PlayedLayeredSong::Rewind() {
     pcm_pos = 0;
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        subsongs[i]->Rewind(); 
+    for(auto & subsong : subsongs) {
+        subsong->Rewind(); 
     } 
 }
 
@@ -664,18 +664,18 @@ int64_t  Soundtrack::PlayedLayeredSong::GetPCMPos() {
 
 void Soundtrack::PlayedLayeredSong::SetPCMPos( int64_t pos ) { 
     pcm_pos = pos;
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        if( pos < subsongs[i]->GetPCMCount() ) {
-            subsongs[i]->SetPCMPos(pos);
+    for(auto & subsong : subsongs) {
+        if( pos < subsong->GetPCMCount() ) {
+            subsong->SetPCMPos(pos);
         }
     }
 }
 
 int64_t Soundtrack::PlayedLayeredSong::GetPCMCount() {
     int64_t max = 0;
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        if( max < subsongs[i]->GetPCMCount() ) {
-            max = subsongs[i]->GetPCMCount();
+    for(auto & subsong : subsongs) {
+        if( max < subsong->GetPCMCount() ) {
+            max = subsong->GetPCMCount();
         }
     }
     return max;
@@ -697,9 +697,9 @@ bool Soundtrack::PlayedLayeredSong::SetLayerGain( const std::string& name, float
         gain = 0.0f;
     }
 
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        if( subsongs[i]->GetSongName() == name ) {
-            subsongs[i]->SetGain(gain);
+    for(auto & subsong : subsongs) {
+        if( subsong->GetSongName() == name ) {
+            subsong->SetGain(gain);
             return true;
         }
     }
@@ -707,9 +707,9 @@ bool Soundtrack::PlayedLayeredSong::SetLayerGain( const std::string& name, float
 }
 
 float Soundtrack::PlayedLayeredSong::GetLayerGain( const std::string& name ) {
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        if( subsongs[i]->GetSongName() == name ) {
-            return subsongs[i]->GetGain();
+    for(auto & subsong : subsongs) {
+        if( subsong->GetSongName() == name ) {
+            return subsong->GetGain();
         }
     }
     return 0.0f;
@@ -717,16 +717,16 @@ float Soundtrack::PlayedLayeredSong::GetLayerGain( const std::string& name ) {
 
 const std::map<std::string,float> Soundtrack::PlayedLayeredSong::GetLayerGains() {
     std::map<std::string,float> gains;
-    for( unsigned i = 0; i < subsongs.size(); i++ ) {
-        gains[subsongs[i]->GetSongName()] = subsongs[i]->GetGain();
+    for(auto & subsong : subsongs) {
+        gains[subsong->GetSongName()] = subsong->GetGain();
     }
     return gains;
 }
 
 std::vector<std::string> Soundtrack::PlayedLayeredSong::GetLayerNames() const {
     std::vector<std::string> layers;
-    for( unsigned i = 0; i < song.songrefs.size(); i++ ) {
-        layers.push_back(song.songrefs[i].name);
+    for(const auto & songref : song.songrefs) {
+        layers.push_back(songref.name);
     }
     return layers;
 }
@@ -1348,12 +1348,12 @@ void Soundtrack::AddMusic( const Path &path )
             std::map<std::string,MusicXMLParser::Music>::iterator musit;
             for(musit = music.begin(); musit != music.end(); ++musit) {
                 bool replace = false;
-                for(size_t new_i = 0; new_i < parser.music.songs.size(); ++new_i) {
+                for(auto & song : parser.music.songs) {
                     for(size_t old_i = 0; old_i < musit->second.songs.size(); ++old_i) {
-                        if(strmtch(parser.music.songs[new_i].name, musit->second.songs[old_i].name)) {
-                            LOGW << "Track " << parser.music.songs[new_i].name << " already found in " << musit->first << ", old music set will be overwritten" << std::endl;
+                        if(strmtch(song.name, musit->second.songs[old_i].name)) {
+                            LOGW << "Track " << song.name << " already found in " << musit->first << ", old music set will be overwritten" << std::endl;
                             replace = true;
-                            if(transitionPlayer.GetSongName() == std::string(parser.music.songs[new_i].name))
+                            if(transitionPlayer.GetSongName() == std::string(song.name))
                                 Stop();
                             break;
                         }

--- a/Source/Sound/threaded_sound_wrapper.cpp
+++ b/Source/Sound/threaded_sound_wrapper.cpp
@@ -698,11 +698,11 @@ static void ThreadedSoundLoop()
 
             std::vector<AudioEmitter*> emitters = sound->GetActiveSounds();
 
-            for( uint32_t i = 0; i < emitters.size(); i++ ) {
+            for(auto & emitter : emitters) {
                 SoundSourceInfo ss;
 
-                strscpy(ss.name, emitters[i]->display_name.c_str(), sizeof(ss.name));
-                ss.pos = emitters[i]->GetPosition();
+                strscpy(ss.name, emitter->display_name.c_str(), sizeof(ss.name));
+                ss.pos = emitter->GetPosition();
 
                 sdc.sound_source.push_back(ss);
             }

--- a/Source/UnitTests/block_allocator_tester.cpp
+++ b/Source/UnitTests/block_allocator_tester.cpp
@@ -61,11 +61,11 @@ namespace tut
 
         uint64_t* ptrs[block_count];
 
-        for(uint32_t i = 0; i < block_count; i++ )
+        for(auto & ptr : ptrs)
         {
-            ptrs[i] = (uint64_t*)ba.Alloc(blocksize);
+            ptr = (uint64_t*)ba.Alloc(blocksize);
         
-            ensure( "NULL Return", ptrs[i] != NULL );
+            ensure( "NULL Return", ptr != NULL );
         }
         free(mem);
     }

--- a/Source/UserInput/keyTranslator.cpp
+++ b/Source/UserInput/keyTranslator.cpp
@@ -565,20 +565,20 @@ void InitKeyTranslator() {
     std::vector<std::pair<int,uint32_t> > offsets;
 
     size_t cur_index = 0;
-    for( size_t i = 0; i < sizeof(SDL_SCANCODES)/sizeof(uint32_t); i++ ) {
-        const char* scancodename = SDL_GetScancodeName((SDL_Scancode)SDL_SCANCODES[i]);  
+    for(unsigned int & i : SDL_SCANCODES) {
+        const char* scancodename = SDL_GetScancodeName((SDL_Scancode)i);  
         size_t memlen = strlen(scancodename) + 1;
         if(cur_index + memlen > key_translation_memory.size()) {
             key_translation_memory.resize(key_translation_memory.size()+1024);
         }
         memcpy(&key_translation_memory[cur_index], scancodename, memlen);
         UTF8InPlaceLower(&key_translation_memory[cur_index]);
-        offsets.push_back(std::pair<int,uint32_t>(cur_index,SDL_SCANCODES[i]));
+        offsets.push_back(std::pair<int,uint32_t>(cur_index,i));
         cur_index += memlen;
     }
 
-    for( size_t i = 0; i < offsets.size(); i++ ) {
-        keys.push_back(KeyPair(&key_translation_memory[offsets[i].first], (SDL_Scancode)offsets[i].second));
+    for(auto & offset : offsets) {
+        keys.push_back(KeyPair(&key_translation_memory[offset.first], (SDL_Scancode)offset.second));
     }
 
     keys.push_back(KeyPair("backspace", SDL_SCANCODE_BACKSPACE));

--- a/Source/UserInput/keyboard.cpp
+++ b/Source/UserInput/keyboard.cpp
@@ -403,8 +403,8 @@ bool Keyboard::wasScancodePressed(SDL_Scancode the_key, const uint32_t kimf) con
 }
 
 void Keyboard::clearKeyPresses() {
-    for (KeyStatusMap::iterator iter = keys.begin(); iter != keys.end(); ++iter){
-        KeyStatus &key = iter->second;
+    for (auto & iter : keys){
+        KeyStatus &key = iter.second;
         key.pressed=0;
     }
 }

--- a/Source/UserInput/keycommands.cpp
+++ b/Source/UserInput/keycommands.cpp
@@ -345,8 +345,8 @@ void KeyCommand::Initialize() {
             FatalError("Error", "Hash collision in KeyCommand hash map");
         }
     }
-    for(int i=0; i<kNumLabels; ++i){
-        commands[i].num_key_events = 0;
+    for(auto & command : commands){
+        command.num_key_events = 0;
     }
 }
 
@@ -354,8 +354,8 @@ void KeyCommand::HandleKeyDownEvent( const Keyboard &keyboard,  SDL_Keysym key_i
     // Check for key_pressed events from longest command to shortest
     int cmd_length = -1;
     SDL_Scancode sc = key_id.scancode;
-    for(int i=0; i<kNumLabels; ++i){
-        Command &cmd = *(commands_sorted_by_length[i]);
+    for(auto & i : commands_sorted_by_length){
+        Command &cmd = *i;
         if(cmd.num_key_events < cmd_length) {
             return;
         }
@@ -400,7 +400,7 @@ void KeyCommand::HandleKeyDownEvent( const Keyboard &keyboard,  SDL_Keysym key_i
 }
 
 void KeyCommand::ClearKeyPresses() {
-    for(int i=0; i<kNumLabels; ++i){
-        commands[i].state = kUp;
+    for(auto & command : commands){
+        command.state = kUp;
     }
 }

--- a/Source/UserInput/mouse.cpp
+++ b/Source/UserInput/mouse.cpp
@@ -51,8 +51,8 @@ Mouse::Mouse()
 void Mouse::Update() {
     wheel_delta_x_ = 0;
     wheel_delta_y_ = 0;
-    for(int i=0; i<2; ++i){
-        delta_[i] = 0;
+    for(int & i : delta_){
+        i = 0;
     }
     for (int i = 0; i < NUM_BUTTONS; ++i)     {
         mouse_double_click_[i] = false;

--- a/Source/Utility/binn_util.cpp
+++ b/Source/Utility/binn_util.cpp
@@ -69,8 +69,8 @@ void binn_object_set_std_string(binn* l, const char* key, const string& v) {
 void binn_object_set_vector_int(binn* l, const char* key, const vector<int>& arr) {
      binn* l_vec_int = binn_list();
 
-     for(int i = 0; i < arr.size(); i++) {
-         binn_list_add_int32(l_vec_int, arr[i]);
+     for(int i : arr) {
+         binn_list_add_int32(l_vec_int, i);
      }
 
      binn_object_set_list(l, key, l_vec_int);

--- a/Source/Utility/strings.cpp
+++ b/Source/Utility/strings.cpp
@@ -229,11 +229,9 @@ bool hasEnding (string const &fullString, string const &ending) {
 
 bool hasAnyOfEndings( const string &fullString, const vector<string> &endings)
 {
-    for( vector<string>::const_iterator sit = endings.begin();
-         sit != endings.end();
-         sit++ )
+    for(const auto & ending : endings)
     {
-        if( hasEnding( fullString, *sit ) )
+        if( hasEnding( fullString, ending ) )
         {
             return true;
         }

--- a/Source/XML/Parsers/activemodsparser.cpp
+++ b/Source/XML/Parsers/activemodsparser.cpp
@@ -109,12 +109,12 @@ uint32_t ActiveModsParser::Load( const std::string& path ) {
 bool ActiveModsParser::SerializeInto( TiXmlDocument* doc ) {
     TiXmlDeclaration * decl = new TiXmlDeclaration( "2.0", "", "" );
     TiXmlElement * root = new TiXmlElement("ActiveMods");
-    for( unsigned i = 0; i < mod_instances.size(); i++ ) {
+    for(auto & mod_instance : mod_instances) {
         TiXmlElement * mi = new TiXmlElement("ModInstance");
-        mi->SetAttribute( "id", mod_instances[i].id );
-        mi->SetAttribute( "activated", mod_instances[i].activated ? "true" : "false" );
+        mi->SetAttribute( "id", mod_instance.id );
+        mi->SetAttribute( "activated", mod_instance.activated ? "true" : "false" );
         const char* modsource = "";
-        switch(mod_instances[i].modsource) {
+        switch(mod_instance.modsource) {
             case ModSourceLocalModFolder:
                 modsource = "local";
                 break;
@@ -127,7 +127,7 @@ bool ActiveModsParser::SerializeInto( TiXmlDocument* doc ) {
                 break;
         }
         mi->SetAttribute("modsource", modsource); 
-        mi->SetAttribute("version", mod_instances[i].version);
+        mi->SetAttribute("version", mod_instance.version);
         root->LinkEndChild(mi);
     }
     doc->LinkEndChild(decl);
@@ -174,8 +174,8 @@ void ActiveModsParser::SetModInstanceActive(const char* id, ModSource modsource,
 }
 
 bool ActiveModsParser::HasModInstance(const char* id, ModSource modsource) {
-    for( unsigned i = 0; i < mod_instances.size(); i++ ) {
-        if(strmtch(mod_instances[i].id,id) && mod_instances[i].modsource == modsource) {
+    for(auto & mod_instance : mod_instances) {
+        if(strmtch(mod_instance.id,id) && mod_instance.modsource == modsource) {
             return true;
         }
     }
@@ -183,9 +183,9 @@ bool ActiveModsParser::HasModInstance(const char* id, ModSource modsource) {
 }
 
 ActiveModsParser::ModInstance ActiveModsParser::GetModInstance(const char* id, ModSource modsource) {
-    for( unsigned i = 0; i < mod_instances.size(); i++ ) {
-        if(strmtch(mod_instances[i].id,id) && mod_instances[i].modsource == modsource) {
-            return mod_instances[i];
+    for(auto & mod_instance : mod_instances) {
+        if(strmtch(mod_instance.id,id) && mod_instance.modsource == modsource) {
+            return mod_instance;
         }
     }
     return ModInstance(id,modsource,false,"");

--- a/Source/XML/Parsers/assetloadwarningparser.cpp
+++ b/Source/XML/Parsers/assetloadwarningparser.cpp
@@ -60,12 +60,12 @@ bool AssetLoadWarningParser::Save( const std::string& path ) {
     TiXmlDeclaration * decl = new TiXmlDeclaration( "2.0", "", "" );
     TiXmlElement * root = new TiXmlElement("AssetWarnings");
 
-    for( std::set<AssetWarning>::iterator sit = asset_warnings.begin(); sit != asset_warnings.end(); sit++ ) {
+    for(const auto & asset_warning : asset_warnings) {
         TiXmlElement * e = new TiXmlElement("AssetWarning");
-        e->SetAttribute("asset_type",sit->asset_type.c_str());
-        e->SetAttribute("path",sit->path.c_str());
-        e->SetAttribute("level_name",sit->level_name.c_str());
-        char flags[9]; flags_to_string(flags,sit->load_flags); e->SetAttribute("load_flags",flags);
+        e->SetAttribute("asset_type",asset_warning.asset_type.c_str());
+        e->SetAttribute("path",asset_warning.path.c_str());
+        e->SetAttribute("level_name",asset_warning.level_name.c_str());
+        char flags[9]; flags_to_string(flags,asset_warning.load_flags); e->SetAttribute("load_flags",flags);
         root->LinkEndChild(e);
     }
 

--- a/Source/XML/level_loader.cpp
+++ b/Source/XML/level_loader.cpp
@@ -107,8 +107,7 @@ void AddCamera(SceneGraph &s) {
 
 static void LoadAll(const PathSet &path_set, ThreadedSound* sound) {
     std::list<std::string> skeleton_paths;
-    for(PathSet::const_iterator iter = path_set.begin(); iter != path_set.end(); ++iter) {
-        const std::string &entry = (*iter);
+    for(const auto & entry : path_set) {
         int space_pos = entry.find(' ');
         const std::string &type = entry.substr(0,space_pos);
         const std::string &path = entry.substr(space_pos+1, entry.size()-(space_pos+1));
@@ -248,13 +247,11 @@ static int IDAndType_CompareID(const void *a, const void *b) {
 static void ExtractFlatList(EntityDescriptionList *desc_list, std::vector<IDAndType> &id_used){
     uint32_t counter = 1; //Zero is assigned to the terrain
 	//bool print_results = false;
-	for(EntityDescriptionList::iterator it = desc_list->begin();
-		it != desc_list->end(); 
-		++it)
+	for(auto & it : *desc_list)
 	{
 		id_used.resize(id_used.size()+1);
 		IDAndType *id_and_type = &id_used.back();
-		id_and_type->desc = &(*it);
+		id_and_type->desc = &it;
 		id_and_type->desc->GetEditableField(EDF_ENTITY_TYPE)->ReadInt((int*)&id_and_type->type);
 		id_and_type->desc->GetEditableField(EDF_ID)->ReadInt(&id_and_type->id);
         id_and_type->counter = counter++;
@@ -428,16 +425,16 @@ bool LevelLoader::LoadLevel(const Path& level_path, SceneGraph& s) {
 
         static const int kBufSize = 256;
         char buf[kBufSize];
-        for(unsigned i=0, len=li.desc_list_.size(); i<len; ++i){
+        for(auto & i : li.desc_list_){
             buf[0] = '\0';
-            const EntityDescriptionField* path_field = li.desc_list_[i].GetField(EDF_FILE_PATH);
+            const EntityDescriptionField* path_field = i.GetField(EDF_FILE_PATH);
             if(path_field && !path_field->data.empty()){
                 FormatString(buf, kBufSize, "Adding object: %s", std::string(path_field->data.begin(), path_field->data.end()).c_str());
                 PROFILER_ENTER_DYNAMIC_STRING(g_profiler_ctx, buf);    
             } else {
                 PROFILER_ENTER(g_profiler_ctx, "Adding object: unknown");
             }
-            Object * obj = MapEditor::AddEntityFromDesc(&s, li.desc_list_[i], true);
+            Object * obj = MapEditor::AddEntityFromDesc(&s, i, true);
             if( obj == NULL ) {
                 LOGE << "Failed to construct object \"" << buf << "\" for level load" << std::endl;
             }
@@ -481,8 +478,8 @@ bool LevelLoader::LoadLevel(const Path& level_path, SceneGraph& s) {
     s.SendMessageToAllObjects(OBJECT_MSG::FINALIZE_LOADED_CONNECTIONS);
 
     AddLoadingText("Loading ambient sounds and music...");
-    for(unsigned i=0; i<li.ambient_sounds_.size(); ++i){
-        Engine::Instance()->GetSound()->AddAmbientTriangle(li.ambient_sounds_[i]);
+    for(auto & ambient_sound : li.ambient_sounds_){
+        Engine::Instance()->GetSound()->AddAmbientTriangle(ambient_sound);
     }
     AddLoadingText("Getting path set...");
     PathSet path_set;
@@ -555,8 +552,7 @@ void LevelLoader::SaveTerrain(TiXmlNode* root, SceneGraph* s) {
         terrain_el->LinkEndChild(terrain_sub_el);
 
         TiXmlElement *does = new TiXmlElement("DetailObjects");
-        for(unsigned i=0; i<ti.detail_object_info.size(); ++i){
-            const DetailObjectLayer &dol = ti.detail_object_info[i];
+        for(const auto & dol : ti.detail_object_info){
             TiXmlElement *doe = new TiXmlElement("DetailObject");
             doe->SetAttribute("obj_path", dol.obj_path.c_str());
             doe->SetAttribute("weight_path", dol.weight_path.c_str());
@@ -724,11 +720,11 @@ void LevelLoader::SaveLevel(SceneGraph &s, SaveLevelType type) {
 
         const std::vector<AmbientTriangle>& ambient_triangles =
             Engine::Instance()->GetSound()->GetAmbientTriangles();
-        for(unsigned i=0; i<ambient_triangles.size(); ++i){
+        for(const auto & ambient_triangle : ambient_triangles){
             TiXmlElement* ambient;
             ambient = new TiXmlElement("Ambient");
             ambient_sound_element->LinkEndChild(ambient);
-            ambient->SetAttribute("path", ambient_triangles[i].path.c_str());
+            ambient->SetAttribute("path", ambient_triangle.path.c_str());
         }
     }
 
@@ -771,8 +767,8 @@ void LevelLoader::SaveLevel(SceneGraph &s, SaveLevelType type) {
 
         std::vector<SpawnerItem> recent_items = s.level->GetRecentlyCreatedItems();
 
-        for( unsigned i = 0; i < recent_items.size(); i++ ) {
-            SpawnerItem* si = &recent_items[i]; 
+        for(auto & recent_item : recent_items) {
+            SpawnerItem* si = &recent_item; 
 
             TiXmlElement* element = new TiXmlElement("SpawnerItem");
             element->SetAttribute("display_name", si->display_name.c_str());


### PR DESCRIPTION
Again use [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/modernize-loop-convert.html) to replace old-style C++ loops with range-based for loops, making code much more readable & compact