### PR TITLE
PVS analyzer fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 BasedOnStyle: Google
-SortIncludes: Never # These can break compilation
+SortIncludes: false # These can break compilation
 IndentWidth: 4
 ColumnLimit: 0 # We don't want to add too many additional linebreaks for now

--- a/Source/GUI/dimgui/imgui_impl_sdl_gl3.cpp
+++ b/Source/GUI/dimgui/imgui_impl_sdl_gl3.cpp
@@ -123,7 +123,7 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data) {
 
     for (int n = 0; n < draw_data->CmdListsCount; n++) {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];
-        const ImDrawIdx* idx_buffer_offset = 0;  // Start at the beginning of the element list, has to be a pointer but otherwise normal integer offset
+        ImDrawIdx idx_buffer_offset = 0;  // Amount of indices to skip until next drawn element
 
         glBindBuffer(GL_ARRAY_BUFFER, g_VboHandle);
         glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)cmd_list->VtxBuffer.Size * sizeof(ImDrawVert), (GLvoid*)cmd_list->VtxBuffer.Data, GL_STREAM_DRAW);
@@ -138,9 +138,9 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data) {
             } else {
                 glBindTexture(GL_TEXTURE_2D, (GLuint)(intptr_t)pcmd->TextureId);
                 glScissor((int)pcmd->ClipRect.x, (int)(fb_height - pcmd->ClipRect.w), (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y));
-                glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, idx_buffer_offset);
+                glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, (void*)(idx_buffer_offset * sizeof(ImDrawIdx)));
             }
-            idx_buffer_offset += pcmd->ElemCount;  // Offset the rendering call by the number of elements rendered
+            idx_buffer_offset += pcmd->ElemCount;
         }
     }
 

--- a/Source/GUI/dimgui/imgui_impl_sdl_gl3.cpp
+++ b/Source/GUI/dimgui/imgui_impl_sdl_gl3.cpp
@@ -123,7 +123,7 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data) {
 
     for (int n = 0; n < draw_data->CmdListsCount; n++) {
         const ImDrawList* cmd_list = draw_data->CmdLists[n];
-        const ImDrawIdx* idx_buffer_offset = 0;
+        const ImDrawIdx* idx_buffer_offset = 0;  // Start at the beginning of the element list, has to be a pointer but otherwise normal integer offset
 
         glBindBuffer(GL_ARRAY_BUFFER, g_VboHandle);
         glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)cmd_list->VtxBuffer.Size * sizeof(ImDrawVert), (GLvoid*)cmd_list->VtxBuffer.Data, GL_STREAM_DRAW);
@@ -140,7 +140,7 @@ void ImGui_ImplSdlGL3_RenderDrawLists(ImDrawData* draw_data) {
                 glScissor((int)pcmd->ClipRect.x, (int)(fb_height - pcmd->ClipRect.w), (int)(pcmd->ClipRect.z - pcmd->ClipRect.x), (int)(pcmd->ClipRect.w - pcmd->ClipRect.y));
                 glDrawElements(GL_TRIANGLES, (GLsizei)pcmd->ElemCount, sizeof(ImDrawIdx) == 2 ? GL_UNSIGNED_SHORT : GL_UNSIGNED_INT, idx_buffer_offset);
             }
-            idx_buffer_offset += pcmd->ElemCount;
+            idx_buffer_offset += pcmd->ElemCount;  // Offset the rendering call by the number of elements rendered
         }
     }
 

--- a/Source/Graphics/skeleton.cpp
+++ b/Source/Graphics/skeleton.cpp
@@ -154,7 +154,7 @@ void Skeleton::SetGravity(bool enable) {
             if (!physics_bone.bullet_object) {
                 continue;
             }
-            physics_bone.bullet_object->SetGravity(true);
+            physics_bone.bullet_object->SetGravity(false);
             // physics_bones[i].bullet_object->SetDamping(1.0f);
         }
     }

--- a/Source/Images/texture_data.cpp
+++ b/Source/Images/texture_data.cpp
@@ -325,7 +325,7 @@ void TextureData::GetUncompressedData(unsigned char *data) {
                 data[4 * curr_index + 3] = bits[x].a;
             }
         }
-        
+
         // TODO: what is this?
         /*
         } else if (m_nImageBits == 96) {

--- a/Source/Images/texture_data.cpp
+++ b/Source/Images/texture_data.cpp
@@ -280,38 +280,40 @@ void TextureData::GetUncompressedData(unsigned char *data) {
         // In both `terrain.cpp` and `textures.cpp`, both uses of this function imply that the only valid data format
         // expected is BGRA_8. Otherwise, one would expect the function signature to also return a `numBits` or similar.
         // Therefore, I'll proclaim `imageBits` obsolete, and comment out the lesser bit depths and the conditional.
-        //int imageBits = 32;
+        // int imageBits = 32;
 
-        //int bytesPerPixel = imageBits / 8;
+        // int bytesPerPixel = imageBits / 8;
         int imageWidth = m_crnTex.get_width();
         int imageHeight = m_crnTex.get_height();
 
-        //int heightDataSize = imageWidth * imageHeight;
-        //int imageDataSize = heightDataSize * bytesPerPixel;
+        // int heightDataSize = imageWidth * imageHeight;
+        // int imageDataSize = heightDataSize * bytesPerPixel;
 
         image_u8 image;
         image_u8 *pImg = m_crnTex.get_level_image(0, 0, image);
 
-        //if (imageBits == 8) {
-        //    for (int y = 0; y < imageHeight; y++) {
-        //        color_quad_u8 *bits = pImg->get_scanline(y);
-        //        for (int x = 0; x < imageWidth; x++) {
-        //            int curr_index = x + y * imageWidth;
-        //            data[curr_index] = bits[x].a;
-        //        }
-        //    }
-        //} else if (imageBits == 24) {
-        //    for (int y = 0; y < imageHeight; y++) {
-        //        color_quad_u8 *bits = pImg->get_scanline(y);
-        //        for (int x = 0; x < imageWidth; x++) {
-        //            int curr_index = x + y * imageWidth;
-        //            data[4 * curr_index] = bits[x].b;
-        //            data[4 * curr_index + 1] = bits[x].g;
-        //            data[4 * curr_index + 2] = bits[x].r;
-        //            data[4 * curr_index + 3] = 255;
-        //        }
-        //    }
-        //} else if (imageBits == 32) {
+        /*
+        if (imageBits == 8) {
+            for (int y = 0; y < imageHeight; y++) {
+                color_quad_u8 *bits = pImg->get_scanline(y);
+                for (int x = 0; x < imageWidth; x++) {
+                    int curr_index = x + y * imageWidth;
+                    data[curr_index] = bits[x].a;
+                }
+            }
+        } else if (imageBits == 24) {
+            for (int y = 0; y < imageHeight; y++) {
+                color_quad_u8 *bits = pImg->get_scanline(y);
+                for (int x = 0; x < imageWidth; x++) {
+                    int curr_index = x + y * imageWidth;
+                    data[4 * curr_index] = bits[x].b;
+                    data[4 * curr_index + 1] = bits[x].g;
+                    data[4 * curr_index + 2] = bits[x].r;
+                    data[4 * curr_index + 3] = 255;
+                }
+            }
+        } else if (imageBits == 32) {
+        */
 
         for (int y = 0; y < imageHeight; y++) {
             color_quad_u8 *bits = pImg->get_scanline(y);

--- a/Source/Images/texture_data.cpp
+++ b/Source/Images/texture_data.cpp
@@ -277,51 +277,56 @@ bool TextureData::EnsureInRAM() {
 void TextureData::GetUncompressedData(unsigned char *data) {
     if (is_loaded) {
         pixel_format format = m_crnTex.get_format();
-        int imageBits = 32;
+        // In both `terrain.cpp` and `textures.cpp`, both uses of this function imply that the only valid data format
+        // expected is BGRA_8. Otherwise, one would expect the function signature to also return a `numBits` or similar.
+        // Therefore, I'll proclaim `imageBits` obsolete, and comment out the lesser bit depths and the conditional.
+        //int imageBits = 32;
 
-        int bytesPerPixel = imageBits / 8;
+        //int bytesPerPixel = imageBits / 8;
         int imageWidth = m_crnTex.get_width();
         int imageHeight = m_crnTex.get_height();
 
-        int heightDataSize = imageWidth * imageHeight;
-        int imageDataSize = heightDataSize * bytesPerPixel;
+        //int heightDataSize = imageWidth * imageHeight;
+        //int imageDataSize = heightDataSize * bytesPerPixel;
 
         image_u8 image;
         image_u8 *pImg = m_crnTex.get_level_image(0, 0, image);
 
-        if (imageBits == 8) {
-            for (int y = 0; y < imageHeight; y++) {
-                color_quad_u8 *bits = pImg->get_scanline(y);
-                for (int x = 0; x < imageWidth; x++) {
-                    int curr_index = x + y * imageWidth;
-                    data[curr_index] = bits[x].a;
-                }
+        //if (imageBits == 8) {
+        //    for (int y = 0; y < imageHeight; y++) {
+        //        color_quad_u8 *bits = pImg->get_scanline(y);
+        //        for (int x = 0; x < imageWidth; x++) {
+        //            int curr_index = x + y * imageWidth;
+        //            data[curr_index] = bits[x].a;
+        //        }
+        //    }
+        //} else if (imageBits == 24) {
+        //    for (int y = 0; y < imageHeight; y++) {
+        //        color_quad_u8 *bits = pImg->get_scanline(y);
+        //        for (int x = 0; x < imageWidth; x++) {
+        //            int curr_index = x + y * imageWidth;
+        //            data[4 * curr_index] = bits[x].b;
+        //            data[4 * curr_index + 1] = bits[x].g;
+        //            data[4 * curr_index + 2] = bits[x].r;
+        //            data[4 * curr_index + 3] = 255;
+        //        }
+        //    }
+        //} else if (imageBits == 32) {
+
+        for (int y = 0; y < imageHeight; y++) {
+            color_quad_u8 *bits = pImg->get_scanline(y);
+            for (int x = 0; x < imageWidth; x++) {
+                int curr_index = x + y * imageWidth;
+                data[4 * curr_index] = bits[x].b;
+                data[4 * curr_index + 1] = bits[x].g;
+                data[4 * curr_index + 2] = bits[x].r;
+                data[4 * curr_index + 3] = bits[x].a;
             }
-        } else if (imageBits == 24) {
-            for (int y = 0; y < imageHeight; y++) {
-                color_quad_u8 *bits = pImg->get_scanline(y);
-                for (int x = 0; x < imageWidth; x++) {
-                    int curr_index = x + y * imageWidth;
-                    data[4 * curr_index] = bits[x].b;
-                    data[4 * curr_index + 1] = bits[x].g;
-                    data[4 * curr_index + 2] = bits[x].r;
-                    data[4 * curr_index + 3] = 255;
-                }
-            }
-        } else if (imageBits == 32) {
-            for (int y = 0; y < imageHeight; y++) {
-                color_quad_u8 *bits = pImg->get_scanline(y);
-                for (int x = 0; x < imageWidth; x++) {
-                    int curr_index = x + y * imageWidth;
-                    data[4 * curr_index] = bits[x].b;
-                    data[4 * curr_index + 1] = bits[x].g;
-                    data[4 * curr_index + 2] = bits[x].r;
-                    data[4 * curr_index + 3] = bits[x].a;
-                }
-            }
-            // TODO: what is this?
-            /*
-            } else if (m_nImageBits == 96) {
+        }
+        
+        // TODO: what is this?
+        /*
+        } else if (m_nImageBits == 96) {
             for(int y = 0; y < m_nImageHeight; y++) {
             BYTE *bits = FreeImage_GetScanLine(image, y);
             for(int x = 0; x < m_nImageWidth; x++) {
@@ -336,9 +341,8 @@ void TextureData::GetUncompressedData(unsigned char *data) {
             m_nImageData[4*curr_index+2] = (unsigned char)(min(1.0f, pixelf[0]) * 255.0f);
             m_nImageData[4*curr_index+3] = 255;
             bits += bytesPerPixel;
-            }
-            */
         }
+        */
     } else {
         LOGE << "Unable to load LoadUncompressedData from texturedata, data is unloaded " << endl;
     }

--- a/Source/Main/scenegraph.cpp
+++ b/Source/Main/scenegraph.cpp
@@ -1931,7 +1931,7 @@ bool SceneGraph::AddDynamicDecal(DecalObject* decal) {
     if (nearest_obj) {
         scale = nearest_obj->GetScale();
         float other_radius = min(scale.x(), min(scale.y(), scale.z()));
-        float other_radius_sq = other_radius * other_radius;
+        other_radius_sq = other_radius * other_radius;
     }
     if (nearest_dist_sq > my_radius_sq && nearest_dist_sq > other_radius_sq) {
         if (ActorsEditor_AddEntity(this, decal, NULL, false)) {

--- a/Source/Memory/bitarray.cpp
+++ b/Source/Memory/bitarray.cpp
@@ -64,21 +64,21 @@ bool Bitarray::GetBit(size_t index) {
     size_t p = index / 64;
     size_t i = index % 64;
 
-    return (arr[p] & (1UL << i));
+    return (arr[p] & (1ULL << i));
 }
 
 void Bitarray::SetBit(size_t index) {
     size_t p = index / 64;
     size_t i = index % 64;
 
-    arr[p] |= (1UL << i);
+    arr[p] |= (1ULL << i);
 }
 
 void Bitarray::FreeBit(size_t index) {
     size_t p = index / 64;
     size_t i = index % 64;
 
-    arr[p] &= ~(1UL << i);
+    arr[p] &= ~(1ULL << i);
 }
 
 void Bitarray::SetBits(size_t index, size_t count) {

--- a/Source/Objects/navmeshhintobject.cpp
+++ b/Source/Objects/navmeshhintobject.cpp
@@ -60,7 +60,7 @@ NavmeshHintObject::NavmeshHintObject() {
         };
 
     for (int i = 0; i < 8; i++) {
-        for (int k = i; k < 8; k++) {
+        for (int k = i + 1; k < 8; k++) {
             if (i != k) {
                 if (
                     corners[i][0] == corners[k][0] ||

--- a/Source/Objects/placeholderobject.cpp
+++ b/Source/Objects/placeholderobject.cpp
@@ -331,9 +331,7 @@ void PlaceholderObject::GetDisplayName(char* buf, int buf_size) {
 ObjectSanityState PlaceholderObject::GetSanity() {
     uint32_t sanity_flags = 0;
     if (special_type_ == kPlayerConnect && connect_id_ == -1) {
-        if (connect_id_ == -1) {
-            sanity_flags |= kObjectSanity_PO_UnsetConnectID;
-        }
+        sanity_flags |= kObjectSanity_PO_UnsetConnectID;
     }
     return ObjectSanityState(GetType(), GetID(), sanity_flags);
 }

--- a/Source/Scripting/angelscript/ascontext.cpp
+++ b/Source/Scripting/angelscript/ascontext.cpp
@@ -125,11 +125,11 @@ ASContext::ASContext(const char *name, const ASData &as_data) : scenegraph(as_da
 
     // Create a context that will execute the script.
     ctx = engine->CreateContext();
-    ctx->SetUserData(this, 0);
     if (ctx == 0) {
         FatalError("Error", "Failed to create the context.");
         return;
     }
+    ctx->SetUserData(this, 0);
 
     if (asdebugger_enabled) {
         dbg.SetEngine(engine);


### PR DESCRIPTION
From issue #75. Figured I'd make a quick PR to implement these, since they seem mostly consistent.

Issues:
1, 2: Issues in Bullet, ignored.
3: Issue in VR SDK, ignored.
4: `ASContext::ASContext`: moved `ctx->setUserData()` after context validity check.
5: `PlaceholderObject::GetSanity`: removed redundant internal if statement.
6: `NavmeshHintObject::NavmeshHintObject`: slight logic change to reduce redundant computations.
7: `SceneGraph::AddDynamicDecal`: fixed duplicate definition.
8, 9: `TextureData::GetUncompressedData`: removed (seemingly) obsolete `imageBits`. The only cases where this function is used only use RGBA_8 format, so I commented out the other routines until they're actually needed. Also commented out a number of other variables that were unused.
10: `ImGui_ImplSdlGL3_RenderDrawLists`: changed `idx_buffer_offset` to a regular integer instead of an int pointer, and instead multiply that value by the `sizeof(ImDrawIdx)` and cast it to a pointer afterward. I believe this is more clear, as `idx_buffer_offset` is supposed to represent the number of indices to skip (which is hard to intuit when you see it labeled as a const pointer), and it avoids pointer arithmetic which is unconventional in C++.
11: Issue in Crunchlib, ignored.
12: `Skeleton::SetGravity`: set this function to actually turn off bullet object gravity when set to false, which given the title of the function I think was a mistake. If the commented lines are truly vestigial, it would probably make sense to remove them. Could also be rewritten more concisely as:
```c++
void Skeleton::SetGravity( bool enable ) 
{
    for(unsigned i=0; i<physics_bones.size(); i++)
    {
        if(!physics_bones[i].bullet_object)
        {
            continue;
        }
        physics_bones[i].bullet_object->SetGravity(enable);
        //physics_bones[i].bullet_object->SetDamping(enable ? 0.0f : 1.0f);
    }
}
```
13: Issue in Angelscript, ignored.
14, 15, 16: `Bitarray::Get/Set/FreeBit`: changed literal `1UL` (32 bits) to `1ULL` (64 bits).
17: Issue in Bullet, ignored.