### PR TITLE
Update sonar-scanner-cli to 5.0.1.3006

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 'registry.fedoraproject.org/fedora:latest'
     env:
-      SONAR_SCANNER_VERSION: 4.7.0.2747
+      SONAR_SCANNER_VERSION: 5.0.1.3006
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:


### PR DESCRIPTION
Related to issue #122 . sonar-scanner-cli uses an embedded Java, so to solve the issue with the outdated Java version it is enough to use the latest version of sonar-scanner-cli.