### PR TITLE
Pressing the skip key while previewing vanilla dialogue no longer breaks things.

### DIFF
--- a/Data/Scripts/dialogue.as
+++ b/Data/Scripts/dialogue.as
@@ -1035,6 +1035,10 @@ class Dialogue {
     }
 
     void Play() {
+		if(EditorModeActive() && !preview){
+			return;
+		}
+	
         bool stop = false;
         bool first = false;
   


### PR DESCRIPTION
Okay okay okay okay okay, I'ma need to go on a little friendly diatribe here rq.


**TL;DR**: 
This does indeed fix the bugs that occured. They no longer happen. User experience is changed for the better and stuff works as intended.
HOWEVER, this is achieved by a "cheat solution". I know that the bug is being caused due to a function being repeatedly called in the wrong circumstances. But I have no idea what is causing that function to be called while in those circumstances.

So what I've done is just make it so that if it is the wrong circumstances, and the function is called, it just instantly returns which does fix the issue.


**Here's the situation**:
When a dialogue is started, "clear_on_complete" is set to true.
A dialogue plays, and at the end , due to "clear_on_complete" being true, ClearEditor() is called which sets it back to false. 
ClearEditor() resets a bunch of different dialogue variables, takes all the characters out of dialogue control, stuff like that.

When you start a dialogue via the preview button, then "preview" = true and "clear_on_complete" = true.
When ClearEditor() is called at the end of a previewed dialogue, it'll only do a portion of the things that ClearEditor() would normally do (because "preview" being true gates the other things) so that the dialogue editor will still be open and you can continue to work on it after previewing dialogue. "preview" is set to false.

Now, if you just click to the end of a dialogue you were previewing (no skipping) then this is exactly what happens and all's lovely.
However, if you skip to the end of the dialogue you're previewing then **this is STILL exactly what happens**, BUT AFTERWARDS the dialogue starts playing AGAIN but this time it is NOT in preview mode (believe me I checked).

And at the end of that dialogue (whether you clicked or skipped to the end), it'll keep on sending the last few character position and camera position commands over and over and over again.
I believe that this is what is happening due to the fact that if you go into play mode and try to move the camera with your mouse, then *it will actually move in the right direction*, but it'll be reset to whatever stuck position the dialogue command is telling it to be at.

This will continue to happen until ClearEditor() is called (this time with "preview" = false, so it'll do all things) by exiting the dialogue. 

The character position and camera position commands are in the ExecuteScriptElement() function.
And I've figured out that the ExecuteScriptElement calls that are responsible for bugging out the player/camera pos are coming from the Play() function. 

But what I cannot, FOR THE LIFE OF ME, figure out - is what on Earth is causing the Play() function to be called after skipping a dialogue you were previewing since that is the only scenario where that bug occurs.

Genuinely no clue what's going on. Words cannot describe my absolute confusion.
But since I figured out that the bugs are caused by the Play() function is getting called when it's not supposed to be getting called, I just made the Play() function instantly return whenever it's called *if* you are in EditorMode but *not* in preview mode.

So yeah. Normal in-game dialogue works fine. Normal editor mode previewing of dialogue works. The bug itself is technically gone, since now everything works as intended.