### PR TITLE
Replace UNIX Case Correction

### DIFF
--- a/Source/Compat/UNIX/unix_compat.cpp
+++ b/Source/Compat/UNIX/unix_compat.cpp
@@ -331,13 +331,24 @@ static bool caseCorrectInner(char* path, char* pathEnd) {
 void caseCorrect(char* path) {
     if(*path == '\0')
         return;
+
+    char* pathEnd;
+    {
+        /* '\' -> '/' conversion */
+        char* current = path;
+        while(*current != '\0') {
+            if(*current == '\\')
+                *current = '/';
+            ++current;
+        }
+        pathEnd = current;
+    }
     if(access(path, F_OK) == 0)
         return;
     if(errno != ENOENT)
         return;
 
     bool restoreSlash = false;
-    char* pathEnd = path + strlen(path);
     if(*(pathEnd - 1) == '/') {
         /* path ends with a slash; to simplify handling things, remove it temporarily */
         --pathEnd;


### PR DESCRIPTION
The existing case-correction algorithm performs an `access`-check on every path component -- this results in a lot of redundant syscalls, since the majority of the path is provided by the engine and should thus be already correct.

This new version instead scans the path backwards, looking for the first incorrect component from the end of the path, correcting it, and then working forward from there (in a similar manner to the old version).

On my setup, this significantly improves loading performance, especially when reloading the game data after regaining focus. Without this patch, the game would often spend several seconds reloading assets; with the patch applied, the game becomes responsive within less than 1 second.

I've verified that the main campaign works with these changes applied.


If there are any code-style issues or similar, I'd be happy to correct them.

The diff might look a bit odd due to how git has decided to match things -- the `std::string caseCorrect(const std::string &path)` overload has not been modified; only the `void caseCorrect(char* path)` function was replaced (alongside a few `static` functions).