### PR TITLE
CI: Fix macOS build by working around bogus SDK detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,6 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones speed things up
       - name: cmake configure
-        run: cmake -S ./Projects -B ./Build
+        run: cmake -S ./Projects -DCMAKE_OSX_DEPLOYMENT_TARGET="13.1" -B ./Build
       - name: compile with cmake
         run: cmake --build ./Build


### PR DESCRIPTION
For whatever reason CMake seems to infer "12.6" as SDK version, because the GitHub Action macOS runner is based on macOS 12.6. But that number doesn't match the SDK version, which should be 13.1 here.

This seems to be a long running issue with GitHub Actions' macOS runner: https://github.com/actions/runner-images/issues/2211

Though I can't tell if it's a CMake bug or a GitHub Actions image setup issue.

It's a bit sad to have to hardcode the value, and it means it might break again next time GitHub Actions update their `macos-12` image, if they remove the `13.1` SDK. If anyone feels like digging into it further, feel free to. :)