### PR TITLE
Add host.url to sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=WolfireGames_overgrowth
 sonar.organization=wolfiregames
+sonar.host.url=https://sonarcloud.io
 sonar.exclusions=Libraries/**,Projects/**
 sonar.cfamily.threads=1
 sonar.cfamily.cache.enabled=false


### PR DESCRIPTION
Related to issue #122 and PR #123 . It seems the new sonar-scanner-cli version needs an additional config entry.