### PR TITLE
New editor ribbon checkbox "Edit reflections" that toggles the editing of reflection captures independently of dynamic light objects.

### DIFF
--- a/Source/Editors/map_editor.cpp
+++ b/Source/Editors/map_editor.cpp
@@ -369,8 +369,9 @@ void MapEditor::RibbonItemClicked(const std::string& item, bool param) {
         SetTypeVisible(_navmesh_connection_object, param);
     } else if (item == "lighteditoractive") {
         SetTypeEnabled(_dynamic_light_object, param);
-        SetTypeEnabled(_reflection_capture_object, param);
         SetTypeEnabled(_light_volume_object, param);
+    } else if (item == "editreflectioncaptures") {
+        SetTypeEnabled(_reflection_capture_object, param);
     } else if (item == "isolate") {
         // ToggleSelectedDecalIsolation();
     } else if (item == "exit") {

--- a/Source/GUI/dimgui/dimgui.cpp
+++ b/Source/GUI/dimgui/dimgui.cpp
@@ -2384,8 +2384,13 @@ void DrawImGui(Graphics* graphics, SceneGraph* scenegraph, GUI* gui, AssetManage
                         me->RibbonItemClicked("hotspoteditoractive", temp);
                     }
                     temp = me->IsTypeEnabled(_dynamic_light_object);
-                    if (ImGui::Checkbox("Edit lighting", &temp)) {
+                    if (ImGui::Checkbox("Edit lighting        ", &temp)) {
                         me->RibbonItemClicked("lighteditoractive", temp);
+                    }
+                    ImGui::SameLine();
+                    temp = me->IsTypeEnabled(_reflection_capture_object);
+                    if (ImGui::Checkbox("Edit reflections", &temp)) {
+                        me->RibbonItemClicked("editreflectioncaptures", temp);
                     }
                     ImGui::Separator();
                     if (ImGui::MenuItem("Play level", "8")) {


### PR DESCRIPTION
No textfile this time around because of how simple this change is, but I will give a quick explaination as to why this exists.

When creating levels that have outdoor and indoor areas, using local reflection captures really helps the indoor areas "feel right". One problem though, is that while placing/re-arranging dynamic light objects within those indoor areas, it's very difficult to select a dynamic light as the reflection capture would be in the way. You'd have to use scroll-select, but this comes with another problem of not being able to shift-select multiple light objects. Overall it just sucked.