### PR TITLE
Fix potential vulnerable cloned functions: Fix a bug when getting a gzip header extra field with inflate()

### DIFF
--- a/Libraries/freetype-2.12.1/src/gzip/inflate.c
+++ b/Libraries/freetype-2.12.1/src/gzip/inflate.c
@@ -769,9 +769,10 @@ int ZEXPORT inflate(
                 copy = state->length;
                 if (copy > have) copy = have;
                 if (copy) {
+                    len = state->head->extra_len - state->length;
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        len < state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
**Description**
This PR fixes a potential vulnerability in inflate() that was cloned from zlib but did not receive the security patch. The original issue was reported and fixed under https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.
This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/cve-2022-37434
https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1