### PR TITLE
Exclude unused header extension from format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,3 +13,4 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: 'Source'
+        exclude-regex: '*.hpp'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,8 +9,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for OverGrowth Source
-      uses: jidicula/clang-format-action@v4.5.0
+      uses: jidicula/clang-format-action@v4.6.2
       with:
         clang-format-version: '13'
         check-path: 'Source'
-        exclude-regex: '(.hpp|snprintf.c|triangle.c)'
+        exclude-regex: '(hpp|snprintf.c|triangle.c)'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: 'Source'
-        exclude-regex: '*.hpp'
+        exclude-regex: '(.hpp|snprintf.c|triangle.c)'

--- a/Source/Graphics/dynamiclightcollection.hpp
+++ b/Source/Graphics/dynamiclightcollection.hpp
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------------
 //           Name: dynamiclightcollection.hpp
 //      Developer: Wolfire Games LLC
-//    Description: 
+//    Description:
 //        License: Read below
 //-----------------------------------------------------------------------------
 //
@@ -37,20 +37,18 @@ struct DynamicLight {
     // for ShaderLight which is the GPU data struct
 };
 
-
 // when you want to add spot lights, DO NOT change DynamicLight
 // add new DynamicSpotLight since they need different data and are processed differently
 // also DynamicLight should be renamed to DynamicPointLight to clarify its meaning
-
 
 class BulletWorld;
 class SceneGraph;
 
 class DynamicLightCollection {
-public:
+   public:
     DynamicLightCollection();
-	~DynamicLightCollection();
-    int AddLight(const vec3& pos, const vec3 &color, float radius);
+    ~DynamicLightCollection();
+    int AddLight(const vec3& pos, const vec3& color, float radius);
     bool MoveLight(int id, const vec3& pos);
     bool DeleteLight(int id);
     void Draw(BulletWorld& bw);
@@ -58,7 +56,7 @@ public:
     void Dispose();
     DynamicLight* GetLightFromID(int id);
 
-private:
+   private:
     std::vector<DynamicLight> dynamic_lights;
     int next_id;
 

--- a/Source/Graphics/lightprobecollection.hpp
+++ b/Source/Graphics/lightprobecollection.hpp
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------------
 //           Name: lightprobecollection.h
 //      Developer: Wolfire Games LLC
-//    Description: 
+//    Description:
 //        License: Read below
 //-----------------------------------------------------------------------------
 //
@@ -37,7 +37,7 @@ struct LightProbe {
     vec3 pos;
     bool negative;
     vec3 ambient_cube_color[6];
-    vec3 ambient_cube_color_buf[6]; // Used for calculating second bounce
+    vec3 ambient_cube_color_buf[6];  // Used for calculating second bounce
 };
 
 struct TetMesh {
@@ -50,23 +50,23 @@ struct TetMesh {
 
 struct LightProbeUpdateEntry {
     int id;
-    int pass; // 0 for first bounce, 1 for second bounce
+    int pass;  // 0 for first bounce, 1 for second bounce
 };
 
 struct GridLookup {
     static const int kMaxGridCells = 1000000;
     vec3 bounds[2];
     int subdivisions[3];
-    std::vector<unsigned> cell_tet; // What tetrahedron is closest to the center of each cell
+    std::vector<unsigned> cell_tet;  // What tetrahedron is closest to the center of each cell
 };
 
 class BulletWorld;
 
 class LightProbeCollection {
-public:
+   public:
     LightProbeCollection();
     ~LightProbeCollection();
-    int AddProbe(const vec3& pos, bool negative, const float *coeff = NULL);
+    int AddProbe(const vec3& pos, bool negative, const float* coeff = NULL);
     bool MoveProbe(int id, const vec3& pos);
     bool SetNegative(int id, bool negative);
     bool DeleteProbe(int id);
@@ -76,7 +76,7 @@ public:
     int ShaderNumLightProbes();
     int ShaderNumTetrahedra();
     LightProbe* GetNextProbeToProcess();
-    // Returns id of tetrahedron containing position, 
+    // Returns id of tetrahedron containing position,
     // and fills interpolated ambient cube color
     int GetTetrahedron(const vec3& position, vec3 ambient_cube_color[], int best_guess);
     GLuint cube_map_fbo;
@@ -98,7 +98,8 @@ public:
     bool probe_lighting_enabled;
     bool light_volume_enabled;
     int probe_model_id;
-private:
+
+   private:
     bool tet_mesh_needs_update;
     int next_id;
     void UpdateTetMesh(BulletWorld& bw);

--- a/Source/Graphics/simplify.hpp
+++ b/Source/Graphics/simplify.hpp
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------------
 //           Name: simplify.hpp
 //      Developer: Wolfire Games LLC
-//    Description: 
+//    Description:
 //        License: Read below
 //-----------------------------------------------------------------------------
 //
@@ -34,9 +34,9 @@
 using std::vector;
 
 namespace WOLFIRE_SIMPLIFY {
-    void CalculateQuadrics(vector<glm::mat4> *quadrics, const vector<float> &vertices, const vector<int> &vert_indices);
-    bool SimplifyMorphLOD( const SimplifyModelInput &model_input, MorphModel* lod, ParentRecordListVec* vert_parents, ParentRecordListVec* tex_parents, int lod_levels );
-    bool SimplifySimpleModel(const Model& input, Model* output, int edge_target, bool include_tex);
-    bool Process( const Model &model, SimplifyModel& processed_model, vector<HalfEdge>& half_edges, bool include_tex);
-    float CalculateError(float* pos, int edge[2], const vector<float> &vertices, const vector<glm::mat4> &quadrics, const int edge_tc[]);
-}
+void CalculateQuadrics(vector<glm::mat4>* quadrics, const vector<float>& vertices, const vector<int>& vert_indices);
+bool SimplifyMorphLOD(const SimplifyModelInput& model_input, MorphModel* lod, ParentRecordListVec* vert_parents, ParentRecordListVec* tex_parents, int lod_levels);
+bool SimplifySimpleModel(const Model& input, Model* output, int edge_target, bool include_tex);
+bool Process(const Model& model, SimplifyModel& processed_model, vector<HalfEdge>& half_edges, bool include_tex);
+float CalculateError(float* pos, int edge[2], const vector<float>& vertices, const vector<glm::mat4>& quadrics, const int edge_tc[]);
+}  // namespace WOLFIRE_SIMPLIFY

--- a/Source/Images/ddsformat.hpp
+++ b/Source/Images/ddsformat.hpp
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------------
 //           Name: ddsformat.hpp
 //      Developer: Wolfire Games LLC
-//    Description: 
+//    Description:
 //        License: Read below
 //-----------------------------------------------------------------------------
 //
@@ -23,4 +23,10 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
-enum DDSFormat {_DXT1, _DXT1A, _DXT3, _DXT5, _DXT5YCoCg, _RGBA, _RGB};
+enum DDSFormat { _DXT1,
+                 _DXT1A,
+                 _DXT3,
+                 _DXT5,
+                 _DXT5YCoCg,
+                 _RGBA,
+                 _RGB };

--- a/Source/Images/image_export.hpp
+++ b/Source/Images/image_export.hpp
@@ -30,20 +30,20 @@
 #include <vector>
 
 namespace ImageExport {
-    struct CubemapFace {
-        std::vector<unsigned char> pixels;
-    };
-    struct CubemapMipLevel {
-        CubemapFace faces[6];
-    };
-    struct CubemapMipmaps {
-        std::vector<CubemapMipLevel> mips;
-    };
+struct CubemapFace {
+    std::vector<unsigned char> pixels;
+};
+struct CubemapMipLevel {
+    CubemapFace faces[6];
+};
+struct CubemapMipmaps {
+    std::vector<CubemapMipLevel> mips;
+};
 
-    void SaveJPEG(const char* abs_path, unsigned char *data, unsigned long width, unsigned long height);
-    void SavePNG(const char *file_path, unsigned char *data, unsigned long width, unsigned long height, unsigned short levels = 0);
-    void SavePNGTransparent(const char *file_path, unsigned char *data, unsigned long width, unsigned long height, unsigned short levels = 0);
-    void SavePNGofGrayscaleFloats(const char *file_path, std::vector<float>& data, unsigned long width, unsigned long height);
-    std::string FindEmptySequentialFile(const char* filename, const char* suffix);
-    void ScaleImageUp(const unsigned char *data, int levels, unsigned long *width, unsigned long *height, std::vector<unsigned char> *new_data);
-}
+void SaveJPEG(const char *abs_path, unsigned char *data, unsigned long width, unsigned long height);
+void SavePNG(const char *file_path, unsigned char *data, unsigned long width, unsigned long height, unsigned short levels = 0);
+void SavePNGTransparent(const char *file_path, unsigned char *data, unsigned long width, unsigned long height, unsigned short levels = 0);
+void SavePNGofGrayscaleFloats(const char *file_path, std::vector<float> &data, unsigned long width, unsigned long height);
+std::string FindEmptySequentialFile(const char *filename, const char *suffix);
+void ScaleImageUp(const unsigned char *data, int levels, unsigned long *width, unsigned long *height, std::vector<unsigned char> *new_data);
+}  // namespace ImageExport

--- a/Source/Version/fallback_version.c
+++ b/Source/Version/fallback_version.c
@@ -20,8 +20,8 @@
 //   limitations under the License.
 //
 //-----------------------------------------------------------------------------
-extern const int phoenix_build_id=-1;
-const char* phoenix_platform="Unknown";
-const char* phoenix_arch="Unknown";
-const char* phoenix_git_version_string="Unknown";
-const char* phoenix_build_timestamp="0000-00-00 00:00:00 UTC";
+extern const int phoenix_build_id = -1;
+const char* phoenix_platform = "Unknown";
+const char* phoenix_arch = "Unknown";
+const char* phoenix_git_version_string = "Unknown";
+const char* phoenix_build_timestamp = "0000-00-00 00:00:00 UTC";

--- a/Tools/format_source.sh
+++ b/Tools/format_source.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find ./Source/ -iname *.h -o -iname *.cpp | xargs clang-format -i
+find ./Source/ -iname *.h -o -iname *.cpp -o -iname *.hpp| xargs clang-format -i

--- a/Tools/format_source.sh
+++ b/Tools/format_source.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find ./Source/ -iname *.h -o -iname *.cpp -o -iname *.hpp| xargs clang-format -i
+find ./Source/ -iname *.h -o -iname *.cpp | xargs clang-format -i


### PR DESCRIPTION
- Remove `.hpp` as a checked extensions
- Format existing `.hpp` headers

I'll eventually change the extension for those existing headers - but other `.hpp` headers are thirdparty code