### PR TITLE
Zipfile bug fix

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 BasedOnStyle: Google
-SortIncludes: Never # These can break compilation
+SortIncludes: false # These can break compilation
 IndentWidth: 4
 ColumnLimit: 0 # We don't want to add too many additional linebreaks for now

--- a/Projects/CMakeLists.txt
+++ b/Projects/CMakeLists.txt
@@ -268,6 +268,12 @@ set(ZSTD_BUILD_PROGRAMS Off)
 set(ZSTD_BUILD_STATIC ON)
 set(ZSTD_BUILD_SHARED Off)
 ADD_SUBDIRECTORY(../Libraries/zstd-1.5.0/build/cmake zstd)
+IF(WIN32)
+    # Make sure freetype uses the precompiled 1.27 binary
+    SET(FT_REQUIRE_ZLIB ON)
+    GET_FILENAME_COMPONENT(ZLIB_INCLUDE "../Libraries/zlib1.2.7/include" ABSOLUTE)
+    GET_FILENAME_COMPONENT(ZLIB_LIBRARY "../Libraries/zlib1.2.7/lib/x64/zlib.lib" ABSOLUTE)
+ENDIF()
 ADD_SUBDIRECTORY(../Libraries/freetype-2.12.1 freetype)
 
 IF(BUILD_OVERGROWTH) 

--- a/Projects/CMakeLists.txt
+++ b/Projects/CMakeLists.txt
@@ -270,9 +270,10 @@ set(ZSTD_BUILD_SHARED Off)
 ADD_SUBDIRECTORY(../Libraries/zstd-1.5.0/build/cmake zstd)
 IF(WIN32)
     # Make sure freetype uses the precompiled 1.2.7 binary
-    SET(FT_REQUIRE_ZLIB ON)
-    GET_FILENAME_COMPONENT(ZLIB_INCLUDE "../Libraries/zlib1.2.7/include" ABSOLUTE)
-    GET_FILENAME_COMPONENT(ZLIB_LIBRARY "../Libraries/zlib1.2.7/lib/x64/zlib.lib" ABSOLUTE)
+    OPTION(FT_REQUIRE_ZLIB "Overridden on Windows" ON)
+    
+    SET(ZLIB_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/../Libraries/zlib1.2.7/include" CACHE INTERNAL "Precompiled zlib include path")
+    SET(ZLIB_LIBRARY "${PROJECT_SOURCE_DIR}/../Libraries/zlib1.2.7/lib/${WINDOWS_LIB_DIR}/zlib.lib" CACHE INTERNAL "Precompiled zlib library path")
 ENDIF()
 ADD_SUBDIRECTORY(../Libraries/freetype-2.12.1 freetype)
 

--- a/Projects/CMakeLists.txt
+++ b/Projects/CMakeLists.txt
@@ -269,7 +269,7 @@ set(ZSTD_BUILD_STATIC ON)
 set(ZSTD_BUILD_SHARED Off)
 ADD_SUBDIRECTORY(../Libraries/zstd-1.5.0/build/cmake zstd)
 IF(WIN32)
-    # Make sure freetype uses the precompiled 1.27 binary
+    # Make sure freetype uses the precompiled 1.2.7 binary
     SET(FT_REQUIRE_ZLIB ON)
     GET_FILENAME_COMPONENT(ZLIB_INCLUDE "../Libraries/zlib1.2.7/include" ABSOLUTE)
     GET_FILENAME_COMPONENT(ZLIB_LIBRARY "../Libraries/zlib1.2.7/lib/x64/zlib.lib" ABSOLUTE)

--- a/Source/AI/navmesh.cpp
+++ b/Source/AI/navmesh.cpp
@@ -845,7 +845,7 @@ bool NavMesh::LoadFromAbs(const Path& level_path, const char* abs_meta_path, con
         if (has_zip) {  // Attempt to load data from the zip file
             ExpandedZipFile ezf;
             UnZip(abs_zip_path, ezf);
-            
+
             if (ezf.GetNumEntries() == 1) {
                 const char* filename;
                 const char* data;

--- a/Source/AI/navmesh.cpp
+++ b/Source/AI/navmesh.cpp
@@ -845,9 +845,7 @@ bool NavMesh::LoadFromAbs(const Path& level_path, const char* abs_meta_path, con
         if (has_zip) {  // Attempt to load data from the zip file
             ExpandedZipFile ezf;
             UnZip(abs_zip_path, ezf);
-
-            LOGI << "success!" << std::endl;
-
+            
             if (ezf.GetNumEntries() == 1) {
                 const char* filename;
                 const char* data;

--- a/Source/Main/engine.cpp
+++ b/Source/Main/engine.cpp
@@ -4113,7 +4113,8 @@ static void UpdateShadowCascades(SceneGraph* scenegraph) {
         {  // Perform per-frame, per-camera functions, like character LOD and spawning grass
             PROFILER_GPU_ZONE(g_profiler_ctx, "Pre-draw camera");
             float predraw_time = game_timer.GetRenderTime();
-            for (auto obj : scenegraph->objects_) {
+            for (int i = 0; i < scenegraph->objects_.size(); i++) {
+                auto obj = scenegraph->objects_[i];
                 if (!obj->parent) {
                     obj->PreDrawCamera(predraw_time);
                 }


### PR DESCRIPTION
Issue being fixed: #78 
Sets the `ZLIB_INCLUDE` and `ZLIB_LIBRARY` paths to the precompiled binary packaged in Overgrowth's libraries, overriding the default one provided by FreeType. I've also set `FT_REQUIRE_ZLIB` to `ON` so that if in the future FreeType is unable to find this precompiled version it will give an error immediately instead of silently and cryptically failing later. Both of these changes are only applied in a Windows build system. Works on Windows 10, and tested on Ubuntu 20.04 LTS with no noticeable changes in the build system from cursory testing. 

Only other changes in this PR are removing some now redundant debug code and changing another engine iterator to a regular for loop (should I create a separate issue to track these?).