### PR TITLE
Fix bugs related to stb_image

### DIFF
--- a/Source/Asset/Asset/image_sampler.cpp
+++ b/Source/Asset/Asset/image_sampler.cpp
@@ -115,9 +115,9 @@ int ImageSampler::Load(const std::string& path, uint32_t load_flags) {
 
         int n = 0;
         // Tell stb_image that we want 4 components (RGBA)
-        stbi_uc* data = stbi_load(abs_path, &width_, &width_, &n, 4);
+        stbi_uc* data = stbi_load(abs_path, &width_, &height_, &n, 4);
 
-        if (data == nullptr || n != 4) {
+        if (data == nullptr) {
             return kLoadErrorGeneralFileError;
         }
 

--- a/Source/Graphics/heightmap.cpp
+++ b/Source/Graphics/heightmap.cpp
@@ -118,7 +118,7 @@ bool HeightmapImage::LoadData(const std::string& rel_path, HMScale scaled) {
             float x_scale = img_width / (float)width_;
             float z_scale = img_height / (float)depth_;
 
-            if (num_comp != 1) {                    // monochrome texture
+            if (num_comp == 1) {                    // monochrome texture
                 for (int z = 0; z < depth_; z++) {  // flipped
                     float* bits = &data[((int)(z * z_scale)) * img_height];
                     for (int x = 0; x < width_; x++) {


### PR DESCRIPTION
- `ImageSampler::Load` forces all images to have RGBA components, but it was still checking that the loaded images were RGBA, which was causing the RGB ones to fail.
- Call to `stbi_load` passed the `_width` value twice, omitting the `_height` value.
- There was a logic error in `HeightmapImage::LoadData`.