### PR TITLE
Use override keyword where applicable

### DIFF
--- a/Source/AI/sample_interfaces.h
+++ b/Source/AI/sample_interfaces.h
@@ -56,12 +56,12 @@ public:
 protected:	
 	/// Virtual functions for custom implementations.
 	///@{
-	virtual void doResetLog();
-	virtual void doLog(const rcLogCategory category, const char* msg, const int len);
-	virtual void doResetTimers();
-	virtual void doStartTimer(const rcTimerLabel label);
-	virtual void doStopTimer(const rcTimerLabel label);
-	virtual int doGetAccumulatedTime(const rcTimerLabel label) const;
+	void doResetLog() override;
+	void doLog(const rcLogCategory category, const char* msg, const int len) override;
+	void doResetTimers() override;
+	void doStartTimer(const rcTimerLabel label) override;
+	void doStopTimer(const rcTimerLabel label) override;
+	int doGetAccumulatedTime(const rcTimerLabel label) const override;
 	///@}
 };
 
@@ -72,13 +72,13 @@ class FileIO : public duFileIO
 	int m_mode;
 public:
 	FileIO();
-	virtual ~FileIO();
+	~FileIO() override;
 	bool openForWrite(const char* path);
 	bool openForRead(const char* path);
-	virtual bool isWriting() const;
-	virtual bool isReading() const;
-	virtual bool write(const void* ptr, const size_t size);
-	virtual bool read(void* ptr, const size_t size);
+	bool isWriting() const override;
+	bool isReading() const override;
+	bool write(const void* ptr, const size_t size) override;
+	bool read(void* ptr, const size_t size) override;
 private:
 	// Explicitly disabled copy constructor and copy assignment operator.
 	FileIO(const FileIO&);

--- a/Source/Asset/Asset/actorfile.h
+++ b/Source/Asset/Asset/actorfile.h
@@ -50,11 +50,11 @@ public:
 
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
-    void ReturnPaths(PathSet& path_set);
+    void ReturnPaths(PathSet& path_set) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 
     static bool AssetWarning() { return true; }
 };

--- a/Source/Asset/Asset/ambientsounds.h
+++ b/Source/Asset/Asset/ambientsounds.h
@@ -57,12 +57,12 @@ public:
     void Unload();
     
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
     float GetDelayNoLower();
-    void ReturnPaths(PathSet &path_set);
+    void ReturnPaths(PathSet &path_set) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
     static bool AssetWarning() { return true; }
 };
 

--- a/Source/Asset/Asset/animation.h
+++ b/Source/Asset/Asset/animation.h
@@ -200,11 +200,11 @@ public:
 class Animation:public AnimationAsset {
 public:
     Animation( AssetManager * owner, uint32_t asset_id );
-    virtual ~Animation();
+    ~Animation() override;
 
-    int GetActiveID( const BlendMap& blendmap, int &anim_id ) const;
+    int GetActiveID( const BlendMap& blendmap, int &anim_id ) const override;
     void clear();
-    void GetMatrices( float normalized_time, AnimOutput &anim_output, const AnimInput& anim_input) const;
+    void GetMatrices( float normalized_time, AnimOutput &anim_output, const AnimInput& anim_input) const override;
     void WriteToFile( FILE * file );
     int ReadFromFile( FILE * file );
 
@@ -216,20 +216,20 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
 
 
-    float GetGroundSpeed(const BlendMap& blendmap) const;
-    float GetFrequency(const BlendMap& blendmap) const;
-    float GetPeriod(const BlendMap& blendmap) const;
-    vector<NormalizedAnimationEvent> GetEvents(int& anim_id, bool mirrored) const;
+    float GetGroundSpeed(const BlendMap& blendmap) const override;
+    float GetFrequency(const BlendMap& blendmap) const override;
+    float GetPeriod(const BlendMap& blendmap) const override;
+    vector<NormalizedAnimationEvent> GetEvents(int& anim_id, bool mirrored) const override;
     float LocalFromNormalized(float normalized_time) const;
     float NormalizedFromLocal(float local_time) const;
-    bool IsLooping() const;
+    bool IsLooping() const override;
     void UpdateIKBones();
     void Reload();
-    virtual void ReportLoad();
-    float AbsoluteTimeFromNormalized(float normalized_time) const;
-    void ReturnPaths( PathSet& path_set );
+    void ReportLoad() override;
+    float AbsoluteTimeFromNormalized(float normalized_time) const override;
+    void ReturnPaths( PathSet& path_set ) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 private:
     int length; // in ms
     vector<Keyframe> keyframes;

--- a/Source/Asset/Asset/animationeffect.h
+++ b/Source/Asset/Asset/animationeffect.h
@@ -54,15 +54,15 @@ public:
     
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
-    ~AnimationEffect();
+    ~AnimationEffect() override;
     AnimationEffect(AssetManager* owner, uint32_t asset_id);
     
     static AssetType GetType() { return ANIMATION_EFFECT_ASSET; }
     static const char* GetTypeName() { return "ANIMATION_EFFECT_ASSET"; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
     static bool AssetWarning() { return true; }
 };
 

--- a/Source/Asset/Asset/attachmentasset.h
+++ b/Source/Asset/Asset/attachmentasset.h
@@ -50,11 +50,11 @@ public:
 
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
     void clear();
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
     static bool AssetWarning() { return true; }
 };
 

--- a/Source/Asset/Asset/attacks.h
+++ b/Source/Asset/Asset/attacks.h
@@ -83,20 +83,20 @@ public:
     CutPlaneType stab_type;
 
     Attack(AssetManager* owner, uint32_t asset_id);
-    void ReturnPaths(PathSet &path_set);
+    void ReturnPaths(PathSet &path_set) override;
     int Load(const string &path, uint32_t load_flags);
     const char* GetLoadErrorString();
     const char* GetLoadErrorStringExtended() { return ""; }
 
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
     void clear();
     static AssetType GetType() { return ATTACK_ASSET; }
     static const char* GetTypeName() { return "ATTACK_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<Attack> AttackRef;

--- a/Source/Asset/Asset/averagecolorasset.h
+++ b/Source/Asset/Asset/averagecolorasset.h
@@ -47,11 +47,11 @@ class AverageColor : public Asset {
         const char* GetLoadErrorStringExtended() { return ""; }
         void Unload();
         void Reload();
-        virtual void ReportLoad();
+        void ReportLoad() override;
 
         inline const vec4& color() const {return color_;}
 
-        virtual AssetLoaderBase* NewLoader();
+        AssetLoaderBase* NewLoader() override;
 
         ModID modsource_;
     private:

--- a/Source/Asset/Asset/character.h
+++ b/Source/Asset/Asset/character.h
@@ -94,16 +94,16 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
     const string& GetSoundMod();
     const vector<MorphInfo>& GetMorphs();
     float GetHearing();
-    void ReturnPaths(PathSet &path_set);
+    void ReturnPaths(PathSet &path_set) override;
     const string & GetChannel( int which ) const;
     const string & GetTag( const string &action );
     bool GetMorphMeta(const string& label, vec3 & start, vec3 & end);
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<Character> CharacterRef;

--- a/Source/Asset/Asset/decalfile.h
+++ b/Source/Asset/Asset/decalfile.h
@@ -51,11 +51,11 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
-    void ReturnPaths(PathSet& path_set);
+    void ReturnPaths(PathSet& path_set) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<DecalFile> DecalFileRef;

--- a/Source/Asset/Asset/filehash.h
+++ b/Source/Asset/Asset/filehash.h
@@ -47,7 +47,7 @@ public:
     void Unload();
     void Reload();
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<FileHashAsset> FileHashAssetRef;

--- a/Source/Asset/Asset/fzx_file.h
+++ b/Source/Asset/Asset/fzx_file.h
@@ -55,7 +55,7 @@ public:
     void Unload();
     void Reload();
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<FZXAsset> FZXAssetRef;

--- a/Source/Asset/Asset/hotspotfile.h
+++ b/Source/Asset/Asset/hotspotfile.h
@@ -48,11 +48,11 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
     
-    void ReturnPaths(PathSet& path_set);
+    void ReturnPaths(PathSet& path_set) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<HotspotFile> HotspotFileRef;

--- a/Source/Asset/Asset/image_sampler.h
+++ b/Source/Asset/Asset/image_sampler.h
@@ -53,12 +53,12 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
     vec4 GetInterpolatedColorUV(float x, float y) const;
     bool GetCachePath(std::string* dst);
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
     
     ModID modsource_;
 

--- a/Source/Asset/Asset/item.h
+++ b/Source/Asset/Asset/item.h
@@ -67,8 +67,8 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
-    virtual void ReturnPaths(PathSet &path_set);
+    void ReportLoad() override;
+    void ReturnPaths(PathSet &path_set) override;
     
     const std::string &GetIKAttach(AttachmentType type) const;
     const std::string &GetAttachAnimPath(AttachmentType type);
@@ -99,7 +99,7 @@ public:
     bool HasReactionOverride( const std::string &anim );
     const std::string & GetReactionOverride( const std::string &anim );
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 
 private:
     static const int kMaxAttachments = 4;

--- a/Source/Asset/Asset/levelinfo.h
+++ b/Source/Asset/Asset/levelinfo.h
@@ -45,8 +45,8 @@ public:
     static bool AssetWarning() { return false; }
 
     int Load( const std::string &path, uint32_t load_flags );
-    virtual void ReportLoad();
-    virtual AssetLoaderBase* NewLoader();
+    void ReportLoad() override;
+    AssetLoaderBase* NewLoader() override;
     void Unload();
 
     const std::string GetLevelName();

--- a/Source/Asset/Asset/levelset.h
+++ b/Source/Asset/Asset/levelset.h
@@ -39,7 +39,7 @@ public:
 
     LevelPaths& level_paths(){return level_paths_;}
     
-    void ReturnPaths(PathSet &path_set);
+    void ReturnPaths(PathSet &path_set) override;
 
     int sub_error;
     int Load(const std::string &path, uint32_t load_flags);
@@ -47,11 +47,11 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
     void clear();
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<LevelSet> LevelSetRef;

--- a/Source/Asset/Asset/lipsyncfile.h
+++ b/Source/Asset/Asset/lipsyncfile.h
@@ -61,7 +61,7 @@ public:
     void Reload();
     void GetWeights(float time, int &marker, std::vector<KeyWeight> &weights );
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<LipSyncFile> LipSyncFileRef;

--- a/Source/Asset/Asset/material.h
+++ b/Source/Asset/Asset/material.h
@@ -59,14 +59,14 @@ class Material : public AssetInfo {
     //ASContext *context;
 public:
     Material(AssetManager *owner, uint32_t asset_id);
-    ~Material();
+    ~Material() override;
 
     int Load(const std::string &path, uint32_t load_flags);
     const char* GetLoadErrorString();
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload( );
-    virtual void ReportLoad();
+    void ReportLoad() override;
     void HandleEvent(const std::string &the_event, const vec3 &pos);
     const MaterialEvent& GetEvent( const std::string &the_event );
     const MaterialEvent& GetEvent( const std::string &the_event, const std::string &mod );
@@ -75,13 +75,13 @@ public:
     float GetHardness() const;
     float GetFriction() const;
     float GetSharpPenetration() const;
-    void ReturnPaths( PathSet & path_set );
+    void ReturnPaths( PathSet & path_set ) override;
 
     static AssetType GetType() { return MATERIAL_ASSET; }
     static const char* GetTypeName() { return "MATERIAL_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<Material> MaterialRef;

--- a/Source/Asset/Asset/objectfile.h
+++ b/Source/Asset/Asset/objectfile.h
@@ -82,15 +82,15 @@ public:
     void Unload();
 
     void Reload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
-    void ReturnPaths(PathSet& path_set);
+    void ReturnPaths(PathSet& path_set) override;
 
     static AssetType GetType() { return OBJECT_FILE_ASSET; }
     static const char* GetTypeName() { return "OBJECT_FILE_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<ObjectFile> ObjectFileRef;

--- a/Source/Asset/Asset/particletype.h
+++ b/Source/Asset/Asset/particletype.h
@@ -79,12 +79,12 @@ public:
     const char* GetLoadErrorString();
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
-    virtual void ReportLoad();
+    void ReportLoad() override;
     void Reload( );
 
     void clear();
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<ParticleType> ParticleTypeRef;

--- a/Source/Asset/Asset/reactions.h
+++ b/Source/Asset/Asset/reactions.h
@@ -47,10 +47,10 @@ public:
     void Unload();
 
     void Reload();
-    virtual void ReportLoad();
-    virtual void ReturnPaths(PathSet &path_set);
+    void ReportLoad() override;
+    void ReturnPaths(PathSet &path_set) override;
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<Reaction> ReactionRef;

--- a/Source/Asset/Asset/skeletonasset.h
+++ b/Source/Asset/Asset/skeletonasset.h
@@ -85,7 +85,7 @@ class SkeletonAsset : public Asset {
     std::string error_string;
 public:
     SkeletonAsset(AssetManager* owner, uint32_t asset_id);
-    ~SkeletonAsset();
+    ~SkeletonAsset() override;
 
     const SkeletonFileData& GetData();
     unsigned short checksum() {return checksum_;}
@@ -97,12 +97,12 @@ public:
     void Unload();
 
     void Reload( );
-    virtual void ReportLoad();
+    void ReportLoad() override;
     static AssetType GetType() { return SKELETON_ASSET; };
     static const char* GetTypeName() { return "SKELETON_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<SkeletonAsset> SkeletonAssetRef;

--- a/Source/Asset/Asset/songlistfile.h
+++ b/Source/Asset/Asset/songlistfile.h
@@ -41,7 +41,7 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
     static const char* GetTypeName() { return "SONG_LIST_ASSET"; }
     static bool AssetWarning() { return true; }
 };

--- a/Source/Asset/Asset/soundgroup.h
+++ b/Source/Asset/Asset/soundgroup.h
@@ -47,7 +47,7 @@ public:
     const char* GetLoadErrorString();
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
-    virtual void ReportLoad() {}
+    void ReportLoad() override {}
     void Reload( );
     std::string GetPath() const;
     int GetNumVariants() const;
@@ -55,7 +55,7 @@ public:
     float GetMaxDistance() const;
     float GetDelay() const;
     std::string GetSoundPath();
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<SoundGroup> SoundGroupRef;

--- a/Source/Asset/Asset/soundgroupinfo.h
+++ b/Source/Asset/Asset/soundgroupinfo.h
@@ -42,9 +42,9 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload( );
-    virtual void ReportLoad();
+    void ReportLoad() override;
 
-    virtual void ReturnPaths(PathSet &path_set);
+    void ReturnPaths(PathSet &path_set) override;
     inline int GetNumVariants() const {return num_variants;}
     inline float GetDelay() const {return delay;}
     inline float GetVolume() const {return volume;}
@@ -54,7 +54,7 @@ public:
     static const char* GetTypeName() { return "SOUND_GROUP_INFO_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 private:
     bool ParseXML( const char* data );
 };

--- a/Source/Asset/Asset/syncedanimation.h
+++ b/Source/Asset/Asset/syncedanimation.h
@@ -64,7 +64,7 @@ class SyncedAnimationGroup: public AnimationAsset {
         void AddAnimation( AnimationAssetRef animation, float blend_coord , float ground_speed, float run_bounce, const std::string& time_coord_label );
         void GetMatrices(float normalized_time,
                          AnimOutput &anim_output,
-                         const AnimInput &anim_input) const;
+                         const AnimInput &anim_input) const override;
         void GetMatrices(float normalized_time,
                          AnimOutput &anim_output,
                          const AnimInput &anim_input,
@@ -75,29 +75,29 @@ class SyncedAnimationGroup: public AnimationAsset {
                          float normalized_time, 
                          AnimOutput &anim_output, 
                          const AnimInput &anim_input) const;
-        float GetFrequency(const BlendMap& blendmap) const;
-        float GetGroundSpeed(const BlendMap& blendmap) const;
-        float GetPeriod(const BlendMap& blendmap) const;
-        std::vector<NormalizedAnimationEvent> GetEvents(int &anim_id, bool mirrored) const;
+        float GetFrequency(const BlendMap& blendmap) const override;
+        float GetGroundSpeed(const BlendMap& blendmap) const override;
+        float GetPeriod(const BlendMap& blendmap) const override;
+        std::vector<NormalizedAnimationEvent> GetEvents(int &anim_id, bool mirrored) const override;
         int Load(const std::string &path, uint32_t load_flags);
         const char* GetLoadErrorString();
         const char* GetLoadErrorStringExtended() { return ""; }
         void Unload();
         void Reload();
-        virtual void ReportLoad();
+        void ReportLoad() override;
         void clear();
-        int GetActiveID(const BlendMap& blendmap, int &anim_id) const;
-        bool IsLooping() const;
+        int GetActiveID(const BlendMap& blendmap, int &anim_id) const override;
+        bool IsLooping() const override;
         void CalcMirrored(bool cache, const std::string &skeleton_path);
         unsigned NearestAnimation(float blend_coord) const;
-        float AbsoluteTimeFromNormalized( float normalized_time ) const;
-        void ReturnPaths(PathSet& path_set);
+        float AbsoluteTimeFromNormalized( float normalized_time ) const override;
+        void ReturnPaths(PathSet& path_set) override;
 
         static AssetType GetType() { return SYNCED_ANIMATION_GROUP_ASSET; }
         static const char* GetTypeName() { return "SYNCED_ANIMATION_GROUP_ASSET"; }
         static bool AssetWarning() { return true; }
 
-        virtual AssetLoaderBase* NewLoader();
+        AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<SyncedAnimationGroup> SyncedAnimationGroupRef;

--- a/Source/Asset/Asset/texture.h
+++ b/Source/Asset/Asset/texture.h
@@ -48,7 +48,7 @@ public:
     TextureRef GetTextureRef();
 
     TextureAsset( AssetManager* owner, uint32_t asset_id );
-    virtual ~TextureAsset();
+    ~TextureAsset() override;
 
     static AssetType GetType() { return TEXTURE_ASSET; }
     static const char* GetTypeName() { return "TEXTURE_ASSET"; }
@@ -59,8 +59,8 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
 
-    virtual void ReportLoad(){}
-    virtual AssetLoaderBase* NewLoader();
+    void ReportLoad() override{}
+    AssetLoaderBase* NewLoader() override;
 
     unsigned int GetTexID();
 };

--- a/Source/Asset/Asset/texturedummy.h
+++ b/Source/Asset/Asset/texturedummy.h
@@ -41,8 +41,8 @@ public:
     const char* GetLoadErrorString() { return ""; }
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload() {};
-    virtual void ReportLoad(){}
-    virtual AssetLoaderBase* NewLoader();
+    void ReportLoad() override{}
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<TextureDummy> TextureDummyRef;

--- a/Source/Asset/Asset/voicefile.h
+++ b/Source/Asset/Asset/voicefile.h
@@ -43,13 +43,13 @@ public:
     const char* GetLoadErrorStringExtended() { return ""; }
     void Unload();
     void Reload();
-    virtual void ReportLoad();
-    void ReturnPaths(PathSet &path_set);
+    void ReportLoad() override;
+    void ReturnPaths(PathSet &path_set) override;
     static AssetType GetType() { return VOICE_FILE_ASSET; }
     static const char* GetTypeName() { return "VOICE_FILE_ASSET"; }
     static bool AssetWarning() { return true; }
 
-    virtual AssetLoaderBase* NewLoader();
+    AssetLoaderBase* NewLoader() override;
 };
 
 typedef AssetRef<VoiceFile> VoiceFileRef;

--- a/Source/Asset/AssetLoader/fallbackassetloader.h
+++ b/Source/Asset/AssetLoader/fallbackassetloader.h
@@ -43,26 +43,26 @@ public:
 
     }
 
-    virtual ~FallbackAssetLoader() {
+    ~FallbackAssetLoader() override {
         
     }
 
-    virtual void Initialize(const std::string& path, uint32_t load_flags, Asset* asset) {
+    void Initialize(const std::string& path, uint32_t load_flags, Asset* asset) override {
         this->load_flags = load_flags;
         this->path = path; 
         this->asset = static_cast<TAsset*>(asset);
     }
 
-    virtual const AssetLoaderStepType* GetAssetLoadSteps() const {
+    const AssetLoaderStepType* GetAssetLoadSteps() const override {
         static const AssetLoaderStepType tl[] = { ASSET_LOADER_SYNC_JOB };
         return tl;
     }
 
-    virtual const int GetAssetLoadStepCount() const {
+    const int GetAssetLoadStepCount() const override {
         return 1;
     }
 
-    virtual int DoLoadStep( const int step_id ) {
+    int DoLoadStep( const int step_id ) override {
         switch( step_id ) {
             case 0:
                 asset->path_ = path;
@@ -79,24 +79,24 @@ public:
         return false;
     }
      
-    virtual const char* GetLoadErrorString() {
+    const char* GetLoadErrorString() override {
         return error_message.c_str();
     }
 
-    virtual const char* GetLoadErrorStringExtended() {
+    const char* GetLoadErrorStringExtended() override {
         return error_message_extended.c_str();
     }
 
-    virtual const AssetLoaderStepType* GetAssetUnloadSteps() const {
+    const AssetLoaderStepType* GetAssetUnloadSteps() const override {
         static const AssetLoaderStepType tl[] = { ASSET_LOADER_SYNC_JOB };
         return tl;
     }
 
-    virtual const unsigned GetAssetUnloadStepCount() const {
+    const unsigned GetAssetUnloadStepCount() const override {
         return 1;
     }
 
-    virtual bool DoUnloadStep( const int step_id ) {
+    bool DoUnloadStep( const int step_id ) override {
         switch( step_id )
         {
             case 0:
@@ -108,7 +108,7 @@ public:
         return false;
     }
 
-    virtual const char* GetTypeName() {
+    const char* GetTypeName() override {
         return TAsset::GetTypeName(); 
     }
 };

--- a/Source/Asset/assetref.h
+++ b/Source/Asset/assetref.h
@@ -40,7 +40,7 @@ private:
     T *asset_ptr_;
 
 public:
-    virtual AssetType GetType() {
+    AssetType GetType() override {
         return T::GetType();
     };
 
@@ -73,7 +73,7 @@ public:
         }
     }
 
-    virtual ~AssetRef() {
+    ~AssetRef() override {
         if(asset_ptr_ != NULL){
             asset_ptr_->DecrementRefCount();
             asset_ptr_ = NULL;

--- a/Source/GUI/IMUI/im_behaviors.h
+++ b/Source/GUI/IMUI/im_behaviors.h
@@ -66,16 +66,16 @@ struct IMFadeIn : public IMUpdateBehavior {
         return new IMFadeIn(time, _tweener);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    void cleanUp( IMElement* element );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    void cleanUp( IMElement* element ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMFadeIn* c = new IMFadeIn(targetTime, tweenType);
         c->originalAlpha = originalAlpha;
         return c;
@@ -100,15 +100,15 @@ struct IMMoveIn : public IMUpdateBehavior {
         return new IMMoveIn( _time, _offset, _tweener);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMMoveIn* c = new IMMoveIn(targetTime, offset, tweenType);
         return c;
     }
@@ -142,15 +142,15 @@ struct IMChangeTextFadeOutIn : public IMUpdateBehavior {
         return new IMChangeTextFadeOutIn(time, _targetText, _tweenerOut, _tweenerIn);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMChangeTextFadeOutIn* c = new IMChangeTextFadeOutIn(targetTime, targetText, tweenerOutType, tweenerInType);
         return c;
     }
@@ -181,15 +181,15 @@ struct IMChangeImageFadeOutIn : public IMUpdateBehavior {
         return new IMChangeImageFadeOutIn(time, _targetImage, _tweenerOut, _tweenerIn);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMChangeImageFadeOutIn* c = new IMChangeImageFadeOutIn(targetTime, targetImage, tweenerOutType, tweenerInType);
         return c;
     }
@@ -219,16 +219,16 @@ struct IMPulseAlpha : public IMUpdateBehavior {
         return new IMPulseAlpha(lower, upper, _speed);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMPulseAlpha* c = new IMPulseAlpha(0, 0, 0);
         c->midPoint = midPoint;
         c->difference = difference;
@@ -255,16 +255,16 @@ struct IMPulseBorderAlpha : public IMUpdateBehavior {
         return new IMPulseBorderAlpha(lower, upper, _speed);
     }
 
-    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool initialize( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool update( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMUpdateBehavior* clone() {
+    IMUpdateBehavior* clone() override {
         IMPulseBorderAlpha* c = new IMPulseBorderAlpha(0, 0, 0);
         c->midPoint = midPoint;
         c->difference = difference;
@@ -308,17 +308,17 @@ struct IMPulseBorderAlpha : public IMUpdateBehavior {
  		return new IMMouseOverScale( _time, _offset, _tweener );
  	}
 
- 	void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+ 	void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
  	float computeTransition( float base, float range );
- 	void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
- 	bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+ 	void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+ 	bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
  	/*******************************************************************************************/
  	/**
  	 * @brief  Create a copy of this object (respecting inheritance)
  	 *
  	 */
- 	virtual IMMouseOverBehavior* clone() {
+ 	IMMouseOverBehavior* clone() override {
  				IMMouseOverScale* c = new IMMouseOverScale(targetTime, offset, tweenType);
  				c->midPoints = midPoints;
  				c->differences = differences;
@@ -351,17 +351,17 @@ struct IMPulseBorderAlpha : public IMUpdateBehavior {
          return new IMMouseOverMove( _time, _offset, _tweener );
      }
 
-		 void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+		 void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
      float computeTransition( float base, float range );
-     void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-     bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+     void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+     bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
      /*******************************************************************************************/
      /**
       * @brief  Create a copy of this object (respecting inheritance)
       *
       */
-     virtual IMMouseOverBehavior* clone() {
+     IMMouseOverBehavior* clone() override {
 				 IMMouseOverMove* c = new IMMouseOverMove(targetTime, offset, tweenType);
 				 c->midPoints = midPoints;
 				 c->differences = differences;
@@ -385,16 +385,16 @@ struct IMMouseOverShowBorder : public IMMouseOverBehavior {
         return new IMMouseOverShowBorder();
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseOverBehavior* clone() {
+    IMMouseOverBehavior* clone() override {
         IMMouseOverShowBorder* c = new IMMouseOverShowBorder;
         return c;
     }
@@ -419,17 +419,17 @@ struct IMMouseOverShowBorder : public IMMouseOverBehavior {
         return new IMMouseOverPulseColor( first, second, _speed );
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
      /*******************************************************************************************/
      /**
       * @brief  Create a copy of this object (respecting inheritance)
       *
       */
-     virtual IMMouseOverBehavior* clone() {
+     IMMouseOverBehavior* clone() override {
          IMMouseOverPulseColor* c = new IMMouseOverPulseColor(0,0,0);
          c->midPoints = midPoints;
          c->differences = differences;
@@ -456,10 +456,10 @@ struct IMMouseOverPulseBorder : public IMMouseOverBehavior {
         return new IMMouseOverPulseBorder( first, second, _speed );
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
 
     /*******************************************************************************************/
@@ -467,7 +467,7 @@ struct IMMouseOverPulseBorder : public IMMouseOverBehavior {
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseOverBehavior* clone() {
+    IMMouseOverBehavior* clone() override {
         IMMouseOverPulseBorder* c = new IMMouseOverPulseBorder(0,0,0);
         c->midPoints = midPoints;
         c->differences = differences;
@@ -494,17 +494,17 @@ struct IMMouseOverPulseBorderAlpha : public IMMouseOverBehavior {
         return new IMMouseOverPulseBorderAlpha( lower, upper, _speed );
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseOverBehavior* clone() {
+    IMMouseOverBehavior* clone() override {
         IMMouseOverPulseBorderAlpha* c = new IMMouseOverPulseBorderAlpha(0,0,0);
         c->midPoint = midPoint;
         c->difference = difference;
@@ -533,16 +533,16 @@ struct IMFixedMessageOnMouseOver : public IMMouseOverBehavior {
         return new IMFixedMessageOnMouseOver( _enterMessage, _overMessage, _leaveMessage );
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseOverBehavior* clone() {
+    IMMouseOverBehavior* clone() override {
 
         IMMessage* eM = NULL;
         IMMessage* oM = NULL;
@@ -562,7 +562,7 @@ struct IMFixedMessageOnMouseOver : public IMMouseOverBehavior {
         return c;
     }
 
-    virtual ~IMFixedMessageOnMouseOver() {
+    ~IMFixedMessageOnMouseOver() override {
         if( enterMessage != NULL ) {
             enterMessage->Release();
         }
@@ -593,17 +593,17 @@ struct IMFixedMessageOnMouseOver : public IMMouseOverBehavior {
         return new IMMouseOverFadeIn(time, _tweener, targetAlpha);
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     float computeTransition( float base, float range );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
      /*******************************************************************************************/
      /**
       * @brief  Create a copy of this object (respecting inheritance)
       *
       */
-     virtual IMMouseOverBehavior* clone() {
+     IMMouseOverBehavior* clone() override {
          IMMouseOverFadeIn* c = new IMMouseOverFadeIn(targetTime, tweenType);
          return c;
      }
@@ -655,19 +655,19 @@ struct IMFixedMessageOnClick : public IMMouseClickBehavior {
         return new IMFixedMessageOnClick( message );
     }
 
-    bool onUp( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    bool onUp( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseClickBehavior* clone() {
+    IMMouseClickBehavior* clone() override {
         IMFixedMessageOnClick* c = new IMFixedMessageOnClick( theMessage );
         return c;
     }
 
-    virtual ~IMFixedMessageOnClick() {
+    ~IMFixedMessageOnClick() override {
         if( theMessage != NULL ) {
             theMessage->Release();
         }
@@ -680,22 +680,22 @@ struct IMMouseOverSound : public IMMouseOverBehavior {
     std::string audioFile = "";
 
     IMMouseOverSound(std::string const& audioFile);
-    virtual ~IMMouseOverSound();
+    ~IMMouseOverSound() override;
 
     static IMMouseOverSound* ASFactory(std::string const& audioFile) {
         return new IMMouseOverSound(audioFile);
     }
 
-    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
-    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void onStart( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    void onContinue( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
+    bool onFinish( IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  Create a copy of this object (respecting inheritance)
      *
      */
-    virtual IMMouseOverBehavior* clone() {
+    IMMouseOverBehavior* clone() override {
         IMMouseOverSound* c = new IMMouseOverSound(audioFile);
         return c;
     }
@@ -711,9 +711,9 @@ struct IMSoundOnClick : public IMMouseClickBehavior {
         return new IMSoundOnClick(audioFile);
     }
 
-    bool onUp(IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate);
+    bool onUp(IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate) override;
 
-    virtual IMMouseClickBehavior* clone() {
+    IMMouseClickBehavior* clone() override {
         IMSoundOnClick* c = new IMSoundOnClick(audioFile);
         return c;
     }
@@ -723,7 +723,7 @@ struct IMFuncOnClick : public IMMouseClickBehavior {
     asIScriptFunction * func = 0;
 
     IMFuncOnClick(asIScriptFunction * func);
-    virtual ~IMFuncOnClick() {
+    ~IMFuncOnClick() override {
         func->Release();
     }
 
@@ -731,9 +731,9 @@ struct IMFuncOnClick : public IMMouseClickBehavior {
         return new IMFuncOnClick(func);
     }
 
-    bool onUp(IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate);
+    bool onUp(IMElement* element, uint64_t delta, vec2 drawOffset, GUIState& guistate) override;
 
-    virtual IMMouseClickBehavior* clone() {
+    IMMouseClickBehavior* clone() override {
         IMFuncOnClick* c = new IMFuncOnClick(func);
         return c;
     }

--- a/Source/GUI/IMUI/im_container.h
+++ b/Source/GUI/IMUI/im_container.h
@@ -188,7 +188,7 @@ public:
      * @param _parent New parent
      *
      */
-    void setOwnerParent( IMGUI* _owner, IMElement* _parent );
+    void setOwnerParent( IMGUI* _owner, IMElement* _parent ) override;
 
     /*******************************************************************************************/
     /**
@@ -207,7 +207,7 @@ public:
      * @returns name of the element type as a string
      *
      */
-    std::string getElementTypeName();
+    std::string getElementTypeName() override;
 
     /*******************************************************************************************/
     /**
@@ -216,7 +216,7 @@ public:
      * @param _size 2d size vector (-1 element implies undefined - or use UNDEFINEDSIZE)
      *
      */
-    void setSize( const vec2 _size );
+    void setSize( const vec2 _size ) override;
 
     /*******************************************************************************************/
     /**
@@ -225,7 +225,7 @@ public:
      * @param x x dimension size (-1 implies undefined - or use UNDEFINEDSIZE)
      *
      */
-    void setSizeX( const float x );
+    void setSizeX( const float x ) override;
 
     /*******************************************************************************************/
     /**
@@ -235,7 +235,7 @@ public:
      * @param resetBoundarySize Should we reset the boundary if it's too small?
      *
      */
-    void setSizeY( const float y );
+    void setSizeY( const float y ) override;
 
     /*******************************************************************************************/
     /**
@@ -253,7 +253,7 @@ public:
      * @param guistate The state of the GUI at this update
      *
      */
-    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
 
     /*******************************************************************************************/
     /**
@@ -264,14 +264,14 @@ public:
      * @param clipSize size of clipping region
      *
      */
-    void render( vec2 drawOffset, vec2 clipPos, vec2 clipSize );
+    void render( vec2 drawOffset, vec2 clipPos, vec2 clipSize ) override;
 
     /*******************************************************************************************/
     /**
      * @brief  When a resize, move, etc has happened do whatever is necessary
      * 
      */
-     void doRelayout();
+     void doRelayout() override;
 
     /*******************************************************************************************/
     /**
@@ -286,7 +286,7 @@ public:
      * @brief  Do whatever is necessary when the resolution changes
      *
      */
-     void doScreenResize();
+     void doScreenResize() override;
 
     /*******************************************************************************************/
     /**
@@ -375,7 +375,7 @@ public:
      *  
      *
      */
-    IMElement* findElement( std::string const& elementName );
+    IMElement* findElement( std::string const& elementName ) override;
 
     /*******************************************************************************************/
     /**
@@ -386,14 +386,14 @@ public:
      */
     void setBackgroundImage( std::string const& fileName, vec4 color = vec4(1.0) );
 
-    virtual void setPauseBehaviors( bool pause );
+    void setPauseBehaviors( bool pause ) override;
     
     /*******************************************************************************************/
     /**
      * @brief  Remove all referenced object without releaseing references
      *
      */
-    virtual void clense();
+    void clense() override;
 
     IMElement* getContents() { if(contents) contents->AddRef(); return contents; }
     std::vector<IMElement*> getFloatingContents();
@@ -403,10 +403,10 @@ public:
      * @brief  Destructor
      *
      */
-    virtual ~IMContainer();
+    ~IMContainer() override;
     
-    virtual void DestroyedIMElement( IMElement* element );
-    virtual void DestroyedIMGUI( IMGUI* imgui );
+    void DestroyedIMElement( IMElement* element ) override;
+    void DestroyedIMGUI( IMGUI* imgui ) override;
 };
 
 

--- a/Source/GUI/IMUI/im_divider.h
+++ b/Source/GUI/IMUI/im_divider.h
@@ -85,7 +85,7 @@ public:
      * @returns name of the element type as a string
      *
      */
-    std::string getElementTypeName();
+    std::string getElementTypeName() override;
     
     /*******************************************************************************************/
     /**
@@ -94,7 +94,7 @@ public:
      * @param _parent New parent
      *
      */
-    void setOwnerParent( IMGUI* _owner, IMElement* _parent );
+    void setOwnerParent( IMGUI* _owner, IMElement* _parent ) override;
     
     /*******************************************************************************************/
     /**
@@ -123,7 +123,7 @@ public:
      * @param guistate The state of the GUI at this update
      *
      */
-    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     
     /*******************************************************************************************/
     /**
@@ -134,7 +134,7 @@ public:
      * @param clipSize size of clipping region
      *
      */
-    void render( vec2 drawOffset, vec2 clipPos, vec2 clipSize );
+    void render( vec2 drawOffset, vec2 clipPos, vec2 clipSize ) override;
     
     /*******************************************************************************************/
     /**
@@ -148,14 +148,14 @@ public:
      * @brief  When a resize, move, etc has happened do whatever is necessary
      * 
      */
-    void doRelayout();
+    void doRelayout() override;
     
     /*******************************************************************************************/
     /**
      * @brief  Do whatever is necessary when the resolution changes
      *
      */
-    void doScreenResize();
+    void doScreenResize() override;
     
 
     /*******************************************************************************************/
@@ -227,9 +227,9 @@ public:
      *  
      *
      */
-    IMElement* findElement( std::string const& elementName );
+    IMElement* findElement( std::string const& elementName ) override;
 
-    void setPauseBehaviors( bool pause );
+    void setPauseBehaviors( bool pause ) override;
 
     DividerOrientation getOrientation() const { return orientation; }
     
@@ -238,18 +238,18 @@ public:
      * @brief  Remove all referenced object without releaseing references
      *
      */
-    virtual void clense();
+    void clense() override;
     
     /*******************************************************************************************/
     /**
      * @brief  Destructor
      *
      */
-    virtual ~IMDivider();
+    ~IMDivider() override;
     
 
-    virtual void DestroyedIMElement( IMElement* element );
-    virtual void DestroyedIMGUI( IMGUI* imgui );
+    void DestroyedIMElement( IMElement* element ) override;
+    void DestroyedIMGUI( IMGUI* imgui ) override;
 };
 
 

--- a/Source/GUI/IMUI/im_element.h
+++ b/Source/GUI/IMUI/im_element.h
@@ -1455,6 +1455,6 @@ public:
     virtual ~IMElement();
 
     static void DestroyQueuedIMElements();
-    virtual void DestroyedIMElement( IMElement* element );
-    virtual void DestroyedIMGUI( IMGUI* imgui );
+    void DestroyedIMElement( IMElement* element ) override;
+    void DestroyedIMGUI( IMGUI* imgui ) override;
 };

--- a/Source/GUI/IMUI/im_image.h
+++ b/Source/GUI/IMUI/im_image.h
@@ -97,7 +97,7 @@ public:
      * @returns name of the element type as a string
      *
      */
-    std::string getElementTypeName();
+    std::string getElementTypeName() override;
 
     void setSkipAspectFitting(bool val);
     void setCenter(bool val);
@@ -139,7 +139,7 @@ public:
      * @param clipSize size of clipping region
      *
      */
-    void render( vec2 drawOffset, vec2 currentClipPos, vec2 currentClipSize );
+    void render( vec2 drawOffset, vec2 currentClipPos, vec2 currentClipSize ) override;
     
     /*******************************************************************************************/
     /**
@@ -150,7 +150,7 @@ public:
      * @param guistate The state of the GUI at this update
      *
      */
-    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     
     /*******************************************************************************************/
     /**
@@ -187,14 +187,14 @@ public:
      * @brief  Remove all referenced object without releaseing references
      *
      */
-    virtual void clense();
+    void clense() override;
     
     /*******************************************************************************************/
     /**
      * @brief  Destructor
      *
      */
-    virtual ~IMImage();
+    ~IMImage() override;
     
 };
 

--- a/Source/GUI/IMUI/im_selection_list.h
+++ b/Source/GUI/IMUI/im_selection_list.h
@@ -89,7 +89,7 @@ public:
      * @returns name of the element type as a string
      *
      */
-    virtual std::string getElementTypeName() {
+    std::string getElementTypeName() override {
         return "TextSelectionList";
     }
     
@@ -119,7 +119,7 @@ public:
      * @brief  Destructor
      *
      */
-    virtual ~IMTextSelectionList();
+    ~IMTextSelectionList() override;
     
 };
 

--- a/Source/GUI/IMUI/im_spacer.h
+++ b/Source/GUI/IMUI/im_spacer.h
@@ -76,14 +76,14 @@ public:
      * @returns name of the element type as a string
      *
      */
-    std::string getElementTypeName();
+    std::string getElementTypeName() override;
     
     /*******************************************************************************************/
     /**
      * @brief  Destructor
      *
      */
-    virtual ~IMSpacer();
+    ~IMSpacer() override;
 };
 
 

--- a/Source/GUI/IMUI/im_text.h
+++ b/Source/GUI/IMUI/im_text.h
@@ -167,7 +167,7 @@ public:
      * @returns name of the element type as a string
      *
      */
-    std::string getElementTypeName();
+    std::string getElementTypeName() override;
     
     /*******************************************************************************************/
     /**
@@ -181,14 +181,14 @@ public:
      * @brief  When a resize, move, etc has happened do whatever is necessary
      * 
      */
-    void doRelayout();
+    void doRelayout() override;
 
     /*******************************************************************************************/
     /**
      * @brief  Do whatever is necessary when the resolution changes
      *
      */
-    void doScreenResize();
+    void doScreenResize() override;
 
     /*******************************************************************************************/
     /**
@@ -263,7 +263,7 @@ public:
      * @param guistate The state of the GUI at this update
      *
      */
-    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate );
+    void update( uint64_t delta, vec2 drawOffset, GUIState& guistate ) override;
     
     /*******************************************************************************************/
     /**
@@ -274,14 +274,14 @@ public:
      * @param clipSize size of clipping region
      *
      */
-    void render( vec2 drawOffset, vec2 currentClipPos, vec2 currentClipSize );
+    void render( vec2 drawOffset, vec2 currentClipPos, vec2 currentClipSize ) override;
     
     /*******************************************************************************************/
     /**
      * @brief  Remove all referenced object without releaseing references
      *
      */
-    virtual void clense();
+    void clense() override;
     
-    virtual ~IMText();
+    ~IMText() override;
 };

--- a/Source/GUI/IMUI/im_tween.h
+++ b/Source/GUI/IMUI/im_tween.h
@@ -71,7 +71,7 @@ struct IMTween {
  **/
 
 struct LinearTween : public IMTween {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * t / d + b;
     }
 };
@@ -82,13 +82,13 @@ struct LinearTween : public IMTween {
  **/
 
 struct InQuadTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * pow(t / d, 2) + b;
     }
 };
 
 struct OutQuadTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d;
         return -c * t * (t - 2) + b;
     }
@@ -96,7 +96,7 @@ struct OutQuadTween : public IMTween  {
 
 
 struct InOutQuadTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d * 2;
         if ( t < 1 ) {
             return c / 2 * pow(t, 2) + b;
@@ -109,7 +109,7 @@ struct OutInQuadTween : public IMTween  {
     InQuadTween inQuad;
     OutQuadTween outQuad;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if ( t < d / 2 ) {
             return outQuad.compute(t * 2, b, c / 2, d);
         }
@@ -123,19 +123,19 @@ struct OutInQuadTween : public IMTween  {
  **/
 
 struct InCubicTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * pow(t / d, 3) + b;
     }
 };
 
 struct OutCubicTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * (pow(t / d - 1, 3) + 1) + b;
     }
 };
 
 struct InOutCubicTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d * 2;
         if ( t < 1 ) {
             return c / 2 * t * t * t + b;
@@ -150,7 +150,7 @@ struct OutInCubicTween : public IMTween  {
     OutCubicTween outCubic;
     InCubicTween inCubic;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ) {
             return outCubic.compute(t * 2, b, c / 2, d);
         }
@@ -164,19 +164,19 @@ struct OutInCubicTween : public IMTween  {
  **/
 
 struct InQuartTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * pow(t / d, 4) + b;
     }
 };
 
 struct OutQuartTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return -c * (pow(t / d - 1, 4) - 1) + b;
     }
 };
 
 struct InOutQuartTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d * 2;
         if (t < 1 ) {
             return c / 2 * pow(t, 4) + b;
@@ -189,7 +189,7 @@ struct OutInQuartTween : public IMTween  {
     OutQuartTween outQuart;
     InQuartTween inQuart;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if (t < d / 2 ) {
             return outQuart.compute(t * 2, b, c / 2, d);
         }
@@ -204,20 +204,20 @@ struct OutInQuartTween : public IMTween  {
 
 
 struct InQuintTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * pow(t / d, 5) + b;
     }
 };
 
 struct OutQuintTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * (pow(t / d - 1, 5) + 1) + b;
     }
 };
 
 
 struct InOutQuintTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d * 2;
         
         if (t < 1) {
@@ -233,7 +233,7 @@ struct OutInQuintTween : public IMTween  {
     InQuintTween inQuint;
     OutQuintTween outQuint;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if ( t < d / 2 ) {
             return outQuint.compute(t * 2, b, c / 2, d);
         }
@@ -247,21 +247,21 @@ struct OutInQuintTween : public IMTween  {
  **/
 
 struct InSineTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return -c * cos(t / d * (PI_f / 2)) + c + b;
     }
 };
 
 
 struct OutSineTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c * sin(t / d * (PI_f / 2)) + b;
     }
 };
 
 
 struct InOutSineTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return -c / 2 * (cos(PI_f * t / d) - 1) + b;
     }
 };
@@ -270,7 +270,7 @@ struct OutInSineTween : public IMTween  {
     InSineTween inSine;
     OutSineTween outSine;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ) {
             return outSine.compute(t * 2, b, c / 2, d);
         }
@@ -285,7 +285,7 @@ struct OutInSineTween : public IMTween  {
  **/
 
 struct InExpoTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t == 0 ){
             return b;
         }
@@ -294,7 +294,7 @@ struct InExpoTween : public IMTween  {
 };
 
 struct OutExpoTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t == d ){
             return b + c;
         }
@@ -304,7 +304,7 @@ struct OutExpoTween : public IMTween  {
 };
 
 struct InOutExpoTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t == 0 ){
             return b;
         }
@@ -327,7 +327,7 @@ struct OutInExpoTween : public IMTween  {
     InExpoTween inExpo;
     OutExpoTween outExpo;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ){
             return outExpo.compute(t * 2, b, c / 2, d);
         }
@@ -343,20 +343,20 @@ struct OutInExpoTween : public IMTween  {
 
 
 struct InCircTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return(-c * (sqrt(1 - pow(t / d, 2)) - 1) + b);
     }
 };
 
 
 struct OutCircTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return(c * sqrt(1 - pow(t / d - 1, 2)) + b);
     }
 };
 
 struct InOutCircTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d * 2;
         if( t < 1 ){
             return -c / 2 * (sqrt(1 - t * t) - 1) + b;
@@ -370,7 +370,7 @@ struct OutInCircTween : public IMTween  {
     InCircTween inCirc;
     OutCircTween outCirc;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ){
             return outCirc.compute(t * 2, b, c / 2, d);
         }
@@ -385,7 +385,7 @@ struct OutInCircTween : public IMTween  {
  **/
 
 struct OutBounceTween : public IMTween  {
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         t = t / d;
         if( t < 1 / 2.75f ){
             return c * (7.5625f * t * t) + b;
@@ -407,7 +407,7 @@ struct OutBounceTween : public IMTween  {
 struct InBounceTween : public IMTween  {
     OutBounceTween outBounce;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         return c - outBounce.compute(d - t, 0, c, d) + b;
     }
 };
@@ -416,7 +416,7 @@ struct InOutBounceTween : public IMTween  {
     OutBounceTween outBounce;
     InBounceTween inBounce;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ) {
             return inBounce.compute(t * 2, 0, c, d) * 0.5f + b;
         }
@@ -428,7 +428,7 @@ struct OutInBounceTween : public IMTween  {
     InBounceTween inBounce;
     OutBounceTween outBounce;
     
-    virtual float compute( float t, float b, float c, float d ) {
+    float compute( float t, float b, float c, float d ) override {
         if( t < d / 2 ) {
             return outBounce.compute(t * 2, b, c / 2, d);
         }

--- a/Source/GUI/IMUI/imgui.h
+++ b/Source/GUI/IMUI/imgui.h
@@ -408,8 +408,8 @@ public:
      */
     virtual ~IMGUI();
 
-    virtual void DestroyedIMElement( IMElement* element );
-    virtual void DestroyedIMGUI( IMGUI* IMGUI );
+    void DestroyedIMElement( IMElement* element ) override;
+    void DestroyedIMGUI( IMGUI* IMGUI ) override;
 };
 
 

--- a/Source/GUI/IMUI/imui.h
+++ b/Source/GUI/IMUI/imui.h
@@ -191,7 +191,7 @@ struct IMUIImage : public IMUIRenderable {
      * @brief  Destructor
      *
      */
-    ~IMUIImage() {
+    ~IMUIImage() override {
     }
     
     /*******************************************************************************************/
@@ -313,7 +313,7 @@ struct IMUIText : public IMUIRenderable {
      * @brief  Destructor
      *
      */
-    ~IMUIText() {
+    ~IMUIText() override {
     }
     
     /*******************************************************************************************/

--- a/Source/GUI/dimgui/modmenu.cpp
+++ b/Source/GUI/dimgui/modmenu.cpp
@@ -1110,7 +1110,7 @@ static void DrawUpdateToSteamworks() {
 static void ModActivationChanged(const ModInstance* mod);
 class ImGuiModMenuLoadingCallback : public ModLoadingCallback {
 public:
-    virtual void ModActivationChange(const ModInstance* mod) {
+    void ModActivationChange(const ModInstance* mod) override {
         ModActivationChanged(mod);
     }
 };

--- a/Source/GUI/scriptable_ui.h
+++ b/Source/GUI/scriptable_ui.h
@@ -71,7 +71,7 @@ public:
         callback_instance_(callback_instance), to_delete_(false),
         notification_callback_(notification_callback) 
     {}
-    ~ScriptableUI() {
+    ~ScriptableUI() override {
         Dispose();
     };
     
@@ -86,7 +86,7 @@ public:
 
     void Reload(bool force=false);
 
-    virtual void ModActivationChange( const ModInstance* mod );
+    void ModActivationChange( const ModInstance* mod ) override;
     
     DISALLOW_COPY_AND_ASSIGN(ScriptableUI);
 };

--- a/Source/Game/color_tint_component.h
+++ b/Source/Game/color_tint_component.h
@@ -32,8 +32,8 @@ public:
     float overbright_;
     ColorTintComponent():tint_(1.0f), overbright_(0.0f) {}
     static void LoadDescriptionFromXML(EntityDescription& desc, const TiXmlElement* el);
-    virtual void SetFromDescription(const EntityDescription& desc);
+    void SetFromDescription(const EntityDescription& desc) override;
     virtual void AddToDescription(EntityDescription& desc) const;
-    virtual void SaveToXML(TiXmlElement* el);
-    virtual void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args);
+    void SaveToXML(TiXmlElement* el) override;
+    void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args) override;
 };

--- a/Source/Game/level.h
+++ b/Source/Game/level.h
@@ -106,7 +106,7 @@ public:
     Level();
     virtual ~Level();
 
-    virtual void IncomingTCPData(SocketID socket, uint8_t* data, size_t len);
+    void IncomingTCPData(SocketID socket, uint8_t* data, size_t len) override;
 
     void StartDialogue(const std::string& dialogue) const;
 	void RegisterMPCallbacks() const;

--- a/Source/Graphics/pxdebugdraw.h
+++ b/Source/Graphics/pxdebugdraw.h
@@ -120,7 +120,7 @@ public:
     DebugDrawWire(const vec4 &_color, const DDFlag& _flags);
     DebugDrawWire(const mat4 &_transform, const vec4 &_color, const DDFlag& _flags);
     DebugDrawWire(const RC_VBOContainer& _vbo, const mat4 &_transform, const vec4 &_color, const DDFlag& _flags);
-    void Draw();
+    void Draw() override;
 };
 
 class LabelText;
@@ -132,21 +132,21 @@ class DebugDrawText : public DebugDrawElement {
         mat4 transform;
         float scale;
     public:
-        void Draw();
+        void Draw() override;
         DebugDrawText(const vec3 &_position,
                       const float &_scale,
                       const std::string &_content,
                       const DDFlag& _flags,
                       const vec4 & _color);
-        ~DebugDrawText();
-        virtual bool SetPosition(const vec3& position);
+        ~DebugDrawText() override;
+        bool SetPosition(const vec3& position) override;
 };
 
 
 class DebugDrawBillboard: public DebugDrawElement {
 public:
-    void Draw();
-    virtual bool SetPosition(const vec3 &position);
+    void Draw() override;
+    bool SetPosition(const vec3 &position) override;
     void SetScale(float scale);
     DebugDrawBillboard(const TextureRef& ref, const vec3 &position, float scale, const vec4& color, AlphaMode mode);
 private: 
@@ -159,7 +159,7 @@ private:
 
 class DebugDrawRibbon: public DebugDrawElement {
 public:
-    void Draw();
+    void Draw() override;
     DebugDrawRibbon(const DDFlag& flags);
     DebugDrawRibbon(const vec3 &start, 
                     const vec3 &end, 
@@ -206,7 +206,7 @@ public:
     DebugDrawWireMesh(const RC_VBOContainer& _vbo,
                       const mat4 &_transform,
                       const vec4 &_color);
-    ~DebugDrawWireMesh();
+    ~DebugDrawWireMesh() override;
 };
 
 class DebugDrawStippleMesh : public DebugDrawElement {
@@ -220,7 +220,7 @@ public:
                          const mat4 &_transform,
                          const vec4 &_color,
                          const DDFlag& _flags);
-    void Draw();
+    void Draw() override;
 };
 
 
@@ -229,7 +229,7 @@ class DebugDrawPoint : public DebugDrawElement {
         vec4 color;
         mat4 transform; 
     public:
-        void Draw();
+        void Draw() override;
         DebugDrawPoint(const vec3 &point, 
                       const vec4 &color,
                       const DDFlag& _flags = _DD_NO_FLAG);
@@ -246,7 +246,7 @@ class DebugDrawWireSphere : public DebugDrawWire {
                             const float radius,
                             const vec3 &scale = vec3(1.0f,1.0f,1.0f),
                             const vec4 &color = vec4(1.0f,1.0f,1.0f,1.0f));
-        ~DebugDrawWireSphere();
+        ~DebugDrawWireSphere() override;
 };
 
 class DebugDrawCircle : public DebugDrawWire {
@@ -266,7 +266,7 @@ class DebugDrawWireCylinder : public DebugDrawWire {
                               const float radius,
                               const float height,
                               const vec4 &color);
-        ~DebugDrawWireCylinder();
+        ~DebugDrawWireCylinder() override;
 };
 
 

--- a/Source/Internal/file_descriptor.h
+++ b/Source/Internal/file_descriptor.h
@@ -42,16 +42,16 @@ public:
 class DiskFileDescriptor : public FileDescriptor {
 public:
     // See FileDescriptor::ReadBytes
-    virtual bool ReadBytes(void* dst, int num_bytes);
+    bool ReadBytes(void* dst, int num_bytes) override;
     int ReadBytesPartial(void* dst, int num_bytes);
     // See FileDescriptor::WriteBytes
-    virtual bool WriteBytes(const void* src, int num_bytes);
+    bool WriteBytes(const void* src, int num_bytes) override;
     // Open file at filename (UTF8 path) with given mode (e.g. r,w,rb,wb)
     bool Open(const std::string& filename, const std::string& mode);
     bool Close();
     int GetSize();
     DiskFileDescriptor():file_(NULL){}
-    ~DiskFileDescriptor();
+    ~DiskFileDescriptor() override;
 private:
     FILE* file_;
 };
@@ -59,9 +59,9 @@ private:
 class MemReadFileDescriptor : public FileDescriptor {
 public:
     // See FileDescriptor::ReadBytes
-    virtual bool ReadBytes(void* dst, int num_bytes);
+    bool ReadBytes(void* dst, int num_bytes) override;
     // Cannot write to this descriptor
-    virtual bool WriteBytes(const void* src, int num_bytes){return false;}
+    bool WriteBytes(const void* src, int num_bytes) override{return false;}
     MemReadFileDescriptor(void* ptr = NULL)
         :ptr_(ptr), index_(0) {}
 private:
@@ -72,9 +72,9 @@ private:
 class MemWriteFileDescriptor : public FileDescriptor {
 public:
     // Cannot read from this descriptor
-    virtual bool ReadBytes(void* dst, int num_bytes){return false;}
+    bool ReadBytes(void* dst, int num_bytes) override{return false;}
     // See FileDescriptor::WriteBytes
-    virtual bool WriteBytes(const void* src, int num_bytes);
+    bool WriteBytes(const void* src, int num_bytes) override;
     MemWriteFileDescriptor(std::vector<uint8_t> &vec):vec_(vec){}
 private:
     std::vector<uint8_t> &vec_;

--- a/Source/JSON/json.h
+++ b/Source/JSON/json.h
@@ -397,8 +397,8 @@ namespace Json {
 class JSON_API Exception : public std::exception {
 public:
   Exception(std::string const& msg);
-  virtual ~Exception() throw();
-  virtual char const* what() const throw();
+  ~Exception() throw() override;
+  char const* what() const throw() override;
 protected:
   std::string const msg_;
 };
@@ -1492,9 +1492,9 @@ public:
   Json::Value settings_;
 
   CharReaderBuilder();
-  virtual ~CharReaderBuilder();
+  ~CharReaderBuilder() override;
 
-  virtual CharReader* newCharReader() const;
+  CharReader* newCharReader() const override;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
@@ -1689,12 +1689,12 @@ public:
   Json::Value settings_;
 
   StreamWriterBuilder();
-  virtual ~StreamWriterBuilder();
+  ~StreamWriterBuilder() override;
 
   /**
    * \throw std::exception if something goes wrong (e.g. invalid settings)
    */
-  virtual StreamWriter* newStreamWriter() const;
+  StreamWriter* newStreamWriter() const override;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
@@ -1735,12 +1735,12 @@ class JSON_API FastWriter : public Writer {
 
 public:
   FastWriter();
-  virtual ~FastWriter() {}
+  ~FastWriter() override {}
 
   void enableYAMLCompatibility();
 
 public: // overridden from Writer
-  virtual std::string write(const Value& root);
+  std::string write(const Value& root) override;
 
 private:
   void writeValue(const Value& value);
@@ -1776,14 +1776,14 @@ private:
 class JSON_API StyledWriter : public Writer {
 public:
   StyledWriter();
-  virtual ~StyledWriter() {}
+  ~StyledWriter() override {}
 
 public: // overridden from Writer
   /** \brief Serialize a Value in <a HREF="http://www.json.org">JSON</a> format.
    * \param root Value to serialize.
    * \return String containing the JSON document that represents the root value.
    */
-  virtual std::string write(const Value& root);
+  std::string write(const Value& root) override;
 
 private:
   void writeValue(const Value& value);

--- a/Source/JSON/jsoncpp.cpp
+++ b/Source/JSON/jsoncpp.cpp
@@ -1919,9 +1919,9 @@ public:
   : collectComments_(collectComments)
   , reader_(features)
   {}
-  virtual bool parse(
+  bool parse(
       char const* beginDoc, char const* endDoc,
-      Value* root, std::string* errs) {
+      Value* root, std::string* errs) override {
     bool ok = reader_.parse(beginDoc, endDoc, *root, collectComments_);
     if (errs) {
       *errs = reader_.getFormattedErrorMessages();
@@ -4576,7 +4576,7 @@ struct BuiltStyledStreamWriter : public StreamWriter
       std::string const& nullSymbol,
       std::string const& endingLineFeedSymbol,
       bool useSpecialFloats);
-  virtual int write(Value const& root, std::ostream* sout);
+  int write(Value const& root, std::ostream* sout) override;
 private:
   void writeValue(Value const& value);
   void writeArrayValue(Value const& value);

--- a/Source/Logging/consolehandler.h
+++ b/Source/Logging/consolehandler.h
@@ -32,10 +32,10 @@ class ConsoleHandler : public LogHandler
 public:
 	ConsoleHandler();
 
-	virtual ~ConsoleHandler();
+	~ConsoleHandler() override;
 
 	/*! \param message will be printed to std::cout */
-	virtual void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message );
-    virtual void Flush();
+	void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message ) override;
+    void Flush() override;
 };
 

--- a/Source/Logging/filehandler.h
+++ b/Source/Logging/filehandler.h
@@ -38,14 +38,14 @@ public:
 	*/
 	FileHandler( std::string path, size_t _startup_file_size, size_t _max_file_size );
 	
-	virtual ~FileHandler();
+	~FileHandler() override;
 
 	/*! 
 		\param message will print message to file if file is open 
 	*/
-	virtual void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message );
+	void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message ) override;
     
-    virtual void Flush();
+    void Flush() override;
 
     void SetMaxWriteLimit( size_t size );
 private:

--- a/Source/Logging/ramhandler.h
+++ b/Source/Logging/ramhandler.h
@@ -56,11 +56,11 @@ private:
 public:
 	RamHandler();
 
-	virtual ~RamHandler();
+	~RamHandler() override;
 
 	/*! \param message will be printed to std::cout */
-	virtual void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message );
-    virtual void Flush();
+	void Log( LogSystem::LogType type, int row, const char* filename, const char* cat, const char* message_prefix, const char* message ) override;
+    void Flush() override;
 
     void Lock();
     void Unlock();

--- a/Source/Main/engine.h
+++ b/Source/Main/engine.h
@@ -311,7 +311,7 @@ public:
 
         void DrawCubeMap(TextureRef cube_map, const vec3 &pos, GLuint cube_map_fbo, SceneGraph::SceneDrawType scene_draw_type);
 
-        void ModActivationChange( const ModInstance* mod );
+        void ModActivationChange( const ModInstance* mod ) override;
 public:
         void InjectWindowResizeEvent(ivec2 size);
         void SetGameSpeed(float val, bool hard);

--- a/Source/Objects/ambientsoundobject.h
+++ b/Source/Objects/ambientsoundobject.h
@@ -36,21 +36,21 @@
 class AmbientSoundObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _ambient_sound_object; }
+    EntityType GetType() const override { return _ambient_sound_object; }
     AmbientSoundObject();
-    virtual ~AmbientSoundObject();
+    ~AmbientSoundObject() override;
 
-    bool Initialize();
+    bool Initialize() override;
 
-    void Update(float timestep);
-    void Draw();
+    void Update(float timestep) override;
+    void Draw() override;
     void Copied();
 
-    virtual void Moved(Object::MoveType type);
+    void Moved(Object::MoveType type) override;
     const std::string & GetPath();
     bool InCameraRange();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
 
 private:
     float delay;

--- a/Source/Objects/cameraobject.h
+++ b/Source/Objects/cameraobject.h
@@ -73,19 +73,19 @@ class CameraObject: public Object {
             exclude_from_undo = true;
         }
 
-        virtual ~CameraObject();
+        ~CameraObject() override;
         
-        virtual EntityType GetType() const {return _camera_type;}
+        EntityType GetType() const override {return _camera_type;}
         
         void saveStateToFile(FILE *);
-        void Update(float timestep);
-		virtual void Reload();
-		void Draw();
-        virtual void GetDisplayName(char* buf, int buf_size);
+        void Update(float timestep) override;
+		void Reload() override;
+		void Draw() override;
+        void GetDisplayName(char* buf, int buf_size) override;
         
         virtual void IgnoreInput(bool val) {}
         virtual void IgnoreMouseInput(bool val) {}
-        bool Initialize();
+        bool Initialize() override;
         vec3 GetMouseRay();
 
         void FrameSelection(bool v);

--- a/Source/Objects/decalobject.h
+++ b/Source/Objects/decalobject.h
@@ -38,18 +38,18 @@ class DecalEditor;
 
 class DecalObject : public Object {
 public:
-    virtual EntityType GetType() const { return _decal_object; }
+    EntityType GetType() const override { return _decal_object; }
     DecalObject();
-    bool Initialize();
-    virtual void Dispose();
-    virtual void GetDisplayName(char* buf, int buf_size);
-    virtual void Draw();
-    virtual bool SetFromDesc( const EntityDescription& desc );
-    virtual void GetDesc(EntityDescription &desc) const;
+    bool Initialize() override;
+    void Dispose() override;
+    void GetDisplayName(char* buf, int buf_size) override;
+    void Draw() override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
+    void GetDesc(EntityDescription &desc) const override;
     void Load( const std::string& type_file );
-    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args );
+    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) override;
 
-    virtual void PreDrawFrame(float curr_game_time);
+    void PreDrawFrame(float curr_game_time) override;
     ColorTintComponent color_tint_component_;
     float spawn_time_;
     

--- a/Source/Objects/dynamiclightobject.h
+++ b/Source/Objects/dynamiclightobject.h
@@ -31,20 +31,20 @@
 class DynamicLightObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _dynamic_light_object; }
-    virtual void Draw();
-    virtual bool Initialize();
+    EntityType GetType() const override { return _dynamic_light_object; }
+    void Draw() override;
+    bool Initialize() override;
 
-    virtual void Moved(Object::MoveType type);
-    virtual void Dispose();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void Moved(Object::MoveType type) override;
+    void Dispose() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     vec3 GetTint() const;
     float GetOverbright() const; 
 	DynamicLightObject();
-	virtual ~DynamicLightObject();
-    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args );
-	virtual void SetEnabled(bool val);
+	~DynamicLightObject() override;
+    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) override;
+	void SetEnabled(bool val) override;
 
 private:
     int light_id_;

--- a/Source/Objects/editorcameraobject.h
+++ b/Source/Objects/editorcameraobject.h
@@ -31,7 +31,7 @@
 
 class EditorCameraObject: public CameraObject {
 public:
-    virtual EntityType GetType() const { return _camera_type; }
+    EntityType GetType() const override { return _camera_type; }
     EditorCameraObject() {
         frozen=false;
         speed=12;
@@ -39,14 +39,14 @@ public:
         rotation2=0;
     };
 
-    virtual ~EditorCameraObject()
+    ~EditorCameraObject() override
     {
 #ifdef _DEBUG
         printf("editor camera destroyed\n");
 #endif
     }
     
-    virtual void IgnoreInput(bool val);
-    void IgnoreMouseInput(bool val);
-    virtual void GetDisplayName(char* buf, int buf_size);
+    void IgnoreInput(bool val) override;
+    void IgnoreMouseInput(bool val) override;
+    void GetDisplayName(char* buf, int buf_size) override;
 };

--- a/Source/Objects/envobject.h
+++ b/Source/Objects/envobject.h
@@ -135,66 +135,66 @@ class EnvObject: public Object {
         list<OnlineMessageRef> incoming_online_env_update;
 
         EnvObject();
-        virtual ~EnvObject();
+        ~EnvObject() override;
 
-        virtual bool Initialize();
-        virtual void GetShaderNames(std::map<std::string, int>& shaders);
-        virtual void Update(float timestep);
+        bool Initialize() override;
+        void GetShaderNames(std::map<std::string, int>& shaders) override;
+        void Update(float timestep) override;
         void UpdateBoundingSphere();
 
 		std::string GetLabel();
 
         // Drawing
-        virtual void Draw();
+        void Draw() override;
         void DrawInstances(EnvObject** instance_array, int num_instances, const mat4& proj_view_matrix, const mat4& prev_proj_view_matrix, const std::vector<mat4>* shadow_matrix, const vec3& cam_pos, Object::DrawType type);
         bool HasDetailObjectSurfaces() const { return !detail_object_surfaces.empty(); }
         void DrawDetailObjectInstances(EnvObject** instance_array, int num_instances, Object::DrawType type);
-        virtual void PreDrawCamera(float curr_game_time);
-        void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type);
-        virtual void SetEnabled(bool val);
-        virtual void SetCollisionEnabled(bool val);
-        virtual void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args);
+        void PreDrawCamera(float curr_game_time) override;
+        void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type) override;
+        void SetEnabled(bool val) override;
+        void SetCollisionEnabled(bool val) override;
+        void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args) override;
 
         void GetObj2World(float *obj2world);
         
 		void EnvInterpolate(uint16_t pending_updates);
 
         // Line hits
-        virtual int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0);
+        int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0) override;
         
         bool UpdatePhysicsTransform();
-        virtual void GetDisplayName(char* buf, int buf_size);
+        void GetDisplayName(char* buf, int buf_size) override;
         
         void CreatePhysicsShape();
 
-        virtual void Moved(Object::MoveType type);
+        void Moved(Object::MoveType type) override;
         void RemovePhysicsShape();
         const Model* GetModel() const;
         vec3 GetBoundingBoxSize();
         void HandleMaterialEvent( const std::string &the_event, const vec3 &event_pos );
-        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, int *tri );
-        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, const std::string &mod, int *tri);
+        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, int *tri ) override;
+        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, const std::string &mod, int *tri) override;
         const MaterialDecal& GetMaterialDecal( const std::string &type, const vec3 &pos );
         const MaterialParticle& GetMaterialParticle( const std::string &type, const vec3 &pos );
-        MaterialRef GetMaterial( const vec3 &pos, int* tri = NULL );
+        MaterialRef GetMaterial( const vec3 &pos, int* tri = NULL ) override;
         void UpdateDetailScale();
         bool Load( const std::string& type_file );
-        void Reload();
+        void Reload() override;
         const vec3 &GetColorTint();
         const float& GetOverbright();
         void LoadModel();
         BulletWorld* GetBulletWorld();
         int GetCollisionModelID();
         void CreateBushPhysicsShape();
-        void ReceiveASVec3Message( int type, const vec3 &vec_a, const vec3 &vec_b );
+        void ReceiveASVec3Message( int type, const vec3 &vec_a, const vec3 &vec_b ) override;
         void CreateLeaf(vec3 pos, vec3 vel, int iterations);
-        virtual bool SetFromDesc( const EntityDescription& desc );
-        virtual void GetDesc(EntityDescription &desc) const;
-		virtual void UpdateParentHierarchy();
+        bool SetFromDesc( const EntityDescription& desc ) override;
+        void GetDesc(EntityDescription &desc) const override;
+		void UpdateParentHierarchy() override;
         void SetCSGModified();
         typedef std::vector<DetailObjectSurface*> DOSList;
     protected:
-        virtual EntityType GetType() const { return _env_object; }
+        EntityType GetType() const override { return _env_object; }
         DOSList detail_object_surfaces;
 
         vec3 GetDisplayTint();

--- a/Source/Objects/group.h
+++ b/Source/Objects/group.h
@@ -41,35 +41,35 @@ public:
     bool child_moved;
 
     Group();
-    bool Initialize();
-    virtual ~Group();
-    virtual int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0);
-    virtual EntityType GetType() const { return _group; }
-    virtual bool SetFromDesc( const EntityDescription &desc );
-    virtual void PreDrawCamera(float curr_game_time);
-    virtual void PreDrawFrame(float curr_game_time);
-    virtual void Moved(Object::MoveType type);
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual void ChildMoved(Object::MoveType type);
-    virtual void ChildLost(Object *obj);
-    virtual void UpdateParentHierarchy();
-    virtual void PropagateTransformsDown(bool deep);
-    virtual void GetDisplayName(char* buf, int buf_size);
-    virtual void SetEnabled(bool val);
+    bool Initialize() override;
+    ~Group() override;
+    int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0) override;
+    EntityType GetType() const override { return _group; }
+    bool SetFromDesc( const EntityDescription &desc ) override;
+    void PreDrawCamera(float curr_game_time) override;
+    void PreDrawFrame(float curr_game_time) override;
+    void Moved(Object::MoveType type) override;
+    void GetDesc(EntityDescription &desc) const override;
+    void ChildMoved(Object::MoveType type) override;
+    void ChildLost(Object *obj) override;
+    void UpdateParentHierarchy() override;
+    void PropagateTransformsDown(bool deep) override;
+    void GetDisplayName(char* buf, int buf_size) override;
+    void SetEnabled(bool val) override;
 	virtual void InitShape();
 	virtual void InitRelMats();
-	virtual void FinalizeLoadedConnections();
-    virtual void GetChildren(std::vector<Object*>* ret_children);
-    virtual void GetBottomUpCompleteChildren(std::vector<Object*>* ret_children);
-    virtual void GetTopDownCompleteChildren(std::vector<Object*>* ret_children);
+	void FinalizeLoadedConnections() override;
+    void GetChildren(std::vector<Object*>* ret_children) override;
+    void GetBottomUpCompleteChildren(std::vector<Object*>* ret_children) override;
+    void GetTopDownCompleteChildren(std::vector<Object*>* ret_children) override;
     virtual void HandleTransformationOccured();
-    virtual void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args);
-    virtual void Update(float timestep){}
-    virtual void RemapReferences(std::map<int,int> id_map);
-	virtual void SetTranslationRotationFast(const vec3& trans, const quaternion& rotation);
+    void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args) override;
+    void Update(float timestep) override{}
+    void RemapReferences(std::map<int,int> id_map) override;
+	void SetTranslationRotationFast(const vec3& trans, const quaternion& rotation) override;
 	void PropagateTransformsDownFast(bool deep);
 
-    virtual bool IsGroupDerived() const {return true;}
+    bool IsGroupDerived() const override {return true;}
 
-    virtual ObjectSanityState GetSanity();
+    ObjectSanityState GetSanity() override;
 };

--- a/Source/Objects/hotspot.h
+++ b/Source/Objects/hotspot.h
@@ -45,37 +45,37 @@ class HotspotEditor;
 class Hotspot : public Object {
 public:
     Hotspot();
-    virtual ~Hotspot();
+    ~Hotspot() override;
 
-    virtual bool Initialize();
-    virtual void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args );
-    virtual void Update(float timestep);
-    virtual void PreDrawFrame(float curr_game_time);
-    virtual void Draw();
-    virtual void Dispose();
-    virtual void GetDisplayName(char* buf, int buf_size);
-    virtual void DrawImGuiEditor();
-    void GetDesc(EntityDescription &desc) const;
-    virtual void NotifyDeleted(Object* o);
-    virtual EntityType GetType() const { return _hotspot_object; }
+    bool Initialize() override;
+    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) override;
+    void Update(float timestep) override;
+    void PreDrawFrame(float curr_game_time) override;
+    void Draw() override;
+    void Dispose() override;
+    void GetDisplayName(char* buf, int buf_size) override;
+    void DrawImGuiEditor() override;
+    void GetDesc(EntityDescription &desc) const override;
+    void NotifyDeleted(Object* o) override;
+    EntityType GetType() const override { return _hotspot_object; }
 
     std::unique_ptr<ASCollisions> as_collisions;
 
-	void Reset();
-	virtual void SetEnabled(bool val);
+	void Reset() override;
+	void SetEnabled(bool val) override;
 
-    virtual int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal);
+    int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal) override;
 
     inline const std::string& GetScriptFile() const { return m_script_file; }
     inline void SetScriptFile(const std::string& script_file) { m_script_file = script_file; }
 
     void SetBillboardColorMap(const std::string& color_map);
-	virtual void Reload();
-	void Moved(Object::MoveType type);
+	void Reload() override;
+	void Moved(Object::MoveType type) override;
     void HandleEvent( const std::string &event, MovementObject* mo );
     void HandleEventItem( const std::string &event, ItemObject* obj );
-    virtual void SetScriptParams( const ScriptParamMap& spm );
-    virtual void UpdateScriptParams();
+    void SetScriptParams( const ScriptParamMap& spm ) override;
+    void UpdateScriptParams() override;
     std::string GetTypeString();
     bool ASHasVar( const std::string &name );
     int ASGetIntVar( const std::string &name );
@@ -86,18 +86,18 @@ public:
     void ASSetArrayIntVar( const std::string &name, int index, int value );
     void ASSetFloatVar( const std::string &name, float value );
     void ASSetBoolVar( const std::string &name, bool value );
-	virtual bool SetFromDesc( const EntityDescription& desc );
+	bool SetFromDesc( const EntityDescription& desc ) override;
 	void UpdateCollisionShape();
 
     bool AcceptConnectionsFromImplemented();
 
-    virtual bool AcceptConnectionsFrom(ConnectionType type, Object& object);
+    bool AcceptConnectionsFrom(ConnectionType type, Object& object) override;
     virtual bool AcceptConnectionsTo(Object& object);
-    virtual bool ConnectTo(Object& other, bool checking_other = false);
+    bool ConnectTo(Object& other, bool checking_other = false) override;
     virtual bool Disconnect(Object& other, bool checking_other = false);
 
-    virtual void ConnectedFrom(Object& other);
-    virtual void DisconnectedFrom(Object& other);
+    void ConnectedFrom(Object& other) override;
+    void DisconnectedFrom(Object& other) override;
 
     CScriptArray* ASGetConnectedObjects();
 

--- a/Source/Objects/itemobject.h
+++ b/Source/Objects/itemobject.h
@@ -54,31 +54,31 @@ class ItemObjectBloodSurfaceTransformedVertexGetter : public BloodSurface::Trans
 public:
     ItemObjectBloodSurfaceTransformedVertexGetter(ItemObject* p_item_object):
         item_object(p_item_object) {}
-    virtual vec3 GetTransformedVertex(int val);
+    vec3 GetTransformedVertex(int val) override;
 private:
     ItemObject* item_object;
 };
 
 class ItemObject: public Object {
 public:
-    virtual EntityType GetType() const { return _item_object; }
+    EntityType GetType() const override { return _item_object; }
     enum ItemState {
         kWielded, kSheathed, kFree
     };
     
     ItemObject();
-    virtual ~ItemObject();
+    ~ItemObject() override;
     
     void Load(const std::string &item_path);
-    void GetShaderNames(std::map<std::string, int>& preload_shaders);
+    void GetShaderNames(std::map<std::string, int>& preload_shaders) override;
 
-    virtual bool Initialize();
-    virtual void Update(float timestep);
-    virtual void Draw();
-    virtual void PreDrawFrame(float curr_game_time);
-    virtual bool ConnectTo(Object& other, bool checking_other = false);
+    bool Initialize() override;
+    void Update(float timestep) override;
+    void Draw() override;
+    void PreDrawFrame(float curr_game_time) override;
+    bool ConnectTo(Object& other, bool checking_other = false) override;
     virtual bool Disconnect(Object& other, bool checking_other = false);
-    virtual void Moved(Object::MoveType type);
+    void Moved(Object::MoveType type) override;
 
     int model_id() const;
     const ItemRef& item_ref() const;
@@ -114,20 +114,20 @@ public:
     
 	mat4 GetTransform() const; // Returns final transform matix, used in multiplayer
 
-    void Collided( const vec3& pos, float impulse, const CollideInfo &collide_info, BulletObject* object );
-    void GetDesc(EntityDescription &desc) const;
+    void Collided( const vec3& pos, float impulse, const CollideInfo &collide_info, BulletObject* object ) override;
+    void GetDesc(EntityDescription &desc) const override;
     void AddBloodDecal( vec3 pos, vec3 dir, float size );
     void CleanBlood();
-    void Reset();
-    virtual void Dispose();
+    void Reset() override;
+    void Dispose() override;
     void SetHolderID( int char_id );
     void SetThrown();
     void SetThrownStraight();
     void SetState(ItemState state);
     ScriptParams* ASGetScriptParams();
     int HeldByWhom();
-    virtual void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args);
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void ReceiveObjectMessageVAList(OBJECT_MSG::Type type, va_list args) override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     const vec3 & GetColorTint();
     const float& GetOverbright();
     bool CheckThrownSafe() const;
@@ -210,7 +210,7 @@ private:
 
     TimeInterpolator network_time_interpolator;
     
-    virtual void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type);
+    void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type) override;
     virtual void HandleMaterialEvent(const std::string &the_event, const vec3& normal, const vec3 &event_pos, float gain = 1.0f, float pitch_shift = 1.0f);
     
     void MakeBulletObject();

--- a/Source/Objects/lightprobeobject.h
+++ b/Source/Objects/lightprobeobject.h
@@ -31,16 +31,16 @@
 class LightProbeObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _light_probe_object; }
-    virtual bool Initialize();
+    EntityType GetType() const override { return _light_probe_object; }
+    bool Initialize() override;
 
-    virtual void SetScriptParams( const ScriptParamMap& spm );
-    virtual void Moved(Object::MoveType type);
-    virtual void Dispose();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void SetScriptParams( const ScriptParamMap& spm ) override;
+    void Moved(Object::MoveType type) override;
+    void Dispose() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     LightProbeObject();
-    virtual ~LightProbeObject();
+    ~LightProbeObject() override;
 private:
     int probe_id_;
     float *stored_coefficients;

--- a/Source/Objects/lightvolume.h
+++ b/Source/Objects/lightvolume.h
@@ -32,16 +32,16 @@
 class LightVolumeObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _light_volume_object; }
-    virtual bool Initialize();
+    EntityType GetType() const override { return _light_volume_object; }
+    bool Initialize() override;
 
-    virtual void Moved(Object::MoveType type);
-    virtual void Dispose();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void Moved(Object::MoveType type) override;
+    void Dispose() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     LightVolumeObject();
-    void Draw();
-    virtual ~LightVolumeObject();
+    void Draw() override;
+    ~LightVolumeObject() override;
 
     bool dirty;
 };

--- a/Source/Objects/movementobject.h
+++ b/Source/Objects/movementobject.h
@@ -118,7 +118,7 @@ public:
     std::vector<OcclusionState> occlusion_states;
     std::vector<OcclusionQuery> occlusion_queries;
 
-    virtual EntityType GetType() const { return _movement_object; }
+    EntityType GetType() const override { return _movement_object; }
     bool controlled;
     bool remote;
     bool was_controlled;
@@ -174,35 +174,35 @@ public:
     float last_walltime_diff = 0.0f;
 
     MovementObject();
-    virtual ~MovementObject();
+    ~MovementObject() override;
 
-    bool Initialize();
+    bool Initialize() override;
 	bool InitializeMultiplayer();
-    void GetShaderNames(std::map<std::string, int>& shaders);
+    void GetShaderNames(std::map<std::string, int>& shaders) override;
 
-    void Update(float timestep);
-    void Draw();
+    void Update(float timestep) override;
+    void Draw() override;
     void ClientBeforeDraw();
     virtual void HandleTransformationOccured();
-    void PreDrawFrame(float curr_game_time);
+    void PreDrawFrame(float curr_game_time) override;
 
-	virtual void Reload();
+	void Reload() override;
 	void ActualPreDraw(float curr_game_time);
-    virtual void NotifyDeleted(Object* other);
-    virtual bool ConnectTo(Object& other, bool checking_other = false);
-    virtual bool AcceptConnectionsFrom(ConnectionType type, Object& object);
-    virtual bool Disconnect(Object& other, bool from_socket = false, bool checking_other = false);
-    void FinalizeLoadedConnections();
-    void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc(const EntityDescription &desc);
+    void NotifyDeleted(Object* other) override;
+    bool ConnectTo(Object& other, bool checking_other = false) override;
+    bool AcceptConnectionsFrom(ConnectionType type, Object& object) override;
+    bool Disconnect(Object& other, bool from_socket = false, bool checking_other = false) override;
+    void FinalizeLoadedConnections() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc(const EntityDescription &desc) override;
     void ChangeControlScript(const std::string &script_path);
     void CollideWith( MovementObject* other );
     void ASSetScriptUpdatePeriod(int val);
     bool HasFunction(const std::string& function_definition);
     int QueryIntFunction(std::string func);
-    void SetScriptParams( const ScriptParamMap& spm );
+    void SetScriptParams( const ScriptParamMap& spm ) override;
     void ApplyPalette( const OGPalette& palette, bool from_socket = false );
-    OGPalette *GetPalette();
+    OGPalette *GetPalette() override;
     void HitByItem( int id, const vec3 &point, const std::string &material, int type );
     void Execute(std::string);
     float ASGetFloatVar( std::string name );
@@ -214,20 +214,20 @@ public:
     void ASSetArrayIntVar( std::string name, int index, int value );
     void ASSetFloatVar( std::string name, float value );
     void ASSetBoolVar( std::string name, bool value );
-    void Dispose( );
+    void Dispose( ) override;
     bool ASOnSameTeam(MovementObject* other);
     void AttachItemToSlot( int which, AttachmentType type, bool mirrored );
     void AttachItemToSlotEditor( int which, AttachmentType type, bool mirrored, const AttachmentRef& attachment_ref, bool from_socket = false );
     void RemovePhysicsShapes();
     void ReceiveMessage(std::string msg);
-    void UpdateScriptParams();
+    void UpdateScriptParams() override;
     void SetRotationFromFacing(vec3 facing);
-    virtual void GetDisplayName(char* buf, int buf_size);
+    void GetDisplayName(char* buf, int buf_size) override;
     RiggedObject* rigged_object();
 
-    virtual void RemapReferences(std::map<int,int> id_map);
+    void RemapReferences(std::map<int,int> id_map) override;
 
-    virtual void GetConnectionIDs(std::vector<int>* cons);
+    void GetConnectionIDs(std::vector<int>* cons) override;
 
     void UpdatePaused();
     int AboutToBeHitByItem(int id);
@@ -302,9 +302,9 @@ private:
     void ReInitializeASFunctions();
 
 	void RegisterMPCallbacks() const;
-    void Collided( const vec3& pos, float impulse, const CollideInfo &collide_info, BulletObject* object );
-    void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type);
-    void PreDrawCamera(float curr_game_time);
+    void Collided( const vec3& pos, float impulse, const CollideInfo &collide_info, BulletObject* object ) override;
+    void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type) override;
+    void PreDrawCamera(float curr_game_time) override;
     void GoLimp();
     void ApplyForce(vec3 force);
     void Ragdoll();
@@ -327,7 +327,7 @@ private:
     void HandleMaterialEventDefault(std::string the_event, vec3 event_pos);
     void ForceSoundGroupVoice(std::string path, float delay);
     int GetWaypointTarget();
-    void Reset(); 
+    void Reset() override; 
     void SetRotationFromEditorTransform();
     void ASSetCharAnimation(std::string path, float fade_speed, char flags);
     void ASSetCharAnimation(std::string path, float fade_speed);
@@ -337,19 +337,19 @@ private:
     static void InvalidatedItemCallback(ItemObjectScriptReader *invalidated, void* this_ptr);
     void ASDetachAllItems();
     bool OnTeam(const std::string &other_team);
-    virtual void SetEnabled(bool val);
+    void SetEnabled(bool val) override;
     void AttachItemToSlotAttachmentRef( int which, AttachmentType type, bool mirrored, const AttachmentRef* ref, bool from_socket = false );
     void AddToAttackHistory(const std::string &str);
     float CheckAttackHistory( const std::string &str);
     void ClearAttackHistory();
-    virtual void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args );
+    void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) override;
     void OverrideCharAnim(const std::string &label, const std::string &new_path);
     void UpdateWeapons();
-    virtual void Moved(Object::MoveType type);
-    void ChildLost(Object* obj);
-    virtual void GetChildren(std::vector<Object*>* ret_children);
-    virtual void GetBottomUpCompleteChildren(std::vector<Object*>* ret_children);
-    virtual bool IsMultiplayerSupported();
+    void Moved(Object::MoveType type) override;
+    void ChildLost(Object* obj) override;
+    void GetChildren(std::vector<Object*>* ret_children) override;
+    void GetBottomUpCompleteChildren(std::vector<Object*>* ret_children) override;
+    bool IsMultiplayerSupported() override;
     void RegenerateNametag();
     void DrawNametag();
 

--- a/Source/Objects/navmeshconnectionobject.h
+++ b/Source/Objects/navmeshconnectionobject.h
@@ -36,15 +36,15 @@
 class NavmeshConnectionObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _navmesh_connection_object; }
+    EntityType GetType() const override { return _navmesh_connection_object; }
     std::vector<NavMeshConnectionData> connections;
 
     NavmeshConnectionObject();
     
-    virtual bool ConnectTo(Object& other, bool checking_other = false);
-    virtual bool AcceptConnectionsFrom(ConnectionType type, Object& object);
+    bool ConnectTo(Object& other, bool checking_other = false) override;
+    bool AcceptConnectionsFrom(ConnectionType type, Object& object) override;
     virtual bool Disconnect( Object& other, bool checking_other = false );
-    virtual void GetConnectionIDs(std::vector<int>* cons);
+    void GetConnectionIDs(std::vector<int>* cons) override;
 
     void ResetConnectionOffMeshReference();
     void ResetPolyAreaAssignment();
@@ -52,18 +52,18 @@ public:
     void UpdatePolyAreas();
 
     int GetModelID();
-    virtual void NotifyDeleted( Object* o);
-    void GetDesc(EntityDescription &desc) const;
+    void NotifyDeleted( Object* o) override;
+    void GetDesc(EntityDescription &desc) const override;
 
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    bool SetFromDesc( const EntityDescription& desc ) override;
     static void RegisterToScript(ASContext* as_context);
-    virtual void Draw();
-    virtual void Update(float timestep);
-    virtual void FinalizeLoadedConnections();
-    virtual bool Initialize();
+    void Draw() override;
+    void Update(float timestep) override;
+    void FinalizeLoadedConnections() override;
+    bool Initialize() override;
 
-    virtual void Moved(Object::MoveType type);
+    void Moved(Object::MoveType type) override;
 
-    virtual void RemapReferences(std::map<int,int> id_map);
+    void RemapReferences(std::map<int,int> id_map) override;
 
 };

--- a/Source/Objects/navmeshhintobject.h
+++ b/Source/Objects/navmeshhintobject.h
@@ -36,11 +36,11 @@ private:
     std::vector<vec3> cross_marking;
 public:
     NavmeshHintObject();
-    virtual ~NavmeshHintObject();
-    virtual EntityType GetType() const { return _navmesh_hint_object; }
-    virtual bool Initialize();
-    virtual void Draw();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    ~NavmeshHintObject() override;
+    EntityType GetType() const override { return _navmesh_hint_object; }
+    bool Initialize() override;
+    void Draw() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
 };
 

--- a/Source/Objects/navmeshregionobject.h
+++ b/Source/Objects/navmeshregionobject.h
@@ -34,13 +34,13 @@ class NavMesh;
 class NavmeshRegionObject: public Object {
 public:
     NavmeshRegionObject();
-    virtual ~NavmeshRegionObject();
+    ~NavmeshRegionObject() override;
 
-    virtual EntityType GetType() const { return _navmesh_region_object; }
-    virtual bool Initialize();
-    virtual void Draw();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    EntityType GetType() const override { return _navmesh_region_object; }
+    bool Initialize() override;
+    void Draw() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
 
     vec3 GetMinBounds();
     vec3 GetMaxBounds();

--- a/Source/Objects/pathpointobject.h
+++ b/Source/Objects/pathpointobject.h
@@ -35,25 +35,25 @@
 class PathPointObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _path_point_object; }
+    EntityType GetType() const override { return _path_point_object; }
     std::vector<int> connection_ids;
 
     PathPointObject();
     
-    virtual bool ConnectTo(Object& other, bool checking_other = false);
-    virtual bool AcceptConnectionsFrom(ConnectionType type, Object& object);
+    bool ConnectTo(Object& other, bool checking_other = false) override;
+    bool AcceptConnectionsFrom(ConnectionType type, Object& object) override;
     virtual bool Disconnect( Object& other, bool checking_other = false );
-    virtual void GetConnectionIDs(std::vector<int>* cons);
+    void GetConnectionIDs(std::vector<int>* cons) override;
 
     int GetModelID();
-    virtual void NotifyDeleted( Object* o);
-    void GetDesc(EntityDescription &desc) const;
+    void NotifyDeleted( Object* o) override;
+    void GetDesc(EntityDescription &desc) const override;
 
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    bool SetFromDesc( const EntityDescription& desc ) override;
     static void RegisterToScript(ASContext* as_context);
-    virtual void Draw();
-    virtual bool Initialize();
+    void Draw() override;
+    bool Initialize() override;
 
-    virtual void RemapReferences(std::map<int,int> id_map);
+    void RemapReferences(std::map<int,int> id_map) override;
 
 };

--- a/Source/Objects/placeholderobject.h
+++ b/Source/Objects/placeholderobject.h
@@ -35,32 +35,32 @@ public:
         kSpawn, kCamPreview, kPlayerConnect
     };
     PlaceholderObject();
-    virtual ~PlaceholderObject();
-    virtual EntityType GetType() const { return _placeholder_object; }
+    ~PlaceholderObject() override;
+    EntityType GetType() const override { return _placeholder_object; }
     PlaceholderObjectType GetSpecialType();
     void SetSpecialType(PlaceholderObjectType val);
-    virtual bool Initialize();
+    bool Initialize() override;
     void SetPreview(const std::string& path);
     void SetBillboard(const std::string& path);
-    virtual bool AcceptConnectionsFrom(ConnectionType type, Object& object);
-    virtual void Draw();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    bool AcceptConnectionsFrom(ConnectionType type, Object& object) override;
+    void Draw() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     void SetVisible(bool visible);
     bool connectable();
     uint64_t GetConnectToTypeFilterFlags();
     void SetConnectToTypeFilterFlags(uint64_t entity_type_flags);
-    virtual bool ConnectTo( Object& other, bool checking_other = false );
+    bool ConnectTo( Object& other, bool checking_other = false ) override;
     virtual bool Disconnect( Object& other, bool checking_other = false );
-    virtual void GetConnectionIDs(std::vector<int>* cons);
+    void GetConnectionIDs(std::vector<int>* cons) override;
 
     int GetConnectID();
-    virtual void NotifyDeleted( Object* o );
-    virtual void Moved(Object::MoveType type);
+    void NotifyDeleted( Object* o ) override;
+    void Moved(Object::MoveType type) override;
     std::string editor_display_name;
-    virtual void GetDisplayName(char* buf, int buf_size);
+    void GetDisplayName(char* buf, int buf_size) override;
 
-    virtual ObjectSanityState GetSanity();
+    ObjectSanityState GetSanity() override;
 
     bool unsaved_changes;
 private:
@@ -82,5 +82,5 @@ private:
     void DrawEditorLabel();
     void ClearEditorLabel();
 
-    virtual void RemapReferences(std::map<int,int> id_map);
+    void RemapReferences(std::map<int,int> id_map) override;
 };

--- a/Source/Objects/prefab.h
+++ b/Source/Objects/prefab.h
@@ -38,18 +38,18 @@ public:
 
     vec3 original_scale_;
 
-    bool Initialize();
-    virtual EntityType GetType() const { return _prefab; }
+    bool Initialize() override;
+    EntityType GetType() const override { return _prefab; }
 
-    virtual void GetDisplayName(char* buf, int buf_size);
+    void GetDisplayName(char* buf, int buf_size) override;
 
-    virtual bool SetFromDesc( const EntityDescription &desc );
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual void InfrequentUpdate();
+    bool SetFromDesc( const EntityDescription &desc ) override;
+    void GetDesc(EntityDescription &desc) const override;
+    void InfrequentUpdate() override;
 
-    virtual void InitShape();
+    void InitShape() override;
 
-    virtual bool LockedChildren();
+    bool LockedChildren() override;
 
-    virtual ObjectSanityState GetSanity();
+    ObjectSanityState GetSanity() override;
 };

--- a/Source/Objects/reflectioncaptureobject.h
+++ b/Source/Objects/reflectioncaptureobject.h
@@ -33,17 +33,17 @@
 class ReflectionCaptureObject: public Object
 {
 public:
-    virtual EntityType GetType() const { return _reflection_capture_object; }
-    virtual bool Initialize();
+    EntityType GetType() const override { return _reflection_capture_object; }
+    bool Initialize() override;
 
-    virtual void Moved(Object::MoveType type);
-    virtual void Dispose();
-    virtual void GetDesc(EntityDescription &desc) const;
-    virtual bool SetFromDesc( const EntityDescription& desc );
+    void Moved(Object::MoveType type) override;
+    void Dispose() override;
+    void GetDesc(EntityDescription &desc) const override;
+    bool SetFromDesc( const EntityDescription& desc ) override;
     ReflectionCaptureObject();
-    void Draw();
-    virtual ~ReflectionCaptureObject();
-    virtual void GetDisplayName(char* buf, int buf_size);
+    void Draw() override;
+    ~ReflectionCaptureObject() override;
+    void GetDisplayName(char* buf, int buf_size) override;
 
     bool dirty;
     TextureRef cube_map_ref;

--- a/Source/Objects/riggedobject.h
+++ b/Source/Objects/riggedobject.h
@@ -179,7 +179,7 @@ class RiggedTransformedVertexGetter : public BloodSurface::TransformedVertexGett
 public:
     RiggedTransformedVertexGetter(RiggedObject* p_rigged_object):
         rigged_object(p_rigged_object) {}
-    virtual vec3 GetTransformedVertex(int val);
+    vec3 GetTransformedVertex(int val) override;
 private:
     RiggedObject* rigged_object;
 };
@@ -214,7 +214,7 @@ class RiggedObject: public Object {
 		float last_draw_time;
         vec3 ambient_cube_color[6];
         CachedSkeletonInfo cached_skeleton_info_;
-         virtual EntityType GetType() const { return _rigged_object; }
+         EntityType GetType() const override { return _rigged_object; }
         // Textures
         TextureAssetRef stab_texture;
         TextureAssetRef texture_ref;
@@ -307,10 +307,10 @@ class RiggedObject: public Object {
 		vec3 camera_translation;
 
         RiggedObject();
-        virtual ~RiggedObject();
+        ~RiggedObject() override;
 
-        bool Initialize();
-        void Update(float timestep);
+        bool Initialize() override;
+        void Update(float timestep) override;
 
 		
 		// Drawing
@@ -328,13 +328,13 @@ class RiggedObject: public Object {
 		void CalcNoDataInterpStep();
         void StoreNetworkBones();
 		void StoreNetworkMorphTargets();
-        void PreDrawFrame(float curr_game_time);
-        void PreDrawCamera(float curr_game_time);
+        void PreDrawFrame(float curr_game_time) override;
+        void PreDrawCamera(float curr_game_time) override;
         void DrawModel( Model* model, int lod_level );
         void SetASContext(ASContext* _as_context);
 
         std::vector<vec3> * GetPaletteColors();
-        void ApplyPalette( const OGPalette& palette );
+        void ApplyPalette( const OGPalette& palette ) override;
         float GetStatusKeyValue(const std::string &label);
         void Ragdoll(const vec3 &velocity);
         void AddAnimation( std::string path, float weight );
@@ -422,7 +422,7 @@ class RiggedObject: public Object {
         bool DrawBoneConnectUI(Object* objects[], int num_obj_ids, IMUIContext &imui_context, EditorTypes::Tool tool, int id);
         void AddToDesc(EntityDescription &desc);
         void UpdateGPUSkinning();
-        void GetShaderNames(std::map<std::string, int>& shaders);
+        void GetShaderNames(std::map<std::string, int>& shaders) override;
 
         bool GetOnlineIncomingMorphTargetState(MorphTargetStateStorage& dest, const char* name);
     private:  

--- a/Source/Objects/terrainobject.h
+++ b/Source/Objects/terrainobject.h
@@ -42,25 +42,25 @@ class BulletObject;
 class TerrainObject: public Object {
     public:   
         const TerrainInfo& terrain_info() const;
-        virtual EntityType GetType() const { return _terrain_type; }
+        EntityType GetType() const override { return _terrain_type; }
         
         TerrainObject(const TerrainInfo &terrain_info);
-        ~TerrainObject();
-        virtual void HandleMaterialEvent( const std::string &the_event, const vec3 &event_pos, int* tri );
-        virtual void PreDrawCamera(float curr_game_time);
-        virtual void PreDrawFrame(float curr_game_time);
-        virtual void Draw();
-        virtual void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type);
-        virtual int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0);
-        virtual bool Initialize();
-        virtual void GetShaderNames(std::map<std::string, int>& preload_shaders);
-        virtual const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, int* tri );
-        virtual const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, const std::string &mod, int* tri );
-        virtual const MaterialDecal& GetMaterialDecal( const std::string &type, const vec3 &pos, int* tri );
-        virtual const MaterialParticle& GetMaterialParticle( const std::string &type, const vec3 &pos, int* tri );
-        virtual void GetDisplayName(char* buf, int buf_size);
-        virtual MaterialRef GetMaterial( const vec3 &pos, int* tri = NULL );
-        virtual vec3 GetColorAtPoint( const vec3 &pos, int* tri );
+        ~TerrainObject() override;
+        void HandleMaterialEvent( const std::string &the_event, const vec3 &event_pos, int* tri ) override;
+        void PreDrawCamera(float curr_game_time) override;
+        void PreDrawFrame(float curr_game_time) override;
+        void Draw() override;
+        void DrawDepthMap(const mat4& proj_view_matrix, const vec4* cull_planes, int num_cull_planes, Object::DrawType draw_type) override;
+        int lineCheck(const vec3 &start, const vec3 &end, vec3 *point, vec3 *normal=0) override;
+        bool Initialize() override;
+        void GetShaderNames(std::map<std::string, int>& preload_shaders) override;
+        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, int* tri ) override;
+        const MaterialEvent& GetMaterialEvent( const std::string &the_event, const vec3 &event_pos, const std::string &mod, int* tri ) override;
+        const MaterialDecal& GetMaterialDecal( const std::string &type, const vec3 &pos, int* tri ) override;
+        const MaterialParticle& GetMaterialParticle( const std::string &type, const vec3 &pos, int* tri ) override;
+        void GetDisplayName(char* buf, int buf_size) override;
+        MaterialRef GetMaterial( const vec3 &pos, int* tri = NULL ) override;
+        vec3 GetColorAtPoint( const vec3 &pos, int* tri ) override;
         
         void PreparePhysicsMesh();
         const Model* GetModel() const;
@@ -68,7 +68,7 @@ class TerrainObject: public Object {
 
         bool preview_mode;
 
-        virtual void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args );
+        void ReceiveObjectMessageVAList( OBJECT_MSG::Type type, va_list args ) override;
         BulletObject* bullet_object_;
         Terrain terrain_;
 

--- a/Source/Ogda/Builders/builderfactory.h
+++ b/Source/Ogda/Builders/builderfactory.h
@@ -39,17 +39,17 @@ private:
     template<class Action>
     class ActionFactory : public ActionFactoryBase
     {
-        virtual ActionBase* NewInstance()
+        ActionBase* NewInstance() override
         {
             return new Action();
         }
 
-        virtual std::string GetActionName()
+        std::string GetActionName() override
         {
             return std::string(Action().GetName());
         }
 
-        virtual bool StoreResultInDatabase()
+        bool StoreResultInDatabase() override
         {
             return Action().StoreResultInDatabase(); 
         }

--- a/Source/Ogda/Builders/copyaction.h
+++ b/Source/Ogda/Builders/copyaction.h
@@ -29,9 +29,9 @@ class JobHandler;
 
 class CopyAction : public ActionBase {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Item& y);
-        virtual inline const char* GetName() const { return "copy"; }
-        virtual inline const char* GetVersion() const {return "2";}
-        virtual inline bool RunEvenOnIdenticalSource() const { return false; }
-        virtual inline bool StoreResultInDatabase() const { return false; }
+        ManifestResult Run(const JobHandler& jh, const Item& y) override;
+        inline const char* GetName() const override { return "copy"; }
+        inline const char* GetVersion() const override {return "2";}
+        inline bool RunEvenOnIdenticalSource() const override { return false; }
+        inline bool StoreResultInDatabase() const override { return false; }
 };

--- a/Source/Ogda/Builders/crunchaction.h
+++ b/Source/Ogda/Builders/crunchaction.h
@@ -29,9 +29,9 @@ class JobHandler;
 
 class CrunchAction : public ActionBase {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Item& y);
-        virtual inline const char* GetName() const { return "crunch"; }
-        virtual inline const char* GetVersion() const {return "1";}
-        virtual inline bool RunEvenOnIdenticalSource() const { return false; }
-        virtual inline bool StoreResultInDatabase() const { return true; }
+        ManifestResult Run(const JobHandler& jh, const Item& y) override;
+        inline const char* GetName() const override { return "crunch"; }
+        inline const char* GetVersion() const override {return "1";}
+        inline bool RunEvenOnIdenticalSource() const override { return false; }
+        inline bool StoreResultInDatabase() const override { return true; }
 };

--- a/Source/Ogda/Builders/dxt5action.h
+++ b/Source/Ogda/Builders/dxt5action.h
@@ -29,9 +29,9 @@ class JobHandler;
 
 class DXT5Action : public ActionBase {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Item& y);
-        virtual inline const char* GetName() const { return "dxt5"; }
-        virtual inline const char* GetVersion() const {return "6";}
-        virtual inline bool RunEvenOnIdenticalSource() const { return false; }
-        virtual inline bool StoreResultInDatabase() const { return true; }
+        ManifestResult Run(const JobHandler& jh, const Item& y) override;
+        inline const char* GetName() const override { return "dxt5"; }
+        inline const char* GetVersion() const override {return "6";}
+        inline bool RunEvenOnIdenticalSource() const override { return false; }
+        inline bool StoreResultInDatabase() const override { return true; }
 };

--- a/Source/Ogda/Builders/voidaction.h
+++ b/Source/Ogda/Builders/voidaction.h
@@ -31,9 +31,9 @@ class JobHandler;
 class VoidAction : public ActionBase
 {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Item& y);
-        virtual inline const char* GetName() const { return "void"; }
-        virtual inline const char* GetVersion() const {return "2";}
-        virtual inline bool RunEvenOnIdenticalSource() const { return true; }
-        virtual inline bool StoreResultInDatabase() const { return false; }
+        ManifestResult Run(const JobHandler& jh, const Item& y) override;
+        inline const char* GetName() const override { return "void"; }
+        inline const char* GetVersion() const override {return "2";}
+        inline bool RunEvenOnIdenticalSource() const override { return true; }
+        inline bool StoreResultInDatabase() const override { return false; }
 };

--- a/Source/Ogda/Generators/generatorfactory.h
+++ b/Source/Ogda/Generators/generatorfactory.h
@@ -39,12 +39,12 @@ private:
     template<class Creator>
     class CreatorFactory : public CreatorFactoryBase
     {
-        virtual CreatorBase* NewInstance()
+        CreatorBase* NewInstance() override
         {
             return new Creator();
         }
 
-        virtual std::string GetCreatorName()
+        std::string GetCreatorName() override
         {
             return std::string(Creator().GetName());
         }

--- a/Source/Ogda/Generators/levellistcreator.h
+++ b/Source/Ogda/Generators/levellistcreator.h
@@ -30,7 +30,7 @@ class JobHandler;
 class LevelListCreator : public CreatorBase
 {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Manifest& manifest);
-        virtual inline const char* GetName() const { return "levellist"; }
-        virtual inline const char* GetVersion() const {return "1";}
+        ManifestResult Run(const JobHandler& jh, const Manifest& manifest) override;
+        inline const char* GetName() const override { return "levellist"; }
+        inline const char* GetVersion() const override {return "1";}
 };

--- a/Source/Ogda/Generators/shortversioncreator.h
+++ b/Source/Ogda/Generators/shortversioncreator.h
@@ -30,7 +30,7 @@ class JobHandler;
 class ShortVersionCreator : public CreatorBase
 {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Manifest& manifest);
-        virtual inline const char* GetName() const { return "shortversion"; }
-        virtual inline const char* GetVersion() const {return "1";}
+        ManifestResult Run(const JobHandler& jh, const Manifest& manifest) override;
+        inline const char* GetName() const override { return "shortversion"; }
+        inline const char* GetVersion() const override {return "1";}
 };

--- a/Source/Ogda/Generators/versionxmlcreator.h
+++ b/Source/Ogda/Generators/versionxmlcreator.h
@@ -30,7 +30,7 @@ class JobHandler;
 class VersionXMLCreator : public CreatorBase
 {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Manifest& manifest);
-        virtual inline const char* GetName() const { return "versionxml"; }
-        virtual inline const char* GetVersion() const {return "1";}
+        ManifestResult Run(const JobHandler& jh, const Manifest& manifest) override;
+        inline const char* GetName() const override { return "versionxml"; }
+        inline const char* GetVersion() const override {return "1";}
 };

--- a/Source/Ogda/Generators/voidcreator.h
+++ b/Source/Ogda/Generators/voidcreator.h
@@ -30,7 +30,7 @@ class JobHandler;
 class VoidCreator : public CreatorBase
 {
     public:
-        virtual ManifestResult Run(const JobHandler& jh, const Manifest& manifest);
-        virtual inline const char* GetName() const { return "void"; }
-        virtual inline const char* GetVersion() const {return "1";}
+        ManifestResult Run(const JobHandler& jh, const Manifest& manifest) override;
+        inline const char* GetName() const override { return "void"; }
+        inline const char* GetVersion() const override {return "1";}
 };

--- a/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.h
+++ b/Source/Ogda/Searchers/Seekers/actorobjectlevelseeker.h
@@ -30,9 +30,9 @@ class ActorObjectLevelSeeker : public LevelSeekerBase
 {
 public:
     virtual void SearchGroup( std::vector<Item>& items, const Item& item, TiXmlElement* root );
-    virtual std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot );
+    std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "actor_object_level_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/actorseeker.h
+++ b/Source/Ogda/Searchers/Seekers/actorseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class ActorSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "actor_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/ambientsoundlevelseeker.h
+++ b/Source/Ogda/Searchers/Seekers/ambientsoundlevelseeker.h
@@ -29,9 +29,9 @@ class TiXmlElement;
 class AmbientSoundLevelSeeker : public LevelSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot );
+    std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "ambient_sound_level_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/animationretargetseeker.h
+++ b/Source/Ogda/Searchers/Seekers/animationretargetseeker.h
@@ -30,10 +30,10 @@ class JobHandler;
 class AnimationRetargetSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
-    virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
+    void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "animation_retarget_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/attackseeker.h
+++ b/Source/Ogda/Searchers/Seekers/attackseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class AttackSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "attack_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/characterseeker.h
+++ b/Source/Ogda/Searchers/Seekers/characterseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class CharacterSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "character_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/decalseeker.h
+++ b/Source/Ogda/Searchers/Seekers/decalseeker.h
@@ -29,9 +29,9 @@ class TiXmlHandle;
 class DecalSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item& item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item& item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "decal_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/hotspotseeker.h
+++ b/Source/Ogda/Searchers/Seekers/hotspotseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class HotspotSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "hotspot_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/itemseeker.h
+++ b/Source/Ogda/Searchers/Seekers/itemseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class ItemSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
-    virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );
-    virtual inline const char* GetName()
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
+    void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata ) override;
+    inline const char* GetName() override
     {
         return "item_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/jsonseekerbase.h
+++ b/Source/Ogda/Searchers/Seekers/jsonseekerbase.h
@@ -34,6 +34,6 @@ namespace Json
 class JSONSeekerBase : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search(const Item& item);
+    std::vector<Item> Search(const Item& item) override;
     virtual std::vector<Item> SearchJSON(const Item & item, Json::Value& root ) = 0;
 };

--- a/Source/Ogda/Searchers/Seekers/levelnormseeker.h
+++ b/Source/Ogda/Searchers/Seekers/levelnormseeker.h
@@ -27,8 +27,8 @@
 class LevelNormSeeker : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search(const Item& item );
-    virtual const char* GetName()
+    std::vector<Item> Search(const Item& item ) override;
+    const char* GetName() override
     {
         return "level_norm_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/levelseekerbase.h
+++ b/Source/Ogda/Searchers/Seekers/levelseekerbase.h
@@ -28,6 +28,6 @@ class TiXmlHandle;
 
 class LevelSeekerBase : public XMLSeekerBase
 {
-    virtual std::vector<Item> SearchXML( const Item& item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item& item, TiXmlDocument& doc ) override;
     virtual std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot ) = 0;
 };

--- a/Source/Ogda/Searchers/Seekers/materialseeker.h
+++ b/Source/Ogda/Searchers/Seekers/materialseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class MaterialSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
-    virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );
-    virtual inline const char* GetName()
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
+    void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata ) override;
+    inline const char* GetName() override
     {
         return "material_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/objcolseeker.h
+++ b/Source/Ogda/Searchers/Seekers/objcolseeker.h
@@ -27,8 +27,8 @@
 class ObjColSeeker : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search( const Item& item );
-    virtual const char* GetName()
+    std::vector<Item> Search( const Item& item ) override;
+    const char* GetName() override
     {
         return "objcol_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/objectseeker.h
+++ b/Source/Ogda/Searchers/Seekers/objectseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class ObjectSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "object_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/objhullseeker.h
+++ b/Source/Ogda/Searchers/Seekers/objhullseeker.h
@@ -27,8 +27,8 @@
 class ObjHullSeeker : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search(const Item& item );
-    virtual const char* GetName()
+    std::vector<Item> Search(const Item& item ) override;
+    const char* GetName() override
     {
         return "objhull_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/particleseeker.h
+++ b/Source/Ogda/Searchers/Seekers/particleseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class ParticleSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
-    virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );
-    virtual inline const char* GetName()
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
+    void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata ) override;
+    inline const char* GetName() override
     {
         return "particle_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/preconvertedddsshadowseeker.h
+++ b/Source/Ogda/Searchers/Seekers/preconvertedddsshadowseeker.h
@@ -29,9 +29,9 @@ class JobHandler;
 class PreConvertedDDSSeeker : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search( const Item& item );
+    std::vector<Item> Search( const Item& item ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "pre_converted_dds_shadow";
     }

--- a/Source/Ogda/Searchers/Seekers/prefabseeker.h
+++ b/Source/Ogda/Searchers/Seekers/prefabseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class PrefabSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
-    virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );
-    virtual inline const char* GetName()
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
+    void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata ) override;
+    inline const char* GetName() override
     {
         return "prefab_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/skeletonseeker.h
+++ b/Source/Ogda/Searchers/Seekers/skeletonseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class SkeletonSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "skeleton_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/skylevelseeker.h
+++ b/Source/Ogda/Searchers/Seekers/skylevelseeker.h
@@ -29,9 +29,9 @@ class TiXmlElement;
 class SkyLevelSeeker : public LevelSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot );
+    std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "sky_level_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/spawnerlistseeker.h
+++ b/Source/Ogda/Searchers/Seekers/spawnerlistseeker.h
@@ -32,6 +32,6 @@ namespace Json
 class SpawnerListSeeker : public JSONSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchJSON( const Item & item, Json::Value& root );
-    virtual const char* GetName() { return "spawner_list_seeker"; }
+    std::vector<Item> SearchJSON( const Item & item, Json::Value& root ) override;
+    const char* GetName() override { return "spawner_list_seeker"; }
 };

--- a/Source/Ogda/Searchers/Seekers/syncedanimationgroupseeker.h
+++ b/Source/Ogda/Searchers/Seekers/syncedanimationgroupseeker.h
@@ -30,9 +30,9 @@ class JobHandler;
 class SyncedAnimationGroupSeeker : public XMLSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc );
+    std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "synced_animation_group_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/terrainlevelseeker.h
+++ b/Source/Ogda/Searchers/Seekers/terrainlevelseeker.h
@@ -29,9 +29,9 @@ class TiXmlElement;
 class TerrainLevelSeeker : public LevelSeekerBase
 {
 public:
-    virtual std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot );
+    std::vector<Item> SearchLevelRoot( const Item& item, TiXmlHandle& hRoot ) override;
 
-    virtual inline const char* GetName()
+    inline const char* GetName() override
     {
         return "terrain_level_seeker";
     }

--- a/Source/Ogda/Searchers/Seekers/voidseeker.h
+++ b/Source/Ogda/Searchers/Seekers/voidseeker.h
@@ -30,8 +30,8 @@ class JobHandler;
 class VoidSeeker : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search( const Item& item );
-    virtual inline const char* GetName()
+    std::vector<Item> Search( const Item& item ) override;
+    inline const char* GetName() override
     {
         return "void";
     }

--- a/Source/Ogda/Searchers/Seekers/xmlseekerbase.h
+++ b/Source/Ogda/Searchers/Seekers/xmlseekerbase.h
@@ -34,7 +34,7 @@ class JobHandler;
 class XMLSeekerBase : public SeekerBase
 {
 public:
-    virtual std::vector<Item> Search( const Item& item );
+    std::vector<Item> Search( const Item& item ) override;
     virtual std::vector<Item> SearchXML( const Item & item, TiXmlDocument& doc ) = 0;
 
     virtual void HandleElementCallback( std::vector<Item>& items, TiXmlNode* eRoot, TiXmlElement* eElem, const Item& item, void* userdata );

--- a/Source/Ogda/Searchers/searcherfactory.h
+++ b/Source/Ogda/Searchers/searcherfactory.h
@@ -37,12 +37,12 @@ private:
     template<class Seeker>
     class SeekerFactory : public SeekerFactoryBase
     {
-        virtual SeekerBase* NewInstance()
+        SeekerBase* NewInstance() override
         {
             return new Seeker();
         }
 
-        virtual std::string GetSeekerName()
+        std::string GetSeekerName() override
         {
             return std::string(Seeker().GetName());
         }

--- a/Source/Physics/bulletcollision.h
+++ b/Source/Physics/bulletcollision.h
@@ -60,7 +60,7 @@ public:
                              int index0,
                              const btCollisionObjectWrapper* colObj1Wrap,
                              int partId1,
-                             int index1);
+                             int index1) override;
 };
 
 typedef std::map<BulletObject*, std::vector<int> > TriListResults;
@@ -77,7 +77,7 @@ public:
         int index0,
         const btCollisionObjectWrapper* colObj1Wrap,
         int partId1,
-        int index1);
+        int index1) override;
 };
 
 class MeshCollisionCallback: public btCollisionWorld::ContactResultCallback {
@@ -91,7 +91,7 @@ public:
         int index0,
         const btCollisionObjectWrapper* colObj1Wrap,
         int partId1,
-        int index1);
+        int index1) override;
 };
 
 struct ContactInfo {
@@ -110,7 +110,7 @@ public:
         int index0,
         const btCollisionObjectWrapper* colObj1Wrap,
         int partId1,
-        int index1);
+        int index1) override;
 };
 
 class RayContactInfoCallback: public btCollisionWorld::ContactResultCallback {
@@ -122,7 +122,7 @@ public:
         int index0,
         const btCollisionObjectWrapper* colObj1Wrap,
         int partId1,
-        int index1);
+        int index1) override;
 };
 
 class SweptSlideCallback: public btCollisionWorld::ConvexResultCallback {
@@ -138,7 +138,7 @@ public:
     {}
 
     btScalar addSingleResult(btCollisionWorld::LocalConvexResult& convexResult, 
-                             bool normalInWorldSpace);
+                             bool normalInWorldSpace) override;
 };
 
 struct RayContactInfo {
@@ -152,14 +152,14 @@ struct    SimpleRayResultCallbackInfo : public btCollisionWorld::RayResultCallba
 {    
     btAlignedObjectArray<RayContactInfo> contact_info;
     btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult,
-        bool normalInWorldSpace);
+        bool normalInWorldSpace) override;
 };
 
 struct    SimpleRayResultCallback : public btCollisionWorld::RayResultCallback
 {    
     vec3 m_hit_normal;
     btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult,
-        bool normalInWorldSpace);
+        bool normalInWorldSpace) override;
 
     const vec3 &GetHitNormal();
 };
@@ -171,7 +171,7 @@ struct    SimpleRayTriResultCallback : public btCollisionWorld::RayResultCallbac
     vec3 m_hit_pos;
     BulletObject* m_object;
     btScalar addSingleResult(btCollisionWorld::LocalRayResult& rayResult,
-        bool normalInWorldSpace);
+        bool normalInWorldSpace) override;
 
     const vec3 &GetHitNormal();
 };

--- a/Source/Physics/bulletworld.cpp
+++ b/Source/Physics/bulletworld.cpp
@@ -1241,7 +1241,7 @@ struct    BinaryContactCallback : public btCollisionWorld::ContactResultCallback
                              int index0,
                              const btCollisionObjectWrapper* colObjWrap1,
                              int partId1,
-                             int index1) 
+                             int index1) override 
     {
         if(cp.getDistance() < 0.0f){ 
             hit_something = true;

--- a/Source/Scripting/angelscript/add_on/scriptstdstring/scriptstdstring.cpp
+++ b/Source/Scripting/angelscript/add_on/scriptstdstring/scriptstdstring.cpp
@@ -32,14 +32,14 @@ class CStdStringFactory : public asIStringFactory
 {
 public:
 	CStdStringFactory() {}
-	~CStdStringFactory() 
+	~CStdStringFactory() override 
 	{
 		// The script engine must release each string 
 		// constant that it has requested
 		assert(stringCache.size() == 0);
 	}
 
-	const void *GetStringConstant(const char *data, asUINT length)
+	const void *GetStringConstant(const char *data, asUINT length) override
 	{
 		string str(data, length);
 		map_t::iterator it = stringCache.find(str);
@@ -51,7 +51,7 @@ public:
 		return reinterpret_cast<const void*>(&it->first);
 	}
 
-	int  ReleaseStringConstant(const void *str)
+	int  ReleaseStringConstant(const void *str) override
 	{
 		if (str == 0)
 			return asERROR;
@@ -66,7 +66,7 @@ public:
 		return asSUCCESS;
 	}
 
-	int  GetRawStringData(const void *str, char *data, asUINT *length) const
+	int  GetRawStringData(const void *str, char *data, asUINT *length) const override
 	{
 		if (str == 0)
 			return asERROR;

--- a/Source/Scripting/angelscript/asdebugger.h
+++ b/Source/Scripting/angelscript/asdebugger.h
@@ -44,7 +44,7 @@ private:
     };
 public:
     ASDebugger();
-    ~ASDebugger();
+    ~ASDebugger() override;
 
     void SetModule(ASModule* module);
 
@@ -52,7 +52,7 @@ public:
 
     void Break();
 
-    void LineCallback(asIScriptContext* ctx);
+    void LineCallback(asIScriptContext* ctx) override;
 
     void ToggleBreakpoint(const char* file_name, int line);
     void AddBreakpoint(const char* file_name, int line);

--- a/Source/Scripting/angelscript/asmodule.cpp
+++ b/Source/Scripting/angelscript/asmodule.cpp
@@ -248,11 +248,11 @@ class CBytecodeStream : public asIBinaryStream {
 public:
     CBytecodeStream(FILE *fp) : f(fp) {}
 
-    int Write(const void *ptr, asUINT size) {
+    int Write(const void *ptr, asUINT size) override {
         if( size == 0 ) return -1;
         return fwrite(ptr, size, 1, f);
     }
-    int Read(void *ptr, asUINT size) {
+    int Read(void *ptr, asUINT size) override {
         if( size == 0 ) return - 1;
         return fread(ptr, size, 1, f);
     }

--- a/Source/Sound/Loader/ogg_loader.h
+++ b/Source/Sound/Loader/ogg_loader.h
@@ -47,15 +47,15 @@ private:
 
 public:
     oggLoader(Path rel_path);
-    virtual ~oggLoader();
+    ~oggLoader() override;
 
-    virtual int stream_buffer_int16(char *buffer, int size);
-    virtual unsigned long get_sample_count();
-    virtual unsigned long get_channels();
-    virtual int get_sample_rate();
-    virtual int rewind();
-    virtual bool is_at_end();
+    int stream_buffer_int16(char *buffer, int size) override;
+    unsigned long get_sample_count() override;
+    unsigned long get_channels() override;
+    int get_sample_rate() override;
+    int rewind() override;
+    bool is_at_end() override;
 
-    virtual int64_t get_pcm_pos();
-    virtual void    set_pcm_pos( int64_t pos );
+    int64_t get_pcm_pos() override;
+    void    set_pcm_pos( int64_t pos ) override;
 };

--- a/Source/Sound/Loader/void_loader.h
+++ b/Source/Sound/Loader/void_loader.h
@@ -28,15 +28,15 @@ class voidLoader : public baseLoader
 {
 public:
     voidLoader();
-    virtual ~voidLoader();
+    ~voidLoader() override;
 
-    virtual int stream_buffer_int16(char *buffer, int size);
-    virtual unsigned long get_sample_count();
-    virtual unsigned long get_channels();
-    virtual int get_sample_rate();
-    virtual int rewind();
-    virtual bool is_at_end();
+    int stream_buffer_int16(char *buffer, int size) override;
+    unsigned long get_sample_count() override;
+    unsigned long get_channels() override;
+    int get_sample_rate() override;
+    int rewind() override;
+    bool is_at_end() override;
 
-    virtual int64_t get_pcm_pos();
-    virtual void    set_pcm_pos( int64_t pos );
+    int64_t get_pcm_pos() override;
+    void    set_pcm_pos( int64_t pos ) override;
 };

--- a/Source/Sound/al_audio.cpp
+++ b/Source/Sound/al_audio.cpp
@@ -70,52 +70,52 @@ public:
         m_priority(_priority)
     {flags_ = flags;}
 
-    ~StaticEmitter()
+    ~StaticEmitter() override
     {}
 
-    virtual bool KeepPlaying() {
+    bool KeepPlaying() override {
         return m_looping?false:true;
     }
 
-    virtual bool GetPosition(vec3 &p) {
+    bool GetPosition(vec3 &p) override {
         p = m_position;
         return ((flags_ & SoundFlags::kRelative) != 0);
     }
 
-    virtual const vec3 GetPosition() {
+    const vec3 GetPosition() override {
         return m_position;
     }
 
-    virtual const vec3 GetOcclusionPosition() {
+    const vec3 GetOcclusionPosition() override {
         return m_occlusion_position;
     }
 
-    virtual float GetMaxDistance() {
+    float GetMaxDistance() override {
         return m_max_distance;
     }
 
-    virtual void GetDirection(vec3 &p)    {
+    void GetDirection(vec3 &p) override    {
         p.x() = 0.0f; p.y() = 0.0f; p.z() = 0.0f;
         return;
     }
 
-    virtual const vec3& GetVelocity() {
+    const vec3& GetVelocity() override {
         return m_velocity;
     }
 
-    virtual float GetVolume() {
+    float GetVolume() override {
         return m_volume * m_volume_mult;
     }
 
-    virtual float GetPitchMultiplier() {
+    float GetPitchMultiplier() override {
         return m_pitch_mul;
     }
 
-    virtual void SetPitchMultiplier(float mul) {
+    void SetPitchMultiplier(float mul) override {
         m_pitch_mul = mul;
     }
 
-    virtual void SetVolume(float mul) {
+    void SetVolume(float mul) override {
         if( mul > 1.0f ) 
             mul = 1.0f;
         if( mul < 0.0f )
@@ -124,28 +124,28 @@ public:
         m_volume = mul;
     }
 
-    virtual void SetVolumeMult(float mul) {
+    void SetVolumeMult(float mul) override {
         m_volume_mult = mul;
     }
 
-    virtual void SetPosition(const vec3 &pos) {
+    void SetPosition(const vec3 &pos) override {
         m_position = pos;
     }
 
-    virtual void SetOcclusionPosition(const vec3 &pos) {
+    void SetOcclusionPosition(const vec3 &pos) override {
         m_occlusion_position = pos;
     }
 
-    virtual void SetVelocity(const vec3 &vel) {
+    void SetVelocity(const vec3 &vel) override {
         m_velocity = vel;
     }
 
-    virtual void Unsubscribe() {
+    void Unsubscribe() override {
         // should call the audioEmitter destructor, all should be cleaned.
         delete this;
     }
 
-    virtual unsigned char GetPriority() {
+    unsigned char GetPriority() override {
         return m_priority;
     }
 

--- a/Source/Sound/al_audio.h
+++ b/Source/Sound/al_audio.h
@@ -68,8 +68,8 @@ public:
 class SimpleFIRFilter : public AudioFilter {
     std::vector<float> filter;
 public:
-    bool Load(const std::string &path);
-    void Apply( AudioBufferData &abd, std::vector<int16_t> *output_new = NULL);
+    bool Load(const std::string &path) override;
+    void Apply( AudioBufferData &abd, std::vector<int16_t> *output_new = NULL) override;
 };
 
 /*
@@ -149,7 +149,7 @@ class audioStreamer : public AudioEmitter
 {
 public:
     audioStreamer();
-    virtual ~audioStreamer();    
+    ~audioStreamer() override;    
 
     /// Request to fill a buffer with data
     virtual void update(rc_alAudioBuffer buffer) = 0;
@@ -264,12 +264,12 @@ public:
 
     public:
         staticLink(rc_alAudioSource source, AudioEmitter &emitter, rc_alAudioBuffer buffer, const SoundPlayInfo& spi);
-        ~staticLink();
+        ~staticLink() override;
 
-        void update(float timestep,unsigned int current_tick);
-        void update_position();
-        void stop();
-        virtual AudioEmitter *get_audioEmitter() {return m_emitter;}
+        void update(float timestep,unsigned int current_tick) override;
+        void update_position() override;
+        void stop() override;
+        AudioEmitter *get_audioEmitter() override {return m_emitter;}
     };
 
 
@@ -285,15 +285,15 @@ public:
 
     public:
         streamerLink(rc_alAudioSource source, audioStreamer &streamer);
-        ~streamerLink();
+        ~streamerLink() override;
 
-        void update(float timestep, unsigned int current_tick);
+        void update(float timestep, unsigned int current_tick) override;
         void update(rc_alAudioBuffer buffer);
-        void update_position();
-        void stop();
+        void update_position() override;
+        void stop() override;
 
         rc_alAudioSource get_source() {return m_source;}
-        virtual AudioEmitter *get_audioEmitter() {return m_streamer;}
+        AudioEmitter *get_audioEmitter() override {return m_streamer;}
     };
 
     typedef std::map<AudioEmitter *, basicLink *> streamer_subscribers;

--- a/Source/Sound/ambient_sound.h
+++ b/Source/Sound/ambient_sound.h
@@ -30,26 +30,26 @@ public:
     ambientSound(float volume = 1.0f);
 
     /// Set to false to allow the emitter to time out (useful only on non-looping sounds)
-    virtual bool KeepPlaying();
+    bool KeepPlaying() override;
     /// if true is returned, this will be a relative-to-listener sound
-    virtual bool GetPosition(vec3 &p);
-    virtual const vec3 GetPosition();
-    virtual const vec3 GetOcclusionPosition();
-    virtual void GetDirection(vec3 &p);
-    virtual const vec3& GetVelocity();
+    bool GetPosition(vec3 &p) override;
+    const vec3 GetPosition() override;
+    const vec3 GetOcclusionPosition() override;
+    void GetDirection(vec3 &p) override;
+    const vec3& GetVelocity() override;
 
     /// allows you to change the global alAudio pitch multiplier for this sound
-    virtual float GetPitchMultiplier();
+    float GetPitchMultiplier() override;
 
     /// allows you to change the global alAudio gain multiplier for this sound
-    virtual float GetVolume();
+    float GetVolume() override;
 
     /// Indicate the priority of this effect to make room for newer/higher priority effects
-    virtual unsigned char GetPriority();
+    unsigned char GetPriority() override;
 
-    void SetVolume(float volume);
+    void SetVolume(float volume) override;
     void SetPitch(float pitch);
-    virtual bool IsTransient() { return false; }
+    bool IsTransient() override { return false; }
 
 private:
     float m_volume;

--- a/Source/Sound/soundtrack.h
+++ b/Source/Sound/soundtrack.h
@@ -65,7 +65,7 @@ class PlayedSongInterface : public PlayedInterface
 public:
     PlayedSongInterface( Soundtrack* _owner );
     PlayedSongInterface( Soundtrack* _owner, const MusicXMLParser::Song& song);
-    virtual ~PlayedSongInterface() {};
+    ~PlayedSongInterface() override {};
 
     virtual void Rewind() = 0;
     virtual bool IsAtEnd() = 0;
@@ -92,18 +92,18 @@ private:
     public:
         PlayedSegment( Soundtrack* _owner );
         PlayedSegment( Soundtrack* _owner, const MusicXMLParser::Segment& segment, bool overlapped_transition );
-        virtual ~PlayedSegment() {};
-        void update( HighResBufferSegment* buffer );
+        ~PlayedSegment() override {};
+        void update( HighResBufferSegment* buffer ) override;
         const MusicXMLParser::Segment& GetSegment();
         bool IsAtEnd();
         void Rewind();
 
-        int64_t  GetPCMPos();
-        void SetPCMPos( int64_t pos );
-        int64_t GetPCMCount();
+        int64_t  GetPCMPos() override;
+        void SetPCMPos( int64_t pos ) override;
+        int64_t GetPCMCount() override;
     
-        int SampleRate();
-        int Channels();
+        int SampleRate() override;
+        int Channels() override;
 
         const std::string GetSegmentName() const;
     private:
@@ -118,25 +118,25 @@ private:
     {
     public:
         PlayedSegmentedSong( Soundtrack* _owner, const MusicXMLParser::Song& _song );
-        virtual ~PlayedSegmentedSong( );
-        void update( HighResBufferSegment* buffer );
+        ~PlayedSegmentedSong( ) override;
+        void update( HighResBufferSegment* buffer ) override;
         bool QueueSegment( const MusicXMLParser::Segment& nextSeg );
         bool TransitionIntoSegment( const MusicXMLParser::Segment& newSeg );
         bool SetSegment( const MusicXMLParser::Segment& nextSeg );
 
-        bool IsAtEnd();
-        void Rewind();
-        int SampleRate();
-        int Channels();
+        bool IsAtEnd() override;
+        void Rewind() override;
+        int SampleRate() override;
+        int Channels() override;
 
-        void SetGain(float v);
-        float GetGain();
+        void SetGain(float v) override;
+        float GetGain() override;
 
         const std::string GetSegmentName() const;
 
-        void SetPCMPos( int64_t c );
-        int64_t GetPCMPos();
-        int64_t GetPCMCount();
+        void SetPCMPos( int64_t c ) override;
+        int64_t GetPCMPos() override;
+        int64_t GetPCMCount() override;
 
         friend bool operator==( const Soundtrack::PlayedSegmentedSong &lhs, const Soundtrack::PlayedSegmentedSong &rhs );
     private:
@@ -152,20 +152,20 @@ private:
     public:
         PlayedSingleSong( Soundtrack* _owner );
         PlayedSingleSong( Soundtrack* _owner, const MusicXMLParser::Song& song );
-        virtual ~PlayedSingleSong() {};
-        void update( HighResBufferSegment* buffer );
-        bool IsAtEnd();
-        void Rewind();
+        ~PlayedSingleSong() override {};
+        void update( HighResBufferSegment* buffer ) override;
+        bool IsAtEnd() override;
+        void Rewind() override;
 
-        int64_t  GetPCMPos();
-        void SetPCMPos( int64_t pos );
-        int64_t GetPCMCount();
+        int64_t  GetPCMPos() override;
+        void SetPCMPos( int64_t pos ) override;
+        int64_t GetPCMCount() override;
 
-        void SetGain(float v);
-        float GetGain();
+        void SetGain(float v) override;
+        float GetGain() override;
     
-        int SampleRate();
-        int Channels();
+        int SampleRate() override;
+        int Channels() override;
     private:
         rc_baseLoader data;
     public:
@@ -184,20 +184,20 @@ private:
     public:
         PlayedLayeredSong( Soundtrack* _owner );
         PlayedLayeredSong( Soundtrack* _owner, const MusicXMLParser::Song& song );
-        virtual ~PlayedLayeredSong();
-        void update( HighResBufferSegment* buffer );
-        bool IsAtEnd();
-        void Rewind();
+        ~PlayedLayeredSong() override;
+        void update( HighResBufferSegment* buffer ) override;
+        bool IsAtEnd() override;
+        void Rewind() override;
 
-        int64_t  GetPCMPos();
-        void SetPCMPos( int64_t pos );
-        int64_t GetPCMCount();
+        int64_t  GetPCMPos() override;
+        void SetPCMPos( int64_t pos ) override;
+        int64_t GetPCMCount() override;
 
-        void SetGain(float v);
-        float GetGain();
+        void SetGain(float v) override;
+        float GetGain() override;
     
-        int SampleRate();
-        int Channels();
+        int SampleRate() override;
+        int Channels() override;
 
         //Specialized
         bool SetLayerGain(const std::string& name, float gain);
@@ -218,9 +218,9 @@ private:
     {
     public:
         TransitionPlayer(Soundtrack* _owner);
-        virtual ~TransitionPlayer();
+        ~TransitionPlayer() override;
 
-        void update( HighResBufferSegment* buffer );
+        void update( HighResBufferSegment* buffer ) override;
         void SetTransitionPeriod( float sec );
         
         bool TransitionToSong( const MusicXMLParser::Song& nextSong );
@@ -236,12 +236,12 @@ private:
         std::vector<std::string> GetLayerNames() const;
         const std::map<std::string,float> GetLayerGains();
 
-        void SetPCMPos( int64_t c );
-        int64_t GetPCMPos();
-        int64_t GetPCMCount();
+        void SetPCMPos( int64_t c ) override;
+        int64_t GetPCMPos() override;
+        int64_t GetPCMCount() override;
 
-        virtual int SampleRate();
-        virtual int Channels();
+        int SampleRate() override;
+        int Channels() override;
 
         const std::string GetSongName() const;
         const std::string GetSongType() const;
@@ -280,36 +280,36 @@ public:
 
     //Audiostreamer API
     /// Request to fill a buffer with data
-    virtual void update(rc_alAudioBuffer buffer);
+    void update(rc_alAudioBuffer buffer) override;
 
     /// Return the number of buffers this streaming class requires (usually 2)
-    virtual unsigned long required_buffers();
+    unsigned long required_buffers() override;
 
 	/// Stop the current stream (reset to empty)
-	virtual void Stop();
+	void Stop() override;
 
     //AudioEmitter API
     //
     /// Set to false to allow the emitter to time out (useful only on non-looping sounds)
-    virtual bool KeepPlaying();
+    bool KeepPlaying() override;
     /// if true is returned, this will be a relative-to-listener sound
-    virtual bool GetPosition(vec3 &p);
-    virtual void GetDirection(vec3 &p);
-    virtual const vec3& GetVelocity();
-    virtual const vec3 GetPosition();
-    virtual const vec3 GetOcclusionPosition();
+    bool GetPosition(vec3 &p) override;
+    void GetDirection(vec3 &p) override;
+    const vec3& GetVelocity() override;
+    const vec3 GetPosition() override;
+    const vec3 GetOcclusionPosition() override;
 
     /// Indicate the priority of this effect to make room for newer/higher priority effects
-    virtual unsigned char GetPriority();
+    unsigned char GetPriority() override;
 
-    virtual void SetVolume(float vol);
+    void SetVolume(float vol) override;
 
-    virtual bool IsTransient();
+    bool IsTransient() override;
     
 public: //Control API
     Soundtrack( float volume );
 
-    virtual ~Soundtrack();
+    ~Soundtrack() override;
 
     void AddMusic( const Path& file );
     void RemoveMusic( const Path& file );

--- a/Source/XML/Parsers/activemodsparser.h
+++ b/Source/XML/Parsers/activemodsparser.h
@@ -44,10 +44,10 @@ private:
 public:
     ActiveModsParser();
 
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
 
-    virtual void Clear();
+    void Clear() override;
 
     bool FileChangedSinceLastLoad();
     bool LocalChangedSinceLastSave();

--- a/Source/XML/Parsers/assetloadwarningparser.h
+++ b/Source/XML/Parsers/assetloadwarningparser.h
@@ -47,9 +47,9 @@ public:
 
     std::set<AssetWarning> asset_warnings;
 
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 
     void AddAssetWarning(AssetWarning asset_warning);
 };

--- a/Source/XML/Parsers/assetmanifestparser.h
+++ b/Source/XML/Parsers/assetmanifestparser.h
@@ -42,7 +42,7 @@ public:
     };
 
     std::vector<Asset> assets;
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 };

--- a/Source/XML/Parsers/jobxmlparser.h
+++ b/Source/XML/Parsers/jobxmlparser.h
@@ -34,9 +34,9 @@ class JobXMLParser : public XMLParserBase
 public:
     JobXMLParser();
 
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 
     class Searcher
     {

--- a/Source/XML/Parsers/levelassetspreloadparser.h
+++ b/Source/XML/Parsers/levelassetspreloadparser.h
@@ -42,7 +42,7 @@ public:
     };
 
     std::vector<Asset> assets;
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 };

--- a/Source/XML/Parsers/levelxmlparser.h
+++ b/Source/XML/Parsers/levelxmlparser.h
@@ -49,9 +49,9 @@ public:
         std::string image;
     };
 
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 
     std::string hash;
     std::string name;

--- a/Source/XML/Parsers/musicxmlparser.h
+++ b/Source/XML/Parsers/musicxmlparser.h
@@ -106,9 +106,9 @@ public:
 
     Music music;
 
-    virtual uint32_t Load( const std::string& path );
-    virtual bool Save( const std::string& path );
-    virtual void Clear();
+    uint32_t Load( const std::string& path ) override;
+    bool Save( const std::string& path ) override;
+    void Clear() override;
 };
 
 inline std::ostream& operator<<( std::ostream& out, const MusicXMLParser::Segment& segment )


### PR DESCRIPTION
The override keyword was introduced in C++11 and allows to get compilation errors when a function does not override something from the base class. See https://en.cppreference.com/w/cpp/keyword/override

- replace virtual keyword in derived classes
- add override keyword where it was missing before