### PR TITLE
Libraries: zstd-1.5.0: fixed build by lcc compiler

### DIFF
--- a/Libraries/zstd-1.5.0/lib/common/compiler.h
+++ b/Libraries/zstd-1.5.0/lib/common/compiler.h
@@ -150,8 +150,9 @@
 }
 
 /* vectorization
- * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax */
-#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__)
+ * older GCC (pre gcc-4.3 picked as the cutoff) uses a different syntax,
+ * and some compilers, like Intel ICC and MCST LCC, do not support it at all. */
+#if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && !defined(__LCC__)
 #  if (__GNUC__ == 4 && __GNUC_MINOR__ > 3) || (__GNUC__ >= 5)
 #    define DONT_VECTORIZE __attribute__((optimize("no-tree-vectorize")))
 #  else


### PR DESCRIPTION
backport of changes from zstd-1.5.1 for mcst-lcc compiler
- https://github.com/facebook/zstd/commit/d4ad02c7210b4b2936cee45b426db9e8e78a7bc4
- https://github.com/facebook/zstd/commit/a5f518ae273ff0000bfd4c50689663f690f95d24
- https://github.com/facebook/zstd/commit/3cd085cec3cc805f19e52ec98bfe60e7f1543672

Fix https://github.com/WolfireGames/overgrowth/issues/158