### PR TITLE
Groups now have a "children_no_navmesh" checkbox that updates the "no_navmesh" value of it's children.

### DIFF
--- a/Source/GUI/dimgui/dimgui.cpp
+++ b/Source/GUI/dimgui/dimgui.cpp
@@ -933,6 +933,21 @@ static void DrawLaunchCustomGuiButton(Object* obj, bool& are_script_params_read_
     }
 }
 
+//Glimpse - Group no_navmesh.
+static void UpdateChildrenNoNavmesh(Group* group, bool enabled) {
+    for (auto& i : group->children) {
+        if (i.direct_ptr->GetType() == _env_object) {
+            EnvObject* eo = (EnvObject*)i.direct_ptr;
+            eo->no_navmesh = enabled;
+        }
+        if (i.direct_ptr->GetType() == _group) {
+            Group* sub_group = (Group*)i.direct_ptr;
+            sub_group->children_no_navmesh = enabled;
+            UpdateChildrenNoNavmesh(sub_group, enabled);
+        }
+    }
+}
+
 static void DrawObjectInfoFlat(Object* obj) {
     ImGui::Indent(ImGui::GetTreeNodeToLabelSpacing());
     obj->DrawImGuiEditor();
@@ -1254,6 +1269,15 @@ static void DrawObjectInfoFlat(Object* obj) {
         ImGui::Separator();
         ImGui::Checkbox("no_navmesh", &eo->no_navmesh);
     }
+    //Glimpse - Group no_navmesh.
+    if (obj->GetType() == _group) {
+        Group* group = (Group*)obj;
+        ImGui::Separator();
+        if (ImGui::Checkbox("children_no_navmesh", &group->children_no_navmesh)) {
+            bool enabled = group->children_no_navmesh;
+            UpdateChildrenNoNavmesh(group, enabled);
+        } 
+    }
 
     ImGui::Separator();
     if (obj->GetType() == _movement_object) {
@@ -1421,6 +1445,16 @@ static void DrawObjectInfo(Object* obj, bool force_expand_script_params) {
         if (ImGui::TreeNode("Flags")) {
             ImGui::Checkbox("no_navmesh", &eo->no_navmesh);
             ImGui::TreePop();
+        }
+    }
+
+    // Glimpse - Group no_navmesh.
+    if (obj->GetType() == _group) {
+        Group* group = (Group*)obj;
+        ImGui::Separator();
+        if (ImGui::Checkbox("children_no_navmesh", &group->children_no_navmesh)) {
+            bool enabled = group->children_no_navmesh;
+            UpdateChildrenNoNavmesh(group, enabled);
         }
     }
 

--- a/Source/GUI/dimgui/dimgui.cpp
+++ b/Source/GUI/dimgui/dimgui.cpp
@@ -933,7 +933,6 @@ static void DrawLaunchCustomGuiButton(Object* obj, bool& are_script_params_read_
     }
 }
 
-//Glimpse - Group no_navmesh.
 static void UpdateChildrenNoNavmesh(Group* group, bool enabled) {
     for (auto& i : group->children) {
         if (i.direct_ptr->GetType() == _env_object) {
@@ -1269,7 +1268,7 @@ static void DrawObjectInfoFlat(Object* obj) {
         ImGui::Separator();
         ImGui::Checkbox("no_navmesh", &eo->no_navmesh);
     }
-    //Glimpse - Group no_navmesh.
+
     if (obj->GetType() == _group) {
         Group* group = (Group*)obj;
         ImGui::Separator();
@@ -1448,7 +1447,6 @@ static void DrawObjectInfo(Object* obj, bool force_expand_script_params) {
         }
     }
 
-    // Glimpse - Group no_navmesh.
     if (obj->GetType() == _group) {
         Group* group = (Group*)obj;
         ImGui::Separator();

--- a/Source/Game/EntityDescription.cpp
+++ b/Source/Game/EntityDescription.cpp
@@ -567,6 +567,15 @@ void EntityDescription::SaveToXML(TiXmlElement* parent) const {
                 }
                 break;
             }
+            //Glimpse - Group no_navmesh.
+            case EDF_CHILDREN_NO_NAVMESH: {
+                bool val;
+                field.ReadBool(&val);
+                if (val) {
+                    object->SetAttribute("children_no_navmesh", "true");
+                }
+                break;
+            }
             case EDF_PREFAB_LOCKED: {
                 bool val;
                 field.ReadBool(&val);
@@ -867,6 +876,14 @@ void LoadGroupDescriptionFromXML(EntityDescription& desc, const TiXmlElement* el
         }
     }
     desc.AddVec3(EDF_COLOR, color);
+
+    // Glimpse - Group no_navmesh.
+    const char* children_no_navmesh = el->Attribute("children_no_navmesh");
+    if (children_no_navmesh) {
+        desc.AddBool(EDF_CHILDREN_NO_NAVMESH, saysTrue(children_no_navmesh) == 1);
+    } else {
+        desc.AddBool(EDF_CHILDREN_NO_NAVMESH, false);
+    }
 
     LoadEntityDescriptionListFromXML(desc.children, el);
 }

--- a/Source/Game/EntityDescription.cpp
+++ b/Source/Game/EntityDescription.cpp
@@ -567,7 +567,6 @@ void EntityDescription::SaveToXML(TiXmlElement* parent) const {
                 }
                 break;
             }
-            //Glimpse - Group no_navmesh.
             case EDF_CHILDREN_NO_NAVMESH: {
                 bool val;
                 field.ReadBool(&val);
@@ -877,7 +876,6 @@ void LoadGroupDescriptionFromXML(EntityDescription& desc, const TiXmlElement* el
     }
     desc.AddVec3(EDF_COLOR, color);
 
-    // Glimpse - Group no_navmesh.
     const char* children_no_navmesh = el->Attribute("children_no_navmesh");
     if (children_no_navmesh) {
         desc.AddBool(EDF_CHILDREN_NO_NAVMESH, saysTrue(children_no_navmesh) == 1);

--- a/Source/Game/EntityDescription.h
+++ b/Source/Game/EntityDescription.h
@@ -71,6 +71,8 @@ enum EntityDescriptionFieldType {
     EDF_GI_COEFFICIENTS,
     EDF_NAV_MESH_CONNECTIONS,
     EDF_NO_NAVMESH,
+    //Glimpse - Group no_navmesh.
+    EDF_CHILDREN_NO_NAVMESH,    //Used for groups. 
     EDF_PREFAB_LOCKED,
     EDF_PREFAB_PATH,
     EDF_ORIGINAL_SCALE,

--- a/Source/Game/EntityDescription.h
+++ b/Source/Game/EntityDescription.h
@@ -71,7 +71,6 @@ enum EntityDescriptionFieldType {
     EDF_GI_COEFFICIENTS,
     EDF_NAV_MESH_CONNECTIONS,
     EDF_NO_NAVMESH,
-    //Glimpse - Group no_navmesh.
     EDF_CHILDREN_NO_NAVMESH,    //Used for groups. 
     EDF_PREFAB_LOCKED,
     EDF_PREFAB_PATH,

--- a/Source/Objects/group.cpp
+++ b/Source/Objects/group.cpp
@@ -39,7 +39,6 @@ extern bool g_debug_runtime_disable_group_pre_draw_frame;
 
 Group::Group() : child_transforms_need_update(false),
                  child_moved(false),
-                 //Glimpse - Group no navmesh.
                  children_no_navmesh(false) {
     box_.dims = vec3(1.0f);
 }

--- a/Source/Objects/group.cpp
+++ b/Source/Objects/group.cpp
@@ -38,7 +38,9 @@ extern bool g_debug_runtime_disable_group_pre_draw_camera;
 extern bool g_debug_runtime_disable_group_pre_draw_frame;
 
 Group::Group() : child_transforms_need_update(false),
-                 child_moved(false) {
+                 child_moved(false),
+                 //Glimpse - Group no navmesh.
+                 children_no_navmesh(false) {
     box_.dims = vec3(1.0f);
 }
 
@@ -118,6 +120,14 @@ bool Group::SetFromDesc(const EntityDescription& desc) {
         if (!version_edf) {
             InitShape();
         }
+        for (const auto& field : desc.fields) {
+            switch (field.type) {
+                case EDF_CHILDREN_NO_NAVMESH: {
+                    field.ReadBool(&children_no_navmesh);
+                    break;
+                }
+            }
+        }
 
         InitRelMats();
     }
@@ -137,6 +147,7 @@ void Group::GetDesc(EntityDescription& desc) const {
             obj->GetDesc(desc.children.back());
         }
     }
+    desc.AddBool(EDF_CHILDREN_NO_NAVMESH, children_no_navmesh);
 }
 
 void Group::InitRelMats() {

--- a/Source/Objects/group.h
+++ b/Source/Objects/group.h
@@ -40,6 +40,9 @@ class Group : public Object {
     bool child_transforms_need_update;
     bool child_moved;
 
+    //Glimpse - Group no navmesh.
+    bool children_no_navmesh;
+
     Group();
     bool Initialize() override;
     ~Group() override;

--- a/Source/Objects/group.h
+++ b/Source/Objects/group.h
@@ -39,8 +39,6 @@ class Group : public Object {
     std::vector<Child> children;
     bool child_transforms_need_update;
     bool child_moved;
-
-    //Glimpse - Group no navmesh.
     bool children_no_navmesh;
 
     Group();


### PR DESCRIPTION
There's a textfile that explains stuffs.