### PR TITLE
Libraries: crunch: crn_platform: No inline x86 asm on non-x86

### DIFF
--- a/Libraries/crunch-r319/crnlib/crn_platform.h
+++ b/Libraries/crunch-r319/crnlib/crn_platform.h
@@ -36,7 +36,11 @@ const bool c_crnlib_big_endian_platform = !c_crnlib_little_endian_platform;
    #define CRNLIB_BREAKPOINT DebugBreak();
    #define CRNLIB_BUILTIN_EXPECT(c, v) c
 #elif defined(__GNUC__)
+#if defined(__i386__) || defined(__x86_64__)
    #define CRNLIB_BREAKPOINT asm("int $3");
+#else
+   #define CRNLIB_BREAKPOINT
+#endif
    #define CRNLIB_BUILTIN_EXPECT(c, v) __builtin_expect(c, v)
 #else
    #define CRNLIB_BREAKPOINT


### PR DESCRIPTION
Guard added to GCC definition of CRNLIB_BREAKPOINT. Fixes compilation on ARM platforms

Back-port from https://github.com/DaemonEngine/crunch/commit/db72ccbf0ea454977f3147e364edf2b0685b62b7

Should fix second part of  https://github.com/WolfireGames/overgrowth/issues/33